### PR TITLE
fix: remove CA bundle as default

### DIFF
--- a/internal/runtimes/k8s/job_builders.go
+++ b/internal/runtimes/k8s/job_builders.go
@@ -35,7 +35,7 @@ const (
 	mlflowTokenMountPath            = "/var/run/secrets/mlflow"
 	mlflowTokenFile                 = "token"
 	serviceCABundleFile             = "service-ca.crt"
-	envRequestsCABundleName         = "REQUESTS_CA_BUNDLE"
+	envMLFlowCertPathName           = "MLFLOW_TRACKING_SERVER_CERT_PATH"
 	defaultAllowPrivilegeEscalation = false
 	//defaultRunAsUser                = int64(1000)
 	//defaultRunAsGroup               = int64(1000)
@@ -324,14 +324,18 @@ func buildEnvVars(cfg *jobConfig) []corev1.EnvVar {
 		seen[envMLFlowWorkspaceName] = true
 	}
 
-	// Set REQUESTS_CA_BUNDLE so Python's requests library (used by mlflow)
-	// trusts the OpenShift service-serving CA certificate.
-	if cfg.serviceCAConfigMap != "" {
+	// Set MLFLOW_TRACKING_SERVER_CERT_PATH so mlflow's tracking client
+	// trusts the OpenShift service-serving CA certificate for internal calls.
+	// Note: we intentionally do NOT set REQUESTS_CA_BUNDLE, because it
+	// overrides the system CA bundle globally for all Python requests calls,
+	// breaking external HTTPS connections (e.g. HuggingFace tokenizer downloads).
+	// The adapter SDK's httpx client auto-detects the service CA independently.
+	if cfg.serviceCAConfigMap != "" && cfg.mlflowTrackingURI != "" {
 		env = append(env, corev1.EnvVar{
-			Name:  envRequestsCABundleName,
+			Name:  envMLFlowCertPathName,
 			Value: serviceCAMountPath + "/" + serviceCABundleFile,
 		})
-		seen[envRequestsCABundleName] = true
+		seen[envMLFlowCertPathName] = true
 	}
 
 	// Add provider-specific environment variables


### PR DESCRIPTION
# Pull Request

## Description

replace REQUESTS_CA_BUNDLE with MLFLOW_TRACKING_SERVER_CERT_PATH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated certificate path configuration for MLflow tracking integration. When MLflow tracking is enabled with a service CA certificate, the system now uses a dedicated certificate path variable instead of a generic environment variable, ensuring proper certificate validation only when MLflow tracking is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->