### PR TITLE
fix: Add GuideLLM provider

### DIFF
--- a/config/providers/guidellm.yaml
+++ b/config/providers/guidellm.yaml
@@ -1,0 +1,128 @@
+provider_id: guidellm
+provider_name: GuideLLM
+description: Performance benchmarking framework for LLM inference servers
+provider_type: builtin
+runtime:
+  k8s:
+    image: quay.io/evalhub/community-guidellm:latest
+    entrypoint:
+      - python
+      - main.py
+    cpu_request: 100m
+    memory_request: 128Mi
+    cpu_limit: 1000m
+    memory_limit: 2Gi
+  local:
+    # reserved for local runtime
+
+benchmarks:
+  # Execution profiles - comprehensive performance testing
+  - benchmark_id: sweep
+    name: Sweep Profile
+    description: Automatically finds optimal request rate by sweeping from low to high concurrency
+    category: performance
+    metrics:
+      - requests_per_second
+      - prompt_tokens_per_second
+      - output_tokens_per_second
+      - mean_ttft_ms
+      - mean_itl_ms
+    tags:
+      - performance
+      - throughput
+      - latency
+      - guidellm
+      - auto
+
+  - benchmark_id: throughput
+    name: Throughput Profile
+    description: Measures maximum throughput by gradually increasing request rate until saturation
+    category: performance
+    metrics:
+      - requests_per_second
+      - prompt_tokens_per_second
+      - output_tokens_per_second
+      - mean_ttft_ms
+      - mean_itl_ms
+    tags:
+      - performance
+      - throughput
+      - guidellm
+      - saturation
+
+  - benchmark_id: concurrent
+    name: Concurrent Profile
+    description: Tests performance with fixed number of concurrent requests
+    category: performance
+    metrics:
+      - requests_per_second
+      - prompt_tokens_per_second
+      - output_tokens_per_second
+      - mean_ttft_ms
+      - mean_itl_ms
+    tags:
+      - performance
+      - concurrency
+      - guidellm
+
+  - benchmark_id: constant
+    name: Constant Rate Profile
+    description: Maintains constant request rate throughout benchmark duration
+    category: performance
+    metrics:
+      - requests_per_second
+      - prompt_tokens_per_second
+      - output_tokens_per_second
+      - mean_ttft_ms
+      - mean_itl_ms
+    tags:
+      - performance
+      - constant_rate
+      - guidellm
+
+  - benchmark_id: poisson
+    name: Poisson Profile
+    description: Sends requests following Poisson distribution for realistic production simulation
+    category: performance
+    metrics:
+      - requests_per_second
+      - prompt_tokens_per_second
+      - output_tokens_per_second
+      - mean_ttft_ms
+      - mean_itl_ms
+    tags:
+      - performance
+      - poisson
+      - realistic
+      - guidellm
+
+  # Pre-configured benchmark suites
+  - benchmark_id: quick_perf_test
+    name: Quick Performance Test
+    description: Fast performance evaluation with sweep profile and limited samples
+    category: performance
+    metrics:
+      - requests_per_second
+      - mean_ttft_ms
+      - mean_itl_ms
+    tags:
+      - performance
+      - quick
+      - guidellm
+      - suite
+
+  - benchmark_id: comprehensive_perf_test
+    name: Comprehensive Performance Test
+    description: Thorough performance evaluation across all profiles
+    category: performance
+    metrics:
+      - requests_per_second
+      - prompt_tokens_per_second
+      - output_tokens_per_second
+      - mean_ttft_ms
+      - mean_itl_ms
+    tags:
+      - performance
+      - comprehensive
+      - guidellm
+      - suite

--- a/internal/runtimes/k8s/examples/eval-job.yaml
+++ b/internal/runtimes/k8s/examples/eval-job.yaml
@@ -24,7 +24,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: adapter
-          image: quay.io/eval-hub/adapter:latest
+          image: quay.io/evalhub/adapter:latest
           imagePullPolicy: IfNotPresent
           command:
             - /path/to/program

--- a/internal/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/runtimes/k8s/k8s_runtime_unit_test.go
@@ -282,7 +282,7 @@ func sampleProviders(providerID string) map[string]api.ProviderResource {
 			ProviderID: providerID,
 			Runtime: &api.Runtime{
 				K8s: &api.K8sRuntime{
-					Image: "quay.io/eval-hub/adapter:latest",
+					Image: "quay.io/evalhub/adapter:latest",
 				},
 			},
 		},

