### PR TITLE
fix: python-server should align with min py of eval-hub-sdk

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -111,7 +111,7 @@ body:
         - Any other relevant system details
       placeholder: |
         OS: Ubuntu 22.04
-        Python: 3.12.0
+        Python: 3.11.0
         Podman: 4.7.0 (if applicable)
         Kubernetes: 1.28 (if applicable)
     validations:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -73,7 +73,7 @@ body:
       description: If your question is environment-specific, please provide details.
       placeholder: |
         - OS: Ubuntu 22.04
-        - Python: 3.12.0
+        - Python: 3.11.0
         - Podman: 4.7.0 (if applicable)
         - Kubernetes: 1.28 (if applicable)
         - eval-hub version: 0.1.1

--- a/.github/workflows/publish-python-server.yml
+++ b/.github/workflows/publish-python-server.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Set up uv python
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Install wheel and setuptools
         run: make install-wheel-tools

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ flowchart TD
 ### Prerequisites
 
 **All Deployments:**
-- Python 3.12+
+- Python 3.11+
 - uv (for dependency management)
 - MLFlow tracking server (local or remote)
 

--- a/python-server/pyproject.toml
+++ b/python-server/pyproject.toml
@@ -10,12 +10,13 @@ authors = [
     {name = "Rui Vieira", email = "rui@redhat.com"},
 ]
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -44,7 +45,7 @@ include = ["evalhub_server*"]
 evalhub_server = ["binaries/*"]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py311"
 line-length = 88
 
 [tool.ruff.lint]

--- a/python-server/uv.lock
+++ b/python-server/uv.lock
@@ -1,0 +1,42 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "eval-hub-server"
+version = "0.1.0a0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.14" }]
+provides-extras = ["dev"]
+
+[[package]]
+name = "ruff"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893, upload-time = "2026-02-03T17:53:35.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332, upload-time = "2026-02-03T17:52:54.892Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189, upload-time = "2026-02-03T17:53:19.778Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384, upload-time = "2026-02-03T17:53:29.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363, upload-time = "2026-02-03T17:52:43.332Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736, upload-time = "2026-02-03T17:53:00.522Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415, upload-time = "2026-02-03T17:53:15.705Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643, upload-time = "2026-02-03T17:53:23.031Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787, upload-time = "2026-02-03T17:52:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797, upload-time = "2026-02-03T17:52:49.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133, upload-time = "2026-02-03T17:53:33.105Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646, upload-time = "2026-02-03T17:53:06.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750, upload-time = "2026-02-03T17:53:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120, upload-time = "2026-02-03T17:53:09.363Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636, upload-time = "2026-02-03T17:52:57.281Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+]


### PR DESCRIPTION
# Pull Request

## Description

I am trying to add python-server to E2E testing in eval-hub-sdk

For example

```
      147  [dependency-groups]                                                                                                                                                                                                                                                                                                                                            
      148  dev = [                                                                                                                                                                                                                                                                                                             
      149 +    "eval-hub-server @ git+https://github.com/eval-hub/eval-hub#subdirectory=python-server",  
```

but failing with

```
uv sync --group dev
  ⎿  Error: Exit code 1                                                               
        Updating https://github.com/eval-hub/eval-hub (HEAD)
         Updated https://github.com/eval-hub/eval-hub (e880c3c7971333d3617b2c2884bf29341231e441)                                                                                                                                                                                                                                                                          
       × No solution found when resolving dependencies for split (markers:            
       │ python_full_version >= '3.13'):                                                                                                                                                                                                                                                                                                                                  
       ╰─▶ Because the current Python version (3.11.6) does not satisfy                                                                                                                                                                                                                                                                                                   
           Python>=3.12 and eval-hub-server==0.1.0a0 depends on Python>=3.12, we                                                                                                                                                                                                                                                                                          
           can conclude that eval-hub-server==0.1.0a0 cannot be used.                                                                                                                                                                                                                                                                                                     
           And because only eval-hub-server==0.1.0a0 is available, we can conclude                                                                                                                                                                                                                                                                                        
           that all versions of eval-hub-server cannot be used.   
```

so this aligns, 

verified locally with:

```                                                                                                                                                                                                                                                                                                                              
      148  dev = [                                                                                                                                                                                                                                                                                                                                                        
      149 -    "eval-hub-server @ git+https://github.com/eval-hub/eval-hub#subdirectory=python-server",                                                                                                                                                                                                                                                                                  
      149 +    "eval-hub-server @ file:///Users/mmortari/git/eval-hub/python-server",                                                                                                                                                                                                                                                                              
      150      "fastapi>=0.124.4",                                                                                                                                                                                                                                                                                                                                        
      151      "httpx>=0.28.1",                                                                                                                                                                                                                                                                                                                                    
      152      "mypy>=1.7.1",                     
```                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                          
and 
`uv sync --group dev`

## Type of Change

Please mark the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test improvements
- [x] CI/CD improvements
- [ ] Other (please describe):

## Component(s) Affected

Please mark the relevant component(s):

- [ ] API endpoints
- [ ] Evaluation executors
- [ ] MLFlow integration
- [ ] Collection management
- [ ] Kubernetes/OpenShift deployment
- [ ] Configuration system
- [ ] Monitoring/metrics
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD
- [x] Other: python-server

## Changes Made

see above

## Testing

see above

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No tests needed (documentation/minor changes)

### Test Results
- [ ] All existing tests pass
- [ ] New tests pass
- [x] Manual testing successful

**Manual Testing Details** (if applicable):
see above

### Performance Impact
- [ ] No performance impact
- [ ] Performance improvement
- [ ] Performance regression (justified and documented)
- [ ] Performance impact unknown

## Documentation

- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] README updated
- [ ] CONTRIBUTING guide updated
- [ ] Examples/tutorials added/updated
- [ ] No documentation changes needed

## Breaking Changes

see above

## Security Considerations

- [ x No security implications
- [ ] Security review needed
- [ ] Authentication/authorization changes
- [ ] Sensitive data handling changes
- [ ] Network security changes

Please describe any security implications:

## Deployment Considerations

- [x] No deployment changes needed
- [ ] Environment variables added/changed
- [ ] Configuration changes required
- [ ] Database migrations needed
- [ ] Kubernetes manifests updated
- [ ] New dependencies added

**Deployment Notes**:

## Screenshots/Evidence

If applicable, add screenshots or other evidence of the changes:

## Checklist

Please confirm the following before submitting:

### Code Quality
- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is properly commented
- [ ] No new linting warnings introduced

### Testing
- [ ] Tests have been added for new functionality
- [ ] All tests pass locally
- [ ] Test coverage is adequate
- [ ] No regression in existing functionality

### Documentation
- [ ] Documentation has been updated as needed
- [ ] API documentation reflects changes
- [ ] Examples updated if needed
- [ ] Breaking changes documented

### Review Readiness
- [ ] PR title is clear and descriptive
- [ ] PR description is complete
- [ ] Commit messages follow conventional commits format
- [ ] Branch is up to date with main
- [ ] Ready for review

## Additional Notes

Add any additional notes, context, or questions for reviewers:

---

**For Reviewers**: Please check that all automated checks pass before approving. Pay special attention to:
- Test coverage and quality
- API contract compatibility
- Security implications
- Performance impact
- Documentation completeness
