### PR TITLE
fix: Add FastAPI app export.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,10 +159,6 @@ python_functions = ["test_*"]
 addopts = [
     "--strict-markers",
     "--strict-config",
-    "--cov=src/eval_hub",
-    "--cov-report=term-missing",
-    "--cov-report=html",
-    "--cov-report=xml",
 ]
 asyncio_mode = "auto"
 markers = [

--- a/src/eval_hub/api/app.py
+++ b/src/eval_hub/api/app.py
@@ -209,3 +209,7 @@ def create_app() -> FastAPI:
     )
 
     return app
+
+
+# Create app instance for uvicorn to find
+app = create_app()


### PR DESCRIPTION
Also remove coverage from `pyproject.toml` as it is included on the GHA.