### PR TITLE
fix: name kube resources as <jobid>-<guid>

### DIFF
--- a/internal/runtimes/k8s/job_builders_test.go
+++ b/internal/runtimes/k8s/job_builders_test.go
@@ -9,15 +9,16 @@ import (
 
 func TestBuildConfigMap(t *testing.T) {
 	cfg := &jobConfig{
-		jobID:       "job-123",
-		namespace:   "default",
-		providerID:  "provider-1",
-		benchmarkID: "bench-1",
-		jobSpecJSON: "{}",
+		jobID:        "job-123",
+		resourceGUID: "guid-123",
+		namespace:    "default",
+		providerID:   "provider-1",
+		benchmarkID:  "bench-1",
+		jobSpecJSON:  "{}",
 	}
 
 	configMap := buildConfigMap(cfg)
-	expectedName := configMapName(cfg.jobID, cfg.providerID, cfg.benchmarkID)
+	expectedName := configMapName(cfg.jobID, cfg.resourceGUID)
 	if configMap.Name != expectedName {
 		t.Fatalf("expected configmap name %s, got %s", expectedName, configMap.Name)
 	}
@@ -37,20 +38,18 @@ func TestBuildConfigMap(t *testing.T) {
 }
 
 func TestBuildK8sNameSanitizes(t *testing.T) {
-	name := buildK8sName("Job-123", "Provider-1", "AraDiCE_boolq_lev", "")
-	prefix := "eval-job-provider-1-aradice-boolq-lev-job-123-"
-	if !strings.HasPrefix(name, prefix) {
-		t.Fatalf("expected sanitized name to start with %q, got %q", prefix, name)
+	name := buildK8sName("Job-123", "Guid-ABC", "")
+	if !strings.HasPrefix(name, "job-123-") {
+		t.Fatalf("expected sanitized name to start with %q, got %q", "job-123-", name)
 	}
 }
 
-func TestBuildK8sNameDiffersAcrossProviders(t *testing.T) {
+func TestBuildK8sNameDiffersAcrossGUIDs(t *testing.T) {
 	jobID := "job-123"
-	benchmarkID := "arc_easy"
-	name1 := buildK8sName(jobID, "lmeval", benchmarkID, "")
-	name2 := buildK8sName(jobID, "lighteval", benchmarkID, "")
+	name1 := buildK8sName(jobID, "guid-1", "")
+	name2 := buildK8sName(jobID, "guid-2", "")
 	if name1 == name2 {
-		t.Fatalf("expected different names for different providers, got %q", name1)
+		t.Fatalf("expected different names for different GUIDs, got %q", name1)
 	}
 }
 
@@ -63,10 +62,11 @@ func TestJobLabelsSanitizeBenchmarkID(t *testing.T) {
 
 func TestBuildJobRequiresAdapterImage(t *testing.T) {
 	cfg := &jobConfig{
-		jobID:       "job-123",
-		namespace:   "default",
-		providerID:  "provider-1",
-		benchmarkID: "bench-1",
+		jobID:        "job-123",
+		resourceGUID: "guid-123",
+		namespace:    "default",
+		providerID:   "provider-1",
+		benchmarkID:  "bench-1",
 	}
 
 	_, err := buildJob(cfg)
@@ -78,6 +78,7 @@ func TestBuildJobRequiresAdapterImage(t *testing.T) {
 func TestBuildJobSecurityContext(t *testing.T) {
 	cfg := &jobConfig{
 		jobID:        "job-123",
+		resourceGUID: "guid-123",
 		namespace:    "default",
 		providerID:   "provider-1",
 		benchmarkID:  "bench-1",
@@ -124,6 +125,7 @@ func TestBuildJobSecurityContext(t *testing.T) {
 func TestBuildJobAnnotations(t *testing.T) {
 	cfg := &jobConfig{
 		jobID:        "job-123",
+		resourceGUID: "guid-123",
 		namespace:    "default",
 		providerID:   "provider-1",
 		benchmarkID:  "bench-1",
@@ -161,6 +163,7 @@ func TestBuildJobAnnotations(t *testing.T) {
 func TestBuildJobWithOCICredentials(t *testing.T) {
 	cfg := &jobConfig{
 		jobID:                "job-oci",
+		resourceGUID:         "guid-oci",
 		namespace:            "default",
 		providerID:           "provider-1",
 		benchmarkID:          "bench-1",
@@ -230,6 +233,7 @@ func TestBuildJobWithOCICredentials(t *testing.T) {
 func TestBuildJobWithoutOCICredentials(t *testing.T) {
 	cfg := &jobConfig{
 		jobID:        "job-no-oci",
+		resourceGUID: "guid-no-oci",
 		namespace:    "default",
 		providerID:   "provider-1",
 		benchmarkID:  "bench-1",

--- a/internal/runtimes/k8s/job_config.go
+++ b/internal/runtimes/k8s/job_config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/google/uuid"
 )
 
 const (
@@ -28,6 +29,7 @@ const (
 
 type jobConfig struct {
 	jobID                string
+	resourceGUID         string
 	namespace            string
 	providerID           string
 	benchmarkID          string
@@ -150,6 +152,7 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 
 	return &jobConfig{
 		jobID:                evaluation.Resource.ID,
+		resourceGUID:         uuid.NewString(),
 		namespace:            namespace,
 		providerID:           provider.Resource.ID,
 		benchmarkID:          benchmarkID,

--- a/internal/runtimes/k8s/k8s_helper.go
+++ b/internal/runtimes/k8s/k8s_helper.go
@@ -99,6 +99,30 @@ func (h *KubernetesHelper) DeleteConfigMap(ctx context.Context, namespace, name 
 	return h.clientset.CoreV1().ConfigMaps(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
+// ListJobs returns Jobs matching the label selector.
+func (h *KubernetesHelper) ListJobs(ctx context.Context, namespace, labelSelector string) ([]batchv1.Job, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	list, err := h.clientset.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// ListConfigMaps returns ConfigMaps matching the label selector.
+func (h *KubernetesHelper) ListConfigMaps(ctx context.Context, namespace, labelSelector string) ([]corev1.ConfigMap, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	list, err := h.clientset.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
 // SetConfigMapOwner sets a single owner reference on the ConfigMap.
 func (h *KubernetesHelper) SetConfigMapOwner(ctx context.Context, namespace, name string, owner metav1.OwnerReference) error {
 	if namespace == "" || name == "" {

--- a/internal/runtimes/k8s/k8s_runtime.go
+++ b/internal/runtimes/k8s/k8s_runtime.go
@@ -114,24 +114,38 @@ func (r *K8sRuntime) DeleteEvaluationJobResources(evaluation *api.EvaluationJobR
 		"namespace", namespace,
 	)
 
+	labelSelector := fmt.Sprintf("%s=%s", labelJobIDKey, sanitizeLabelValue(evaluation.Resource.ID))
+	jobs, err := r.helper.ListJobs(r.ctx, namespace, labelSelector)
+	if err != nil {
+		return err
+	}
+	configMaps, err := r.helper.ListConfigMaps(r.ctx, namespace, labelSelector)
+	if err != nil {
+		return err
+	}
+
 	var deleteErr error
-	for _, bench := range evaluation.Benchmarks {
-		jobName := jobName(evaluation.Resource.ID, bench.ProviderID, bench.ID)
-		configMapName := configMapName(evaluation.Resource.ID, bench.ProviderID, bench.ID)
+	for _, job := range jobs {
 		r.logger.Info(
-			"deleting evaluation runtime resources for benchmark",
+			"deleting evaluation runtime job",
 			"job_id", evaluation.Resource.ID,
-			"benchmark_id", bench.ID,
-			"job_name", jobName,
-			"configmap_name", configMapName,
+			"job_name", job.Name,
 			"namespace", namespace,
 		)
-		if err := r.helper.DeleteJob(r.ctx, namespace, jobName, deleteOptions); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.helper.DeleteJob(r.ctx, namespace, job.Name, deleteOptions); err != nil && !apierrors.IsNotFound(err) {
 			deleteErr = errors.Join(deleteErr, err)
 		}
-		// OwnerReferences should GC ConfigMaps when Jobs are deleted, but we delete explicitly
-		// to avoid orphans if the owner ref was never set or the job delete is delayed.
-		if err := r.helper.DeleteConfigMap(r.ctx, namespace, configMapName); err != nil && !apierrors.IsNotFound(err) {
+	}
+	// OwnerReferences should GC ConfigMaps when Jobs are deleted, but we delete explicitly
+	// to avoid orphans if the owner ref was never set or the job delete is delayed.
+	for _, configMap := range configMaps {
+		r.logger.Info(
+			"deleting evaluation runtime configmap",
+			"job_id", evaluation.Resource.ID,
+			"configmap_name", configMap.Name,
+			"namespace", namespace,
+		)
+		if err := r.helper.DeleteConfigMap(r.ctx, namespace, configMap.Name); err != nil && !apierrors.IsNotFound(err) {
 			deleteErr = errors.Join(deleteErr, err)
 		}
 	}

--- a/internal/runtimes/k8s/k8s_runtime_test.go
+++ b/internal/runtimes/k8s/k8s_runtime_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -21,6 +22,26 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
+func listJobsByJobID(t *testing.T, clientset *fake.Clientset, jobID string) []batchv1.Job {
+	t.Helper()
+	labelSelector := fmt.Sprintf("%s=%s", labelJobIDKey, sanitizeLabelValue(jobID))
+	jobs, err := clientset.BatchV1().Jobs(defaultNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		t.Fatalf("failed to list jobs: %v", err)
+	}
+	return jobs.Items
+}
+
+func listConfigMapsByJobID(t *testing.T, clientset *fake.Clientset, jobID string) []corev1.ConfigMap {
+	t.Helper()
+	labelSelector := fmt.Sprintf("%s=%s", labelJobIDKey, sanitizeLabelValue(jobID))
+	configMaps, err := clientset.CoreV1().ConfigMaps(defaultNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		t.Fatalf("failed to list configmaps: %v", err)
+	}
+	return configMaps.Items
+}
+
 func TestRunEvaluationJobCreatesResources(t *testing.T) {
 	// Integration test: creates one ConfigMap and Job per benchmark in a real cluster.
 	if os.Getenv("K8S_INTEGRATION_TEST") != "1" {
@@ -34,7 +55,6 @@ func TestRunEvaluationJobCreatesResources(t *testing.T) {
 		t.Fatalf("failed to create kubernetes helper: %v", err)
 	}
 	jobID := uuid.NewString()
-	providerID := "lm_evaluation_harness"
 	benchmarkID := "arc_easy"
 	benchmarkIDTwo := "arc"
 	runtime := &K8sRuntime{
@@ -99,27 +119,54 @@ func TestRunEvaluationJobCreatesResources(t *testing.T) {
 		t.Fatalf("RunEvaluationJob returned error: %v", err)
 	}
 
-	benchmarkIDs := []string{benchmarkID, benchmarkIDTwo}
 	t.Cleanup(func() {
 		_ = runtime.DeleteEvaluationJobResources(evaluation)
 	})
-	namespace := "default"
-	for _, id := range benchmarkIDs {
-		configMapName := configMapName(jobID, providerID, id)
-		jobName := jobName(jobID, providerID, id)
-		found := false
-		deadline := time.Now().Add(apiTimeout)
-		for time.Now().Before(deadline) {
-			if _, err := helper.clientset.CoreV1().ConfigMaps(namespace).Get(context.Background(), configMapName, metav1.GetOptions{}); err == nil {
-				if _, err := helper.clientset.BatchV1().Jobs(namespace).Get(context.Background(), jobName, metav1.GetOptions{}); err == nil {
-					found = true
-					break
-				}
-			}
-			time.Sleep(200 * time.Millisecond)
+	namespace := resolveNamespace("")
+	labelSelector := fmt.Sprintf("%s=%s", labelJobIDKey, sanitizeLabelValue(jobID))
+	deadline := time.Now().Add(apiTimeout)
+	for time.Now().Before(deadline) {
+		jobs, err := helper.ListJobs(context.Background(), namespace, labelSelector)
+		if err != nil {
+			t.Fatalf("failed to list jobs: %v", err)
 		}
-		if !found {
-			t.Fatalf("expected configmap/job to be created for %s", id)
+		configMaps, err := helper.ListConfigMaps(context.Background(), namespace, labelSelector)
+		if err != nil {
+			t.Fatalf("failed to list configmaps: %v", err)
+		}
+		if len(jobs) == len(evaluation.Benchmarks) &&
+			len(configMaps) == len(evaluation.Benchmarks) {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	jobs, err := helper.ListJobs(context.Background(), namespace, labelSelector)
+	if err != nil {
+		t.Fatalf("failed to list jobs: %v", err)
+	}
+	configMaps, err := helper.ListConfigMaps(context.Background(), namespace, labelSelector)
+	if err != nil {
+		t.Fatalf("failed to list configmaps: %v", err)
+	}
+	if len(jobs) != len(evaluation.Benchmarks) {
+		t.Fatalf("expected %d jobs, got %d", len(evaluation.Benchmarks), len(jobs))
+	}
+	if len(configMaps) != len(evaluation.Benchmarks) {
+		t.Fatalf("expected %d configmaps, got %d", len(evaluation.Benchmarks), len(configMaps))
+	}
+	expectedBenchmarks := map[string]struct{}{
+		benchmarkID:    {},
+		benchmarkIDTwo: {},
+	}
+	foundBenchmarks := map[string]struct{}{}
+	for _, job := range jobs {
+		if id, ok := job.Labels[labelBenchmarkIDKey]; ok {
+			foundBenchmarks[id] = struct{}{}
+		}
+	}
+	for id := range expectedBenchmarks {
+		if _, ok := foundBenchmarks[sanitizeLabelValue(id)]; !ok {
+			t.Fatalf("expected benchmark label %s to be present", id)
 		}
 	}
 }
@@ -129,6 +176,9 @@ func TestCreateBenchmarkResourcesReturnsErrorWhenConfigMapExists(t *testing.T) {
 	t.Setenv("SERVICE_URL", "http://eval-hub")
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	clientset := fake.NewSimpleClientset()
+	clientset.PrependReactor("create", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(corev1.Resource("configmaps"), "job-spec")
+	})
 	runtime := &K8sRuntime{
 		logger: logger,
 		helper: &KubernetesHelper{clientset: clientset},
@@ -176,17 +226,6 @@ func TestCreateBenchmarkResourcesReturnsErrorWhenConfigMapExists(t *testing.T) {
 		},
 	}
 
-	cmName := configMapName(evaluation.Resource.ID, evaluation.Benchmarks[0].ProviderID, evaluation.Benchmarks[0].ID)
-	_, err := clientset.CoreV1().ConfigMaps(defaultNamespace).Create(context.Background(), &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmName,
-			Namespace: defaultNamespace,
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("failed to seed configmap: %v", err)
-	}
-
 	if err := runtime.createBenchmarkResources(context.Background(), logger, evaluation, &evaluation.Benchmarks[0]); err == nil {
 		t.Fatalf("expected error but got nil")
 	} else if !apierrors.IsAlreadyExists(err) {
@@ -194,8 +233,8 @@ func TestCreateBenchmarkResourcesReturnsErrorWhenConfigMapExists(t *testing.T) {
 	}
 }
 
-func TestCreateBenchmarkResourcesDuplicateBenchmarkIDCollides(t *testing.T) {
-	// Integration test: repro name collision in a real cluster.
+func TestCreateBenchmarkResourcesDuplicateBenchmarkIDDoesNotCollide(t *testing.T) {
+	// Integration test: duplicates should still create distinct resources.
 	if os.Getenv("K8S_INTEGRATION_TEST") != "1" {
 		t.Skip("set K8S_INTEGRATION_TEST=1 to run against a real cluster")
 	}
@@ -254,15 +293,8 @@ func TestCreateBenchmarkResourcesDuplicateBenchmarkIDCollides(t *testing.T) {
 		},
 	}
 
-	firstJobName := jobName(evaluation.Resource.ID, evaluation.Benchmarks[0].ProviderID, evaluation.Benchmarks[0].ID)
-	firstConfigMapName := configMapName(evaluation.Resource.ID, evaluation.Benchmarks[0].ProviderID, evaluation.Benchmarks[0].ID)
-	secondJobName := jobName(evaluation.Resource.ID, evaluation.Benchmarks[1].ProviderID, evaluation.Benchmarks[1].ID)
-	secondConfigMapName := configMapName(evaluation.Resource.ID, evaluation.Benchmarks[1].ProviderID, evaluation.Benchmarks[1].ID)
 	t.Cleanup(func() {
-		_ = runtime.helper.DeleteJob(context.Background(), defaultNamespace, firstJobName, metav1.DeleteOptions{})
-		_ = runtime.helper.DeleteConfigMap(context.Background(), defaultNamespace, firstConfigMapName)
-		_ = runtime.helper.DeleteJob(context.Background(), defaultNamespace, secondJobName, metav1.DeleteOptions{})
-		_ = runtime.helper.DeleteConfigMap(context.Background(), defaultNamespace, secondConfigMapName)
+		_ = runtime.DeleteEvaluationJobResources(evaluation)
 	})
 
 	if err := runtime.createBenchmarkResources(context.Background(), logger, evaluation, &evaluation.Benchmarks[0]); err != nil {
@@ -274,17 +306,13 @@ func TestCreateBenchmarkResourcesDuplicateBenchmarkIDCollides(t *testing.T) {
 		t.Fatalf("unexpected error creating second benchmark resources: %v", err)
 	}
 
-	if _, err := helper.clientset.BatchV1().Jobs(defaultNamespace).Get(context.Background(), firstJobName, metav1.GetOptions{}); err != nil {
-		t.Fatalf("expected first job to exist, got %v", err)
+	jobs := listJobsByJobID(t, helper.clientset.(*fake.Clientset), evaluation.Resource.ID)
+	configMaps := listConfigMapsByJobID(t, helper.clientset.(*fake.Clientset), evaluation.Resource.ID)
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d", len(jobs))
 	}
-	if _, err := helper.clientset.BatchV1().Jobs(defaultNamespace).Get(context.Background(), secondJobName, metav1.GetOptions{}); err != nil {
-		t.Fatalf("expected second job to exist, got %v", err)
-	}
-	if _, err := helper.clientset.CoreV1().ConfigMaps(defaultNamespace).Get(context.Background(), firstConfigMapName, metav1.GetOptions{}); err != nil {
-		t.Fatalf("expected first configmap to exist, got %v", err)
-	}
-	if _, err := helper.clientset.CoreV1().ConfigMaps(defaultNamespace).Get(context.Background(), secondConfigMapName, metav1.GetOptions{}); err != nil {
-		t.Fatalf("expected second configmap to exist, got %v", err)
+	if len(configMaps) != 2 {
+		t.Fatalf("expected 2 configmaps, got %d", len(configMaps))
 	}
 }
 
@@ -334,21 +362,19 @@ func TestCreateBenchmarkResourcesSetsAnnotationsIntegration(t *testing.T) {
 		},
 	}
 
-	jobName := jobName(evaluation.Resource.ID, evaluation.Benchmarks[0].ProviderID, evaluation.Benchmarks[0].ID)
-	configMapName := configMapName(evaluation.Resource.ID, evaluation.Benchmarks[0].ProviderID, evaluation.Benchmarks[0].ID)
 	t.Cleanup(func() {
-		_ = runtime.helper.DeleteJob(context.Background(), defaultNamespace, jobName, metav1.DeleteOptions{})
-		_ = runtime.helper.DeleteConfigMap(context.Background(), defaultNamespace, configMapName)
+		_ = runtime.DeleteEvaluationJobResources(evaluation)
 	})
 
 	if err := runtime.createBenchmarkResources(context.Background(), logger, evaluation, &evaluation.Benchmarks[0]); err != nil {
 		t.Fatalf("unexpected error creating benchmark resources: %v", err)
 	}
 
-	cm, err := helper.clientset.CoreV1().ConfigMaps(defaultNamespace).Get(context.Background(), configMapName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("expected configmap to exist, got %v", err)
+	configMaps := listConfigMapsByJobID(t, helper.clientset.(*fake.Clientset), evaluation.Resource.ID)
+	if len(configMaps) != 1 {
+		t.Fatalf("expected 1 configmap, got %d", len(configMaps))
 	}
+	cm := configMaps[0]
 	if cm.Annotations[annotationJobIDKey] != evaluation.Resource.ID {
 		t.Fatalf("expected configmap job_id annotation %q, got %q", evaluation.Resource.ID, cm.Annotations[annotationJobIDKey])
 	}
@@ -359,10 +385,11 @@ func TestCreateBenchmarkResourcesSetsAnnotationsIntegration(t *testing.T) {
 		t.Fatalf("expected configmap benchmark_id annotation %q, got %q", evaluation.Benchmarks[0].ID, cm.Annotations[annotationBenchmarkIDKey])
 	}
 
-	job, err := helper.clientset.BatchV1().Jobs(defaultNamespace).Get(context.Background(), jobName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("expected job to exist, got %v", err)
+	jobs := listJobsByJobID(t, helper.clientset.(*fake.Clientset), evaluation.Resource.ID)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
 	}
+	job := jobs[0]
 	if job.Annotations[annotationJobIDKey] != evaluation.Resource.ID {
 		t.Fatalf("expected job job_id annotation %q, got %q", evaluation.Resource.ID, job.Annotations[annotationJobIDKey])
 	}
@@ -463,11 +490,15 @@ func TestDeleteEvaluationJobResourcesDeletesJobsAndConfigMaps(t *testing.T) {
 		},
 	}
 
-	for _, bench := range evaluation.Benchmarks {
+	for range evaluation.Benchmarks {
+		guid := uuid.NewString()
 		job := &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      jobName(evaluation.Resource.ID, bench.ProviderID, bench.ID),
+				Name:      jobName(evaluation.Resource.ID, guid),
 				Namespace: defaultNamespace,
+				Labels: map[string]string{
+					labelJobIDKey: sanitizeLabelValue(evaluation.Resource.ID),
+				},
 			},
 		}
 		if _, err := clientset.BatchV1().Jobs(defaultNamespace).Create(context.Background(), job, metav1.CreateOptions{}); err != nil {
@@ -476,8 +507,11 @@ func TestDeleteEvaluationJobResourcesDeletesJobsAndConfigMaps(t *testing.T) {
 
 		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName(evaluation.Resource.ID, bench.ProviderID, bench.ID),
+				Name:      configMapName(evaluation.Resource.ID, guid),
 				Namespace: defaultNamespace,
+				Labels: map[string]string{
+					labelJobIDKey: sanitizeLabelValue(evaluation.Resource.ID),
+				},
 			},
 		}
 		if _, err := clientset.CoreV1().ConfigMaps(defaultNamespace).Create(context.Background(), configMap, metav1.CreateOptions{}); err != nil {
@@ -489,13 +523,13 @@ func TestDeleteEvaluationJobResourcesDeletesJobsAndConfigMaps(t *testing.T) {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 
-	for _, bench := range evaluation.Benchmarks {
-		if _, err := clientset.BatchV1().Jobs(defaultNamespace).Get(context.Background(), jobName(evaluation.Resource.ID, bench.ProviderID, bench.ID), metav1.GetOptions{}); err == nil || !apierrors.IsNotFound(err) {
-			t.Fatalf("expected job to be deleted for %s", bench.ID)
-		}
-		if _, err := clientset.CoreV1().ConfigMaps(defaultNamespace).Get(context.Background(), configMapName(evaluation.Resource.ID, bench.ProviderID, bench.ID), metav1.GetOptions{}); err == nil || !apierrors.IsNotFound(err) {
-			t.Fatalf("expected configmap to be deleted for %s", bench.ID)
-		}
+	jobs := listJobsByJobID(t, clientset, evaluation.Resource.ID)
+	configMaps := listConfigMapsByJobID(t, clientset, evaluation.Resource.ID)
+	if len(jobs) != 0 {
+		t.Fatalf("expected jobs to be deleted for %d benchmarks, got %d", len(evaluation.Benchmarks), len(jobs))
+	}
+	if len(configMaps) != 0 {
+		t.Fatalf("expected configmaps to be deleted for %d benchmarks, got %d", len(evaluation.Benchmarks), len(configMaps))
 	}
 }
 
@@ -528,6 +562,32 @@ func TestDeleteEvaluationJobResourcesReturnsJoinedErrors(t *testing.T) {
 				{Ref: api.Ref{ID: "bench-2"}, ProviderID: "provider-2"},
 			},
 		},
+	}
+
+	guid := uuid.NewString()
+	_, errJobCreate := clientset.BatchV1().Jobs(defaultNamespace).Create(context.Background(), &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName(evaluation.Resource.ID, guid),
+			Namespace: defaultNamespace,
+			Labels: map[string]string{
+				labelJobIDKey: sanitizeLabelValue(evaluation.Resource.ID),
+			},
+		},
+	}, metav1.CreateOptions{})
+	if errJobCreate != nil {
+		t.Fatalf("failed to seed job: %v", errJobCreate)
+	}
+	_, errConfigCreate := clientset.CoreV1().ConfigMaps(defaultNamespace).Create(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName(evaluation.Resource.ID, guid),
+			Namespace: defaultNamespace,
+			Labels: map[string]string{
+				labelJobIDKey: sanitizeLabelValue(evaluation.Resource.ID),
+			},
+		},
+	}, metav1.CreateOptions{})
+	if errConfigCreate != nil {
+		t.Fatalf("failed to seed configmap: %v", errConfigCreate)
 	}
 
 	err := runtime.DeleteEvaluationJobResources(evaluation)

--- a/tests/kubernetes/features/kubernetes_resources.feature
+++ b/tests/kubernetes/features/kubernetes_resources.feature
@@ -14,7 +14,7 @@ Feature: Kubernetes Resources Validation
     And Jobs should be created in the background
     And the number of Jobs created should equal the number of benchmarks
     And the number of ConfigMaps created should equal the number of benchmarks
-    And a ConfigMap should be created with name pattern "eval-job-{provider_id}-{benchmark_id}-{id}-{hash}-spec"
+    And a ConfigMap should be created with name pattern "{id}-{guid}-spec"
     And the ConfigMap should have label "app" with value "evalhub"
     And the ConfigMap should have label "component" with value "evaluation-job"
     And the ConfigMap should have label "job_id" matching the evaluation job ID
@@ -31,7 +31,7 @@ Feature: Kubernetes Resources Validation
     And the ConfigMap should have an ownerReference of kind "Job"
     And the ConfigMap ownerReference should have controller set to true
     And the ConfigMap ownerReference should reference the created Job
-    And a Kubernetes Job should be created with name pattern "eval-job-{provider_id}-{benchmark_id}-{id}-{hash}"
+    And a Kubernetes Job should be created with name pattern "{id}-{guid}"
     And the Job should have label "app" with value "evalhub"
     And the Job should have label "component" with value "evaluation-job"
     And the Job should have label "job_id" matching the evaluation job ID

--- a/tests/kubernetes/features/step_definitions_test.go
+++ b/tests/kubernetes/features/step_definitions_test.go
@@ -578,6 +578,8 @@ func (tc *testContext) theResponseCodeShouldBe(code int) error {
 func (tc *testContext) configMapShouldBeCreatedWithNamePattern(pattern string) error {
 	// Convert pattern to regex
 	regexPattern := strings.ReplaceAll(pattern, "{id}", ".*")
+	regexPattern = strings.ReplaceAll(regexPattern, "{guid}", ".*")
+	regexPattern = strings.ReplaceAll(regexPattern, "{resource_guid}", ".*")
 	regexPattern = strings.ReplaceAll(regexPattern, "{benchmark_id}", ".*")
 	regexPattern = strings.ReplaceAll(regexPattern, "{provider_id}", ".*")
 	regexPattern = strings.ReplaceAll(regexPattern, "{hash}", ".*")
@@ -1071,6 +1073,8 @@ func (tc *testContext) configMapDataShouldContainFieldAsArray(dataKey, field str
 func (tc *testContext) jobShouldBeCreatedWithNamePattern(pattern string) error {
 	// Convert pattern to regex
 	regexPattern := strings.ReplaceAll(pattern, "{id}", ".*")
+	regexPattern = strings.ReplaceAll(regexPattern, "{guid}", ".*")
+	regexPattern = strings.ReplaceAll(regexPattern, "{resource_guid}", ".*")
 	regexPattern = strings.ReplaceAll(regexPattern, "{benchmark_id}", ".*")
 	regexPattern = strings.ReplaceAll(regexPattern, "{provider_id}", ".*")
 	regexPattern = strings.ReplaceAll(regexPattern, "{hash}", ".*")

--- a/tests/kubernetes/features/test_data/evaluation_job_multi_benchmark.json
+++ b/tests/kubernetes/features/test_data/evaluation_job_multi_benchmark.json
@@ -18,8 +18,8 @@
       "parameters": {}
     },
     {
-      "id": "toxicity",
-      "provider_id": "garak"
+      "id": "blimp",
+      "provider_id": "lm_evaluation_harness"
     }
   ]
 }


### PR DESCRIPTION


# Pull Request

## Description

- Switch K8s Job/ConfigMap naming to `jobid-guid` for uniqueness.
- Delete Jobs/ConfigMaps by `job_id` label instead of name pattern.
- Update tests to match the new naming and label-based cleanup.


**Related Issue(s)**:
- Fixes #(issue number)
- Relates to #(issue number)

## Type of Change

Please mark the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements
- [ ] CI/CD improvements
- [ ] Other (please describe):

## Component(s) Affected

Please mark the relevant component(s):

- [ ] API endpoints
- [ ] Evaluation executors
- [ ] MLFlow integration
- [ ] Collection management
- [x] Kubernetes/OpenShift deployment
- [ ] Configuration system
- [ ] Monitoring/metrics
- [ ] Storage
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD
- [ ] Other:

## Changes Made

Please describe the specific changes made:

### Added
-

### Changed
- Switch K8s Job/ConfigMap naming to `jobid-guid` for uniqueness.
- Delete Jobs/ConfigMaps by `job_id` label instead of name pattern.
- Update tests to match the new naming and label-based cleanup.

### Removed
-

### Fixed
-

## Testing

Please describe how you tested your changes:

### Test Coverage
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No tests needed (documentation/minor changes)

### Test Results
- [x] All existing tests pass
- [x] New tests pass
- [x] Manual testing successful

**Manual Testing Details** (if applicable):
```
Connected to remote cluster from local service, created job, validate the new naming convention followed by kube resources, ensured that the delete job API cleans up the resources
```

### Performance Impact
- [x] No performance impact
- [ ] Performance improvement
- [ ] Performance regression (justified and documented)
- [ ] Performance impact unknown

## Documentation

- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] README updated
- [ ] CONTRIBUTING guide updated
- [ ] Examples/tutorials added/updated
- [x] No documentation changes needed

## Breaking Changes

If this PR introduces breaking changes, please describe them and the migration path:

```
Describe breaking changes:
-
-

Migration path:
1.
2.
```

## Security Considerations

- [x] No security implications
- [ ] Security review needed
- [ ] Authentication/authorization changes
- [ ] Sensitive data handling changes
- [ ] Network security changes

Please describe any security implications:

## Deployment Considerations

- [x] No deployment changes needed
- [ ] Environment variables added/changed
- [ ] Configuration changes required
- [ ] Database migrations needed
- [ ] Kubernetes manifests updated
- [ ] New dependencies added

**Deployment Notes**:

## Screenshots/Evidence

If applicable, add screenshots or other evidence of the changes:

## Checklist

Please confirm the following before submitting:

### Code Quality
- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Code is properly commented
- [x] No new linting warnings introduced

### Testing
- [x] Tests have been added for new functionality
- [x] All tests pass locally
- [x] Test coverage is adequate
- [x] No regression in existing functionality

### Documentation
- [ ] Documentation has been updated as needed
- [ ] API documentation reflects changes
- [ ] Examples updated if needed
- [ ] Breaking changes documented

### Review Readiness
- [x] PR title is clear and descriptive
- [x] PR description is complete
- [x] Commit messages follow conventional commits format
- [x] Branch is up to date with main
- [x] Ready for review

## Additional Notes

Add any additional notes, context, or questions for reviewers:

---

**For Reviewers**: Please check that all automated checks pass before approving. Pay special attention to:
- Test coverage and quality
- API contract compatibility
- Security implications
- Performance impact
- Documentation completeness
