### PR TITLE
refactor: add ProviderID to benchmark status and results structures

### DIFF
--- a/internal/storage/sql/evaluations.go
+++ b/internal/storage/sql/evaluations.go
@@ -472,8 +472,9 @@ func findAndUpdateBenchmarkStatus(benchmarkStatus []api.BenchmarkStatus, runStat
 	if !found {
 		// if the benchmark is not found, create a new benchmark status
 		newBenchmarkStatus := api.BenchmarkStatus{
-			ID:     runStatus.BenchmarkStatusEvent.ID,
-			Status: runStatus.BenchmarkStatusEvent.Status,
+			ProviderID: runStatus.BenchmarkStatusEvent.ProviderID,
+			ID:         runStatus.BenchmarkStatusEvent.ID,
+			Status:     runStatus.BenchmarkStatusEvent.Status,
 		}
 		if runStatus.BenchmarkStatusEvent.Status == api.StateFailed && runStatus.BenchmarkStatusEvent.ErrorMessage != nil {
 			newBenchmarkStatus.ErrorMessage = &api.MessageInfo{
@@ -505,10 +506,11 @@ func findAndUpdateBenchmarkResults(benchmarkResults *api.EvaluationJobResults, r
 	if !found {
 		if runStatus.BenchmarkStatusEvent.Status == api.StateCompleted {
 			newBenchmarkResult := api.BenchmarkStatus{
-				ID:        runStatus.BenchmarkStatusEvent.ID,
-				Status:    runStatus.BenchmarkStatusEvent.Status,
-				Metrics:   runStatus.BenchmarkStatusEvent.Metrics,
-				Artifacts: runStatus.BenchmarkStatusEvent.Artifacts,
+				ProviderID: runStatus.BenchmarkStatusEvent.ProviderID,
+				ID:         runStatus.BenchmarkStatusEvent.ID,
+				Status:     runStatus.BenchmarkStatusEvent.Status,
+				Metrics:    runStatus.BenchmarkStatusEvent.Metrics,
+				Artifacts:  runStatus.BenchmarkStatusEvent.Artifacts,
 			}
 			benchmarkResults.Benchmarks = append(benchmarkResults.Benchmarks, newBenchmarkResult)
 		}

--- a/internal/storage/sql/evaluations_test.go
+++ b/internal/storage/sql/evaluations_test.go
@@ -1,0 +1,123 @@
+package sql_test
+
+import (
+	"testing"
+
+	"github.com/eval-hub/eval-hub/internal/logging"
+	"github.com/eval-hub/eval-hub/internal/storage"
+	"github.com/eval-hub/eval-hub/pkg/api"
+)
+
+// TestUpdateEvaluationJob_PreservesProviderID verifies that provider_id is
+// preserved when creating benchmark statuses via status updates.
+//
+// Regression test for: provider_id was empty in results because the fallback
+// path in findAndUpdateBenchmarkStatus didn't preserve it from the status event.
+func TestUpdateEvaluationJob_PreservesProviderID(t *testing.T) {
+	// Setup storage
+	logger := logging.FallbackLogger()
+	databaseConfig := map[string]any{
+		"driver":        "sqlite",
+		"url":           "file::memory:?mode=memory&cache=shared",
+		"database_name": "eval_hub",
+	}
+	store, err := storage.NewStorage(&databaseConfig, logger)
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+
+	// Create job without initializing benchmark statuses
+	// (simulating old behavior before initialization was added)
+	config := &api.EvaluationJobConfig{
+		Model: api.ModelRef{
+			URL:  "http://test-model:8000",
+			Name: "test-model",
+		},
+		Benchmarks: []api.BenchmarkConfig{
+			{
+				Ref: api.Ref{
+					ID: "arc_easy",
+				},
+				ProviderID: "lm_evaluation_harness",
+			},
+		},
+	}
+
+	job, err := store.CreateEvaluationJob(config, "")
+	if err != nil {
+		t.Fatalf("Failed to create job: %v", err)
+	}
+
+	// Send status update with provider_id (simulating SDK behavior)
+	statusUpdate := &api.StatusEvent{
+		BenchmarkStatusEvent: &api.BenchmarkStatus{
+			ProviderID: "lm_evaluation_harness",
+			ID:         "arc_easy",
+			Status:     api.StateRunning,
+		},
+	}
+
+	err = store.UpdateEvaluationJob(job.Resource.ID, statusUpdate)
+	if err != nil {
+		t.Fatalf("Failed to update job: %v", err)
+	}
+
+	// Verify provider_id was preserved in status
+	updatedJob, err := store.GetEvaluationJob(job.Resource.ID)
+	if err != nil {
+		t.Fatalf("Failed to get updated job: %v", err)
+	}
+
+	if len(updatedJob.Results.Benchmarks) != 1 {
+		t.Fatalf("Expected 1 benchmark, got %d", len(updatedJob.Results.Benchmarks))
+	}
+
+	benchmark := updatedJob.Results.Benchmarks[0]
+	if benchmark.ProviderID != "lm_evaluation_harness" {
+		t.Errorf("Expected provider_id=%q, got %q",
+			"lm_evaluation_harness", benchmark.ProviderID)
+	}
+
+	// Send completion update with results
+	completionUpdate := &api.StatusEvent{
+		BenchmarkStatusEvent: &api.BenchmarkStatus{
+			ProviderID: "lm_evaluation_harness",
+			ID:         "arc_easy",
+			Status:     api.StateCompleted,
+			Metrics: map[string]any{
+				"acc":      0.85,
+				"acc_norm": 0.87,
+			},
+		},
+	}
+
+	err = store.UpdateEvaluationJob(job.Resource.ID, completionUpdate)
+	if err != nil {
+		t.Fatalf("Failed to update job with results: %v", err)
+	}
+
+	// Verify provider_id is preserved in results
+	finalJob, err := store.GetEvaluationJob(job.Resource.ID)
+	if err != nil {
+		t.Fatalf("Failed to get final job: %v", err)
+	}
+
+	if len(finalJob.Results.Benchmarks) != 1 {
+		t.Fatalf("Expected 1 benchmark in results, got %d", len(finalJob.Results.Benchmarks))
+	}
+
+	result := finalJob.Results.Benchmarks[0]
+	if result.ProviderID != "lm_evaluation_harness" {
+		t.Errorf("Expected provider_id=%q in results, got %q",
+			"lm_evaluation_harness", result.ProviderID)
+	}
+
+	// Verify metrics were also stored
+	if result.Metrics == nil {
+		t.Fatal("Expected metrics to be stored, got nil")
+	}
+
+	if acc, ok := result.Metrics["acc"].(float64); !ok || acc != 0.85 {
+		t.Errorf("Expected acc=0.85, got %v", result.Metrics["acc"])
+	}
+}


### PR DESCRIPTION
# Pull Request

## Description

Please provide a clear and concise description of the changes in this PR.

**Related Issue(s)**:
- Fixes #(issue number)
- Relates to #(issue number)

## Type of Change

Please mark the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements
- [ ] CI/CD improvements
- [ ] Other (please describe):

## Component(s) Affected

Please mark the relevant component(s):

- [ ] API endpoints
- [ ] Evaluation executors
- [ ] MLFlow integration
- [ ] Collection management
- [ ] Kubernetes/OpenShift deployment
- [ ] Configuration system
- [ ] Monitoring/metrics
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD
- [x] Other: storage

## Changes Made

Add ProviderID to benchmark status and results structures



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Benchmark evaluations now correctly preserve and maintain provider identification information throughout the entire evaluation lifecycle, including during interim status updates and final result generation.

* **Tests**
  * Added comprehensive test coverage to verify that provider information is consistently maintained during benchmark evaluation updates, status changes, and completion cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->