### PR TITLE
fix: Rename job_id to id in JobSpec

### DIFF
--- a/internal/runtimes/k8s/job_config.go
+++ b/internal/runtimes/k8s/job_config.go
@@ -45,7 +45,7 @@ type jobConfig struct {
 }
 
 type jobSpec struct {
-	JobID           string              `json:"job_id"`
+	JobID           string              `json:"id"`
 	BenchmarkID     string              `json:"benchmark_id"`
 	Model           api.ModelRef        `json:"model"`
 	NumExamples     *int                `json:"num_examples,omitempty"`

--- a/internal/runtimes/k8s/job_config_test.go
+++ b/internal/runtimes/k8s/job_config_test.go
@@ -75,9 +75,9 @@ func TestBuildJobConfigDefaults(t *testing.T) {
 	if err := json.Unmarshal([]byte(cfg.jobSpecJSON), &decoded); err != nil {
 		t.Fatalf("unmarshal job spec json: %v", err)
 	}
-	jobID, ok := decoded["job_id"].(string)
+	jobID, ok := decoded["id"].(string)
 	if !ok || jobID != "job-123" {
-		t.Fatalf("expected job spec json job_id to be %q, got %v", "job-123", decoded["job_id"])
+		t.Fatalf("expected job spec json id to be %q, got %v", "job-123", decoded["id"])
 	}
 	benchmarkID, ok := decoded["benchmark_id"].(string)
 	if !ok || benchmarkID != "bench-1" {


### PR DESCRIPTION
# Pull Request

## Description

refactor(k8s): align jobSpec field naming with REST API conventions

**Related Issue(s)**:

## Type of Change

Please mark the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements
- [ ] CI/CD improvements
- [ ] Other (please describe):

## Component(s) Affected

Please mark the relevant component(s):

- [ ] API endpoints
- [x] Evaluation executors
- [ ] MLFlow integration
- [ ] Collection management
- [ ] Kubernetes/OpenShift deployment
- [ ] Configuration system
- [ ] Monitoring/metrics
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD
- [ ] Other:

## Changes Made

Align internal jobSpec field with REST API naming conventions (Resource.ID -> "id"). Updated jobSpec.JobID JSON tag and tests.

### Test Coverage
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No tests needed (documentation/minor changes)

### Test Results
- [x] All existing tests pass
- [ ] New tests pass
- [ ] Manual testing successful

### Performance Impact
- [x] No performance impact
- [ ] Performance improvement
- [ ] Performance regression (justified and documented)
- [ ] Performance impact unknown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal job configuration serialization format. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->