### PR TITLE
fix:Allow multiline entry point commands for K8s jobs

### DIFF
--- a/config/providers/garak.yaml
+++ b/config/providers/garak.yaml
@@ -6,7 +6,9 @@ base_url: null
 runtime:
   k8s:
     image: quay.io/eval-hub/garak:latest
-    entrypoint: /path_to_program
+    entrypoint:
+      - python
+      - /opt/app-root/src/main.py
     cpu_request: 100m
     memory_request: 128Mi
     cpu_limit: 500m

--- a/config/providers/lighteval.yaml
+++ b/config/providers/lighteval.yaml
@@ -5,8 +5,10 @@ provider_type: builtin
 base_url: null
 runtime:
   k8s:
-    image: quay.io/eval-hub/garak:latest
-    entrypoint: /path_to_program
+    image: quay.io/eval-hub/lighteval:latest
+    entrypoint:
+      - python
+      - /opt/app-root/src/main.py
     cpu_request: 100m
     memory_request: 128Mi
     cpu_limit: 500m

--- a/config/providers/lm_evaluation_harness.yaml
+++ b/config/providers/lm_evaluation_harness.yaml
@@ -5,8 +5,10 @@ provider_type: builtin
 base_url: null
 runtime:
   k8s:
-    image: quay.io/eval-hub/garak:latest
-    entrypoint: /path_to_program
+    image: quay.io/eval-hub/lm_evaluation_harness:latest
+    entrypoint:
+      - python
+      - /opt/app-root/src/main.py
     cpu_request: 100m
     memory_request: 128Mi
     cpu_limit: 500m

--- a/config/providers/ragas.yaml
+++ b/config/providers/ragas.yaml
@@ -5,8 +5,10 @@ provider_type: builtin
 base_url: null
 runtime:
   k8s:
-    image: quay.io/eval-hub/garak:latest
-    entrypoint: /path_to_program
+    image: quay.io/eval-hub/ragas:latest
+    entrypoint:
+      - python
+      - /opt/app-root/src/main.py
     cpu_request: 100m
     memory_request: 128Mi
     cpu_limit: 500m

--- a/internal/runtimes/k8s/job_builders.go
+++ b/internal/runtimes/k8s/job_builders.go
@@ -117,7 +117,7 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 							Name:            adapterContainerName,
 							Image:           cfg.adapterImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Command:         containerCommand(cfg.entrypoint),
+							Command:         buildContainerCommand(cfg.entrypoint),
 							Env:             envVars,
 							Resources:       resources,
 							SecurityContext: defaultSecurityContext(),
@@ -157,11 +157,22 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 	}, nil
 }
 
