### PR TITLE
K8s runtime: integrate RunEvaluationJob, update job naming and other fields as per python SDK and add tests

### DIFF
--- a/cmd/eval_hub/server/server.go
+++ b/cmd/eval_hub/server/server.go
@@ -164,7 +164,7 @@ func (s *Server) loggerWithRequest(r *http.Request) (string, *slog.Logger) {
 
 func (s *Server) setupRoutes() (http.Handler, error) {
 	router := http.NewServeMux()
-	h := handlers.New(s.storage, s.validate)
+	h := handlers.New(s.storage, s.validate, s.runtime)
 
 	// Health and status endpoints
 	router.HandleFunc("/api/v1/health", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/evaluations.go
+++ b/internal/handlers/evaluations.go
@@ -94,6 +94,13 @@ func (h *Handlers) HandleCreateEvaluation(ctx *executioncontext.ExecutionContext
 		return
 	}
 
+	if h.runtime != nil {
+		job := response
+		go func() {
+			_ = h.runtime.RunEvaluationJob(job, &h.storage)
+		}()
+	}
+
 	w.WriteJSON(response, 202)
 }
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -8,11 +8,13 @@ import (
 type Handlers struct {
 	storage  abstractions.Storage
 	validate *validator.Validate
+	runtime  abstractions.Runtime
 }
 
-func New(storage abstractions.Storage, validate *validator.Validate) *Handlers {
+func New(storage abstractions.Storage, validate *validator.Validate, runtime abstractions.Runtime) *Handlers {
 	return &Handlers{
 		storage:  storage,
 		validate: validate,
+		runtime:  runtime,
 	}
 }

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	h := handlers.New(nil, nil)
+	h := handlers.New(nil, nil, nil)
 	if h == nil {
 		t.Error("New() returned nil")
 	}

--- a/internal/handlers/health_test.go
+++ b/internal/handlers/health_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHandleHealth(t *testing.T) {
-	h := handlers.New(nil, nil)
+	h := handlers.New(nil, nil, nil)
 
 	t.Run("GET request returns healthy status", func(t *testing.T) {
 		r := createMockRequest("GET", "/health")

--- a/internal/handlers/openapi_test.go
+++ b/internal/handlers/openapi_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHandleOpenAPI(t *testing.T) {
-	h := handlers.New(nil, nil)
+	h := handlers.New(nil, nil, nil)
 
 	// Ensure the OpenAPI file exists for testing
 	apiPath := filepath.Join("..", "..", "docs", "openapi.yaml")
@@ -65,7 +65,7 @@ func TestHandleOpenAPI(t *testing.T) {
 }
 
 func TestHandleDocs(t *testing.T) {
-	h := handlers.New(nil, nil)
+	h := handlers.New(nil, nil, nil)
 
 	t.Run("GET request returns HTML documentation", func(t *testing.T) {
 		ctx := createExecutionContext()

--- a/internal/handlers/status_test.go
+++ b/internal/handlers/status_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHandleStatus(t *testing.T) {
-	h := handlers.New(nil, nil)
+	h := handlers.New(nil, nil, nil)
 
 	t.Run("GET request returns status information", func(t *testing.T) {
 		ctx := createExecutionContext()

--- a/internal/runtimes/k8s/examples/eval-job-configmap.yaml
+++ b/internal/runtimes/k8s/examples/eval-job-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: eval-job-001-spec
+  name: eval-job-001-mmlu-spec
   namespace: evalhub
   labels:
     app: "evalhub"
@@ -12,7 +12,7 @@ metadata:
 data:
   job.json: |
     {
-      "job_id": "001", # mandatory
+      "job_id": "001",
       "benchmark_id": "mmlu",
       "model": {
         "url": "http://model-server.models.svc.cluster.local:8000/v1",
@@ -30,5 +30,5 @@ data:
       },
       "timeout_seconds": 1800,
       "retry_attempts": 2,
-      "callback_url": "https://example.org/eval/callback"
+      "callback_url": "http://eval-hub"
     }

--- a/internal/runtimes/k8s/examples/eval-job.yaml
+++ b/internal/runtimes/k8s/examples/eval-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: eval-job-001
+  name: eval-job-001-mmlu
   namespace: evalhub
   labels:
     app: "evalhub"
@@ -26,6 +26,8 @@ spec:
         - name: adapter
           image: quay.io/eval-hub/adapter:latest
           imagePullPolicy: IfNotPresent
+          command:
+            - /path/to/program
           env:
             - name: JOB_ID
               value: "001"
@@ -56,6 +58,6 @@ spec:
       volumes:
         - name: job-spec
           configMap:
-            name: eval-job-001-spec
+            name: eval-job-001-mmlu-spec
         - name: data
           emptyDir: {}

--- a/internal/runtimes/k8s/job_builders_test.go
+++ b/internal/runtimes/k8s/job_builders_test.go
@@ -16,7 +16,7 @@ func TestBuildConfigMap(t *testing.T) {
 	}
 
 	configMap := buildConfigMap(cfg)
-	expectedName := jobPrefix + cfg.jobID + specSuffix
+	expectedName := jobPrefix + cfg.jobID + "-" + cfg.benchmarkID + specSuffix
 	if configMap.Name != expectedName {
 		t.Fatalf("expected configmap name %s, got %s", expectedName, configMap.Name)
 	}

--- a/internal/runtimes/k8s/k8s_runtime_test.go
+++ b/internal/runtimes/k8s/k8s_runtime_test.go
@@ -1,78 +1,165 @@
 package k8s
 
 import (
+	"context"
+	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/eval-hub/eval-hub/internal/abstractions"
 	"github.com/eval-hub/eval-hub/pkg/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestResolveProviderFromEvaluation(t *testing.T) {
-	providers := map[string]api.ProviderResource{
-		"provider-1": {
-			ProviderID: "provider-1",
-			Benchmarks: []api.BenchmarkResource{
-				{BenchmarkId: "bench-1"},
-			},
-		},
+func TestRunEvaluationJobCreatesResources(t *testing.T) {
+	// Integration test: creates one ConfigMap and Job per benchmark in a real cluster.
+	if os.Getenv("K8S_INTEGRATION_TEST") != "1" {
+		t.Skip("set K8S_INTEGRATION_TEST=1 to run against a real cluster")
 	}
-	evaluation := &api.EvaluationJobResource{
-		EvaluationJobConfig: api.EvaluationJobConfig{
-			Benchmarks: []api.BenchmarkConfig{
-				{Ref: api.Ref{ID: "bench-1"}},
-			},
-		},
-	}
-
-	provider, benchmarkID, err := resolveProviderFromEvaluation(providers, evaluation)
+	t.Setenv("SERVICE_URL", "http://eval-hub")
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	helper, err := NewKubernetesHelper()
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("failed to create kubernetes helper: %v", err)
 	}
-	if provider.ProviderID != "provider-1" {
-		t.Fatalf("expected provider provider-1, got %s", provider.ProviderID)
-	}
-	if benchmarkID != "bench-1" {
-		t.Fatalf("expected benchmark bench-1, got %s", benchmarkID)
-	}
-}
-
-func TestResolveProviderFromEvaluationMissingBenchmarks(t *testing.T) {
-	providers := map[string]api.ProviderResource{
-		"provider-1": {
-			ProviderID: "provider-1",
-		},
-	}
-	evaluation := &api.EvaluationJobResource{}
-
-	_, _, err := resolveProviderFromEvaluation(providers, evaluation)
-	if err == nil {
-		t.Fatalf("expected error for missing benchmarks")
-	}
-}
-
-func TestResolveProviderFromEvaluationMultipleBenchmarks(t *testing.T) {
-	providers := map[string]api.ProviderResource{
-		"provider-1": {
-			ProviderID: "provider-1",
-			Benchmarks: []api.BenchmarkResource{
-				{BenchmarkId: "bench-1"},
+	jobID := "1936da05-2f27-4fd4-b000-ebcb71af1fbe"
+	benchmarkID := "mmlu"
+	benchmarkIDTwo := "arc"
+	runtime := &K8sRuntime{
+		logger: logger,
+		helper: helper,
+		providers: map[string]api.ProviderResource{
+			"lm_evaluation_harness": {
+				ProviderID: "lm_evaluation_harness",
+				Runtime: &api.Runtime{
+					K8s: &api.K8sRuntime{
+						Image:       "docker.io/library/busybox:1.36",
+						Entrypoint:  "/bin/sh",
+						CPULimit:    "500m",
+						MemoryLimit: "1Gi",
+						Env: []api.EnvVar{
+							{Name: "VAR_NAME", Value: "VALUE"},
+						},
+					},
+				},
 			},
 		},
 	}
+
 	evaluation := &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{
+			Resource: api.Resource{ID: jobID},
+		},
 		EvaluationJobConfig: api.EvaluationJobConfig{
+			Model: api.ModelRef{
+				URL:  "http://model",
+				Name: "model",
+			},
 			Benchmarks: []api.BenchmarkConfig{
-				{Ref: api.Ref{ID: "bench-1"}},
-				{Ref: api.Ref{ID: "bench-2"}},
+				{
+					Ref:        api.Ref{ID: benchmarkID},
+					ProviderID: "lm_evaluation_harness",
+					Parameters: map[string]any{
+						"num_examples": 1,
+						"max_tokens":   128,
+						"temperature":  0.2,
+					},
+				},
+				{
+					Ref:        api.Ref{ID: benchmarkIDTwo},
+					ProviderID: "lm_evaluation_harness",
+					Parameters: map[string]any{
+						"num_examples": 2,
+						"max_tokens":   256,
+						"temperature":  0.1,
+					},
+				},
 			},
 		},
 	}
 
-	_, _, err := resolveProviderFromEvaluation(providers, evaluation)
-	if err == nil {
-		t.Fatalf("expected error for multiple benchmarks")
+	var storageNil = (*abstractions.Storage)(nil)
+	if err := runtime.RunEvaluationJob(evaluation, storageNil); err != nil {
+		t.Fatalf("RunEvaluationJob returned error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "multi-benchmark evaluations are not supported") {
-		t.Fatalf("unexpected error: %v", err)
+
+	namespace := "default"
+	benchmarkIDs := []string{benchmarkID, benchmarkIDTwo}
+	for _, id := range benchmarkIDs {
+		configMapName := "eval-job-" + jobID + "-" + id + "-spec"
+		jobName := "eval-job-" + jobID + "-" + id
+
+		if _, err := helper.clientset.CoreV1().ConfigMaps(namespace).Get(context.Background(), configMapName, metav1.GetOptions{}); err != nil {
+			t.Fatalf("expected configmap to be created for %s: %v", id, err)
+		}
+		if _, err := helper.clientset.BatchV1().Jobs(namespace).Get(context.Background(), jobName, metav1.GetOptions{}); err != nil {
+			t.Fatalf("expected job to be created for %s: %v", id, err)
+		}
+	}
+	for _, id := range benchmarkIDs {
+		jobName := "eval-job-" + jobID + "-" + id
+		configMapName := "eval-job-" + jobID + "-" + id + "-spec"
+		_ = helper.clientset.BatchV1().Jobs(namespace).Delete(context.Background(), jobName, metav1.DeleteOptions{})
+		_ = helper.clientset.CoreV1().ConfigMaps(namespace).Delete(context.Background(), configMapName, metav1.DeleteOptions{})
+	}
+}
+
+func TestRunEvaluationJobReturnsErrorForInvalidConfig(t *testing.T) {
+	// Unit test: validates config errors are surfaced and aggregated across benchmarks.
+	t.Setenv("SERVICE_URL", "http://eval-hub")
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	runtime := &K8sRuntime{
+		logger: logger,
+		helper: nil,
+		providers: map[string]api.ProviderResource{
+			"lm_evaluation_harness": {
+				ProviderID: "lm_evaluation_harness",
+				Runtime: &api.Runtime{
+					K8s: &api.K8sRuntime{
+						Image: "",
+					},
+				},
+			},
+		},
+	}
+
+	evaluation := &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{
+			Resource: api.Resource{ID: "job-invalid"},
+		},
+		EvaluationJobConfig: api.EvaluationJobConfig{
+			Model: api.ModelRef{
+				URL:  "http://model",
+				Name: "model",
+			},
+			Benchmarks: []api.BenchmarkConfig{
+				{
+					Ref:        api.Ref{ID: "bench-1"},
+					ProviderID: "lm_evaluation_harness",
+					Parameters: map[string]any{
+						"num_examples": 1,
+						"max_tokens":   64,
+					},
+				},
+				{
+					Ref:        api.Ref{ID: "bench-2"},
+					ProviderID: "lm_evaluation_harness",
+					Parameters: map[string]any{
+						"num_examples": 2,
+						"temperature":  0.3,
+					},
+				},
+			},
+		},
+	}
+
+	var storageNil = (*abstractions.Storage)(nil)
+	err := runtime.RunEvaluationJob(evaluation, storageNil)
+	if err == nil {
+		t.Fatalf("expected error but got nil")
+	}
+	if !strings.Contains(err.Error(), "runtime adapter image is required") {
+		t.Fatalf("expected runtime adapter image error, got %v", err)
 	}
 }

--- a/pkg/api/evaluations.go
+++ b/pkg/api/evaluations.go
@@ -87,7 +87,6 @@ type EvaluationJobConfig struct {
 	Experiment     ExperimentConfig  `json:"experiment"`
 	TimeoutMinutes *int              `json:"timeout_minutes,omitempty"`
 	RetryAttempts  *int              `json:"retry_attempts,omitempty"`
-	CallbackURL    *string           `json:"callback_url,omitempty"`
 }
 
 type EvaluationResource struct {


### PR DESCRIPTION
# Pull Request

## Description

Integrated RunEvaluationJob into create‑evaluation and refactored the k8s runtime to create one ConfigMap + Job per benchmark concurrently. Updated the job/configmap spec to match the Python SDK input, added entrypoint support, and changed resource naming to include the benchmark ID.

**Related Issue(s)**:
- Fixes #(issue number)
- Relates to #(issue number)

## Type of Change

Please mark the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements
- [ ] CI/CD improvements
- [ ] Other (please describe):

## Component(s) Affected

Please mark the relevant component(s):

- [x] API endpoints
- [ ] Evaluation executors
- [ ] MLFlow integration
- [ ] Collection management
- [ ] Kubernetes/OpenShift deployment
- [ ] Configuration system
- [ ] Monitoring/metrics
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD
- [ ] Other:

## Changes Made

Please describe the specific changes made:

- Integrated RunEvaluationJob into the create‑evaluation flow and refactored k8s runtime to create one ConfigMap + Job per benchmark concurrently with DB status update on failure.
- Updated job/configmap naming to include benchmark_id for uniqueness, and standardized labels with app/component/job/provider/benchmark IDs (underscored keys).
- Added security context hardening (runAsNonRoot/runAsUser/runAsGroup/seccomp/drop ALL) and entrypoint support in k8s job builder.
- Implemented job spec generation aligned with SDK fields (job_id, benchmark_id, model, num_examples, benchmark_config, experiment_name, tags, timeout_seconds, retry_attempts, callback_url via SERVICE_URL)
- Added/updated k8s examples for ConfigMap and Job accordingly.
- Added k8s runtime tests: integration test for resource creation (two benchmarks + cleanup), plus unit test that triggers config errors and verifies error handling.

### Added
-

### Changed
-

### Removed
-

### Fixed
-

## Testing

Please describe how you tested your changes:

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No tests needed (documentation/minor changes)

### Test Results
- [x] All existing tests pass
- [ ] New tests pass
- [ ] Manual testing successful

**Manual Testing Details** (if applicable):
```
Describe manual testing steps and results:
Connected to a kube cluster, and triggered unit tests to validate RunEvaluationJob() if it can successfully create kube job/configmap

oc get job
NAME                                                 STATUS    COMPLETIONS   DURATION   AGE
eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-arc    Running   0/1           13s        13s
eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-mmlu   Running   0/1           13s        13s
scheruku@scheruku-mac work % oc get cm 
NAME                                                      DATA   AGE
eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-arc-spec    1      15s
eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-mmlu-spec   1      15s
kube-root-ca.crt                                          1      20d
migration-kserve-inferenceservices-role                   1      14d
odh-kserve-custom-ca-bundle                               1      20d
openshift-service-ca.crt                                  1      20d
scheruku@scheruku-mac work % oc get po | grep -i eval-job
eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-arc-jx8mx    0/1     ContainerCreating   0          21s
eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-mmlu-hh5jl   0/1     ContainerCreating   0          21s
$oc get cm eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-arc-spec -o yaml
apiVersion: v1
data:
  job.json: |-
    {
      "job_id": "1936da05-2f27-4fd4-b000-ebcb71af1fbe",
      "benchmark_id": "arc",
      "model": {
        "url": "http://model",
        "name": "model"
      },
      "num_examples": 2,
      "benchmark_config": {
        "max_tokens": 256,
        "temperature": 0.1
      },
      "callback_url": "http://eval-hub"
    }
kind: ConfigMap
metadata:
  creationTimestamp: "2026-02-03T07:28:43Z"
  labels:
    app: evalhub
    benchmark_id: arc
    component: evaluation-job
    job_id: 1936da05-2f27-4fd4-b000-ebcb71af1fbe
    provider_id: lm_evaluation_harness
  name: eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-arc-spec
  namespace: default
  resourceVersion: "25836491"
  uid: 68a14dae-4ee9-4113-96c7-03e5c9ed8c59
scheruku@scheruku-mac work % oc get job eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-arc -o yaml
apiVersion: batch/v1
kind: Job
metadata:
  creationTimestamp: "2026-02-03T07:28:43Z"
  generation: 1
  labels:
    app: evalhub
    benchmark_id: arc
    component: evaluation-job
    job_id: 1936da05-2f27-4fd4-b000-ebcb71af1fbe
    provider_id: lm_evaluation_harness
  name: eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-arc
  namespace: default
  resourceVersion: "25836507"
  uid: fe7dd0a0-2cc1-44a7-a4dc-3fe8d930c45c
spec:
  backoffLimit: 0
  completionMode: NonIndexed
  completions: 1
  manualSelector: false
  parallelism: 1
  podReplacementPolicy: TerminatingOrFailed
  selector:
    matchLabels:
      batch.kubernetes.io/controller-uid: fe7dd0a0-2cc1-44a7-a4dc-3fe8d930c45c
  suspend: false
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: evalhub
        batch.kubernetes.io/controller-uid: fe7dd0a0-2cc1-44a7-a4dc-3fe8d930c45c
        batch.kubernetes.io/job-name: eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-arc
        benchmark_id: arc
        component: evaluation-job
        controller-uid: fe7dd0a0-2cc1-44a7-a4dc-3fe8d930c45c
        job-name: eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-arc
        job_id: 1936da05-2f27-4fd4-b000-ebcb71af1fbe
        provider_id: lm_evaluation_harness
    spec:
      containers:
      - command:
        - /bin/sh
        env:
        - name: JOB_ID
          value: 1936da05-2f27-4fd4-b000-ebcb71af1fbe
        - name: VAR_NAME
          value: VALUE
        image: docker.io/library/busybox:1.36
        imagePullPolicy: IfNotPresent
        name: adapter
        resources:
          limits:
            cpu: 500m
            memory: 1Gi
          requests:
            cpu: 250m
            memory: 512Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          runAsGroup: 1000
          runAsNonRoot: true
          runAsUser: 1000
          seccompProfile:
            type: RuntimeDefault
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /meta/job.json
          name: job-spec
          readOnly: true
          subPath: job.json
        - mountPath: /data
          name: data
      dnsPolicy: ClusterFirst
      restartPolicy: Never
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
      volumes:
      - configMap:
          defaultMode: 420
          name: eval-job-1936da05-2f27-4fd4-b000-ebcb71af1fbe-arc-spec
        name: job-spec
      - emptyDir: {}
        name: data
  ttlSecondsAfterFinished: 3600
status:
  active: 1
  ready: 0
  startTime: "2026-02-03T07:28:43Z"
  terminating: 0
  uncountedTerminatedPods: {}

```

### Performance Impact
- [ ] No performance impact
- [ ] Performance improvement
- [ ] Performance regression (justified and documented)
- [ ] Performance impact unknown

## Documentation

- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] README updated
- [ ] CONTRIBUTING guide updated
- [ ] Examples/tutorials added/updated
- [ ] No documentation changes needed

## Breaking Changes

If this PR introduces breaking changes, please describe them and the migration path:

```
Describe breaking changes:
-
-

Migration path:
1.
2.
```

## Security Considerations

- [ ] No security implications
- [ ] Security review needed
- [ ] Authentication/authorization changes
- [ ] Sensitive data handling changes
- [ ] Network security changes

Please describe any security implications:

## Deployment Considerations

- [ ] No deployment changes needed
- [ ] Environment variables added/changed
- [ ] Configuration changes required
- [ ] Database migrations needed
- [ ] Kubernetes manifests updated
- [ ] New dependencies added

**Deployment Notes**:

## Screenshots/Evidence

If applicable, add screenshots or other evidence of the changes:

## Checklist

Please confirm the following before submitting:

### Code Quality
- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is properly commented
- [ ] No new linting warnings introduced

### Testing
- [ ] Tests have been added for new functionality
- [ ] All tests pass locally
- [ ] Test coverage is adequate
- [ ] No regression in existing functionality

### Documentation
- [ ] Documentation has been updated as needed
- [ ] API documentation reflects changes
- [ ] Examples updated if needed
- [ ] Breaking changes documented

### Review Readiness
- [ ] PR title is clear and descriptive
- [ ] PR description is complete
- [ ] Commit messages follow conventional commits format
- [ ] Branch is up to date with main
- [ ] Ready for review

## Additional Notes

Add any additional notes, context, or questions for reviewers:

---

**For Reviewers**: Please check that all automated checks pass before approving. Pay special attention to:
- Test coverage and quality
- API contract compatibility
- Security implications
- Performance impact
- Documentation completeness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Evaluations now execute asynchronously, with API responding immediately (HTTP 202) while processing continues in the background
  * Enhanced support for benchmark configurations and parameters in evaluation jobs

* **Chores**
  * Updated tests to align with refactored runtime architecture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->