--- a/pkg/api/providers.go
+++ b/pkg/api/providers.go
@@ -20,7 +20,7 @@ type Runtime struct {
 // Example YAML for provider configs:
 //
 //	runtime:
-//	  image: "quay.io/eval-hub/adapter:latest"
+//	  image: "quay.io/evalhub/adapter:latest"
 //	  entrypoint:
 //	    - "/path/to/program"
 //	  cpu_request: "250m"


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a provider definition for GuideLLM.
The provider is defined in https://github.com/eval-hub/eval-hub-contrib/tree/main/adapters/guidellm

## Type of Change

Please mark the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements
- [ ] CI/CD improvements
- [x] Other (please describe): New provider

## Component(s) Affected

Please mark the relevant component(s):

- [ ] API endpoints
- [ ] Evaluation executors
- [ ] MLFlow integration
- [ ] Collection management
- [ ] Kubernetes/OpenShift deployment
- [ ] Configuration system
- [ ] Monitoring/metrics
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD
- [x] Other: Provider definitions

## Testing

Please describe how you tested your changes:

- Tested manually on an OpenShift cluster.

Job submission:

```json
{
  "resource": {
    "id": "66b8502d-b0a6-4728-8d9d-312f3ea1afba",
    "tenant": "TODO",
    "created_at": "2026-02-08T13:03:42.875158757Z",
    "updated_at": "2026-02-08T13:03:42.87515881Z",
    "message": {
      "message": "Evaluation job created",
      "message_code": "evaluation_job_created"
    }
  },
  "model": {
    "url": "http://vllm-server.test.svc.cluster.local:8000",
    "name": "tinyllama"
  },
  "benchmarks": [
    {
      "id": "sweep",
      "provider_id": "guidellm",
      "parameters": {
        "data": "prompt_tokens=256,output_tokens=128",
        "detect_saturation": true,
        "max_requests": 10,
        "max_seconds": 60,
        "num_examples": 10,
        "processor": "google/flan-t5-small",
        "profile": "sweep",
        "request_type": "chat_completions"
      }
    }
  ],
  "collection": {
    "id": ""
  },
  "timeout_minutes": 30,
  "retry_attempts": 1
}
```

Job results:

```json
{
  "resource": {
    "id": "66b8502d-b0a6-4728-8d9d-312f3ea1afba",
    "tenant": "TODO",
    "created_at": "2026-02-08T13:03:42Z",
    "updated_at": "2026-02-08T13:04:12Z",
    "message": {
      "message": "Evaluation job is completed",
      "message_code": "evaluation_job_updated"
    }
  },
  "status": {
    "state": "completed",
    "message": {
      "message": "Evaluation job is completed",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "",
        "id": "sweep",
        "status": "completed",
        "completed_at": "2026-02-08T13:04:12.081445Z"
      }
    ]
  },
  "results": {
    "total_evaluations": 0,
    "benchmarks": [
      {
        "id": "sweep",
        "provider_id": "",
        "metrics": {
          "mean_itl_ms": 0,
          "mean_ttft_ms": 0,
          "output_tokens_per_second": 35015.68010018066,
          "prompt_tokens_per_second": 70031.36020036132,
          "requests_per_second": 170.28488374453437
        },
        "artifacts": {
          "oci_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
          "oci_reference": "localhost:5000/eval-results/sweep:66b8502d-b0a6-4728-8d9d-312f3ea1afba@sha256:0000000000000000000000000000000000000000000000000000000000000000",
          "size_bytes": 3072
        }
      }
    ]
  },
  "model": {
    "url": "http://vllm-server.test.svc.cluster.local:8000",
    "name": "tinyllama"
  },
  "benchmarks": [
    {
      "id": "sweep",
      "provider_id": "guidellm",
      "parameters": {
        "data": "prompt_tokens=256,output_tokens=128",
        "detect_saturation": true,
        "max_requests": 10,
        "max_seconds": 60,
        "num_examples": 10,
        "processor": "google/flan-t5-small",
        "profile": "sweep",
        "request_type": "chat_completions"
      }
    }
  ],
  "collection": {
    "id": ""
  },
  "timeout_minutes": 30,
  "retry_attempts": 1
}
```

(unrealistic numbers due to using a vLLM simulator)

This PR should wait for https://github.com/eval-hub/eval-hub/pull/154, since 154 changes the provider's schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GuideLLM provider configuration with multiple performance benchmark profiles (Sweep, Throughput, Concurrent, Constant Rate, Poisson) for flexible performance testing.
  * Introduced pre-configured benchmark suites: Quick Performance Test and Comprehensive Performance Test for streamlined evaluations.

* **Bug Fixes**
  * Updated container image registry reference for consistency across deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->