### PR TITLE
ci: avoid codecov upload for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         uv run pytest tests/ -m "integration" --tb=short
 
     - name: Upload coverage reports to Codecov
+      continue-on-error: ${{ github.actor == 'dependabot[bot]' }}  # Don't fail CI on Dependabot PRs since they can't access secrets
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml


### PR DESCRIPTION
avoid RED flags on running test "quality-checks" only due to Codecov upload for Dependabot PRs