-func containerCommand(entrypoint string) []string {
-	if entrypoint == "" {
+func buildContainerCommand(entrypoint []string) []string {
+	if len(entrypoint) == 0 {
 		return nil
 	}
-	return []string{entrypoint}
+	var command []string
+	for _, part := range entrypoint {
+		item := strings.TrimSpace(part)
+		if item == "" {
+			continue
+		}
+		command = append(command, item)
+	}
+	if len(command) == 0 {
+		return nil
+	}
+	return command
 }
 
 func defaultSecurityContext() *corev1.SecurityContext {

--- a/internal/runtimes/k8s/job_builders_test.go
+++ b/internal/runtimes/k8s/job_builders_test.go
@@ -89,3 +89,20 @@ func TestBuildJobSecurityContext(t *testing.T) {
 		t.Fatalf("expected seccomp profile to be set")
 	}
 }
+
+func TestContainerCommandList(t *testing.T) {
+	command := buildContainerCommand([]string{"/bin/sh", "-c", "echo hello"})
+	if len(command) != 3 {
+		t.Fatalf("expected 3 command parts, got %d", len(command))
+	}
+	if command[0] != "/bin/sh" || command[1] != "-c" || command[2] != "echo hello" {
+		t.Fatalf("unexpected command parts: %v", command)
+	}
+}
+
+func TestContainerCommandTrimsEmptyItems(t *testing.T) {
+	command := buildContainerCommand([]string{"  entrypoint ", "", " "})
+	if len(command) != 1 || command[0] != "entrypoint" {
+		t.Fatalf("unexpected command: %v", command)
+	}
+}

--- a/internal/runtimes/k8s/job_config.go
+++ b/internal/runtimes/k8s/job_config.go
@@ -27,7 +27,7 @@ type jobConfig struct {
 	benchmarkID   string
 	retryAttempts int
 	adapterImage  string
-	entrypoint    string
+	entrypoint    []string
 	defaultEnv    []api.EnvVar
 	cpuRequest    string
 	memoryRequest string

--- a/internal/runtimes/k8s/k8s_runtime_test.go
+++ b/internal/runtimes/k8s/k8s_runtime_test.go
@@ -43,7 +43,7 @@ func TestRunEvaluationJobCreatesResources(t *testing.T) {
 				Runtime: &api.Runtime{
 					K8s: &api.K8sRuntime{
 						Image:       "docker.io/library/busybox:1.36",
-						Entrypoint:  "/bin/sh",
+						Entrypoint:  []string{"/bin/sh", "-c", "echo hello"},
 						CPULimit:    "500m",
 						MemoryLimit: "1Gi",
 						Env: []api.EnvVar{

--- a/pkg/api/providers.go
+++ b/pkg/api/providers.go
@@ -22,7 +22,8 @@ type Runtime struct {
 //
 //	runtime:
 //	  image: "quay.io/eval-hub/adapter:latest"
-//	  entrypoint: "/path/to/program"
+//	  entrypoint:
+//	    - "/path/to/program"
 //	  cpu_request: "250m"
 //	  memory_request: "512Mi"
 //	  cpu_limit: "1"
@@ -32,7 +33,7 @@ type Runtime struct {
 //	      value: "bar"
 type K8sRuntime struct {
 	Image         string   `mapstructure:"image" yaml:"image"`
-	Entrypoint    string   `mapstructure:"entrypoint" yaml:"entrypoint"`
+	Entrypoint    []string `mapstructure:"entrypoint" yaml:"entrypoint"`
 	CPURequest    string   `mapstructure:"cpu_request" yaml:"cpu_request"`
 	MemoryRequest string   `mapstructure:"memory_request" yaml:"memory_request"`
 	CPULimit      string   `mapstructure:"cpu_limit" yaml:"cpu_limit"`


### PR DESCRIPTION
# Pull Request
Enable list‑based provider entrypoints so K8s jobs accept multi‑arg commands cleanly.

## Description

Updated K8s entrypoint handling to be list‑based and adjusted docs/tests accordingly. Specifically:
- entrypoint is now []string in pkg/api/providers.go and flows through job_config.go.
- New helper name `buildContainerCommand()` trims/filters list items.
- Provider YAML examples updated to list form (python, /opt/app-root/src/main.py).
- Tests updated for list entrypoint, plus new unit tests in job_builders_test.go.
- k8s_runtime_test.go now uses a multi‑arg entrypoint list (/bin/sh -c "echo hello").


**Related Issue(s)**:
- Fixes #(issue number) https://issues.redhat.com/browse/RHOAIENG-47894
- Relates to #(issue number)

## Type of Change

Please mark the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements
- [ ] CI/CD improvements
- [ ] Other (please describe):

## Component(s) Affected

Please mark the relevant component(s):

- [x] API endpoints
- [ ] Evaluation executors
- [ ] MLFlow integration
- [ ] Collection management
- [ ] Kubernetes/OpenShift deployment
- [ ] Configuration system
- [ ] Monitoring/metrics
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD
- [ ] Other:

## Changes Made

Please describe the specific changes made:

### Added
-

### Changed

Updated K8s entrypoint handling to be list‑based and adjusted docs/tests accordingly. Specifically:
- entrypoint is now []string in pkg/api/providers.go and flows through job_config.go.
- New helper name `buildContainerCommand()` trims/filters list items.
- Provider YAML examples updated to list form (python, /opt/app-root/src/main.py).
- Tests updated for list entrypoint, plus new unit tests in job_builders_test.go.
- k8s_runtime_test.go now uses a multi‑arg entrypoint list (/bin/sh -c "echo hello").

### Removed
-

### Fixed
-

## Testing

Please describe how you tested your changes:

### Test Coverage
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] No tests needed (documentation/minor changes)

### Test Results
- [x] All existing tests pass
- [x] New tests pass
- [x] Manual testing successful

**Manual Testing Details** (if applicable):
```
Describe manual testing steps and results:
1. Now the job creation accepts multi-line command:
  spec:
      containers:
      - command:
        - /bin/sh
        - -c
        - echo hello
        env:
        - name: JOB_ID
          value: 1936da05-2f27-4fd4-b000-ebcb71af1fbe
        - name: VAR_NAME
          value: VALUE
        image: docker.io/library/busybox:1.36
        imagePullPolicy: IfNotPresent
        name: adapter
        resources:
          limits:
            cpu: 500m
            memory: 1Gi
```

### Performance Impact
- [x] No performance impact
- [ ] Performance improvement
- [ ] Performance regression (justified and documented)
- [ ] Performance impact unknown

## Documentation

- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] README updated
- [ ] CONTRIBUTING guide updated
- [ ] Examples/tutorials added/updated
- [x] No documentation changes needed

## Breaking Changes

If this PR introduces breaking changes, please describe them and the migration path:

```
Describe breaking changes:
-
-

Migration path:
1.
2.
```

## Security Considerations

- [ ] No security implications
- [ ] Security review needed
- [ ] Authentication/authorization changes
- [ ] Sensitive data handling changes
- [ ] Network security changes

Please describe any security implications:

## Deployment Considerations

- [ ] No deployment changes needed
- [ ] Environment variables added/changed
- [ ] Configuration changes required
- [ ] Database migrations needed
- [ ] Kubernetes manifests updated
- [ ] New dependencies added

**Deployment Notes**:

## Screenshots/Evidence

If applicable, add screenshots or other evidence of the changes:

## Checklist

Please confirm the following before submitting:

### Code Quality
- [ ] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Code is properly commented
- [x] No new linting warnings introduced

### Testing
- [x] Tests have been added for new functionality
- [x] All tests pass locally
- [x] Test coverage is adequate
- [x] No regression in existing functionality

### Documentation
- [ ] Documentation has been updated as needed
- [ ] API documentation reflects changes
- [ ] Examples updated if needed
- [ ] Breaking changes documented

### Review Readiness
- [ ] PR title is clear and descriptive
- [ ] PR description is complete
- [ ] Commit messages follow conventional commits format
- [ ] Branch is up to date with main
- [ ] Ready for review

## Additional Notes

Add any additional notes, context, or questions for reviewers:

---

**For Reviewers**: Please check that all automated checks pass before approving. Pay special attention to:
- Test coverage and quality
- API contract compatibility
- Security implications
- Performance impact
- Documentation completeness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes entrypoint configuration for evaluation providers from single path strings to multi-argument command arrays, improving container startup handling.
  * Updated container images for evaluation providers (Garak, Lighteval, LM Evaluation Harness, and Ragas) to provider-specific variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->