### PR TITLE
feat: Add model inference proxy in sidecar and remove credentials from adapter

### DIFF
--- a/internal/eval_hub/config/sidecar_config.go
+++ b/internal/eval_hub/config/sidecar_config.go
@@ -6,13 +6,14 @@ import (
 )
 
 type SidecarConfig struct {
-	Port             int                     `mapstructure:"port,omitempty" json:"port,omitempty"`
-	BaseURL          string                  `mapstructure:"base_url,omitempty" json:"base_url,omitempty"`
-	EvalHub          *EvalHubClientConfig    `mapstructure:"eval_hub" json:"eval_hub,omitempty"`
-	MLFlow           *SidecarMLFlowConfig    `mapstructure:"mlflow,omitempty" json:"mlflow,omitempty"`
-	Model            *SidecarModelConfig     `mapstructure:"model,omitempty" json:"model,omitempty"`
-	OCI              *SidecarOCIConfig       `mapstructure:"oci,omitempty" json:"oci,omitempty"`
-	SidecarContainer *SidecarContainerConfig `mapstructure:"sidecar_container,omitempty" json:"sidecar_container,omitempty"`
+	Port             int                       `mapstructure:"port,omitempty" json:"port,omitempty"`
+	BaseURL          string                    `mapstructure:"base_url,omitempty" json:"base_url,omitempty"`
+	EvalHub          *EvalHubClientConfig      `mapstructure:"eval_hub" json:"eval_hub,omitempty"`
+	MLFlow           *SidecarMLFlowConfig      `mapstructure:"mlflow,omitempty" json:"mlflow,omitempty"`
+	Model            *SidecarModelConfig       `mapstructure:"model,omitempty" json:"model,omitempty"`
+	HuggingFace      *SidecarHuggingFaceConfig `mapstructure:"huggingface,omitempty" json:"huggingface,omitempty"`
+	OCI              *SidecarOCIConfig         `mapstructure:"oci,omitempty" json:"oci,omitempty"`
+	SidecarContainer *SidecarContainerConfig   `mapstructure:"sidecar_container,omitempty" json:"sidecar_container,omitempty"`
 }
 
 // SidecarModelConfig configures the sidecar reverse proxy for OpenAI-compatible model HTTP traffic.
@@ -23,6 +24,19 @@ type SidecarModelConfig struct {
 	URL                string        `mapstructure:"url,omitempty" json:"url,omitempty"`
 	AuthAPIKeyPath     string        `mapstructure:"auth_api_key_path,omitempty" json:"auth_api_key_path,omitempty"` // optional; if empty, sidecar uses pod default service account token file
 	AuthCACertPath     string        `mapstructure:"auth_ca_cert_path,omitempty" json:"auth_ca_cert_path,omitempty"` // optional PEM for model TLS (e.g. secret key ca_cert)
+	InsecureSkipVerify bool          `mapstructure:"insecure_skip_verify,omitempty" json:"insecure_skip_verify,omitempty"`
+	HTTPTimeout        time.Duration `mapstructure:"http_timeout,omitempty" json:"http_timeout,omitempty"`
+	TokenCacheTimeout  time.Duration `mapstructure:"token_cache_timeout,omitempty" json:"token_cache_timeout,omitempty"`
+}
+
+// SidecarHuggingFaceConfig configures the sidecar reverse proxy for Hugging Face Hub HTTP traffic.
+// Public Hub assets need no token; for gated models/datasets, use evaluation model.auth.secret_ref with a
+// secret key "hf-token" (same secret as OpenAI API credentials). Job pods set token_path to that file when
+// the secret is mounted. Clients call the sidecar at path prefix /huggingface (e.g. .../huggingface/api/...).
+// URL defaults to https://huggingface.co when sidecar.huggingface is present but url is empty.
+type SidecarHuggingFaceConfig struct {
+	URL                string        `mapstructure:"url,omitempty" json:"url,omitempty"`               // default https://huggingface.co
+	TokenPath          string        `mapstructure:"token_path,omitempty" json:"token_path,omitempty"` // file containing HF token; empty => anonymous Hub requests (no Authorization)
 	InsecureSkipVerify bool          `mapstructure:"insecure_skip_verify,omitempty" json:"insecure_skip_verify,omitempty"`
 	HTTPTimeout        time.Duration `mapstructure:"http_timeout,omitempty" json:"http_timeout,omitempty"`
 	TokenCacheTimeout  time.Duration `mapstructure:"token_cache_timeout,omitempty" json:"token_cache_timeout,omitempty"`

--- a/internal/eval_hub/config/sidecar_config.go
+++ b/internal/eval_hub/config/sidecar_config.go
@@ -10,8 +10,22 @@ type SidecarConfig struct {
 	BaseURL          string                  `mapstructure:"base_url,omitempty" json:"base_url,omitempty"`
 	EvalHub          *EvalHubClientConfig    `mapstructure:"eval_hub" json:"eval_hub,omitempty"`
 	MLFlow           *SidecarMLFlowConfig    `mapstructure:"mlflow,omitempty" json:"mlflow,omitempty"`
+	Model            *SidecarModelConfig     `mapstructure:"model,omitempty" json:"model,omitempty"`
 	OCI              *SidecarOCIConfig       `mapstructure:"oci,omitempty" json:"oci,omitempty"`
 	SidecarContainer *SidecarContainerConfig `mapstructure:"sidecar_container,omitempty" json:"sidecar_container,omitempty"`
+}
+
+// SidecarModelConfig configures the sidecar reverse proxy for OpenAI-compatible model HTTP traffic.
+// Clients call the sidecar at path prefix /model (e.g. base URL http://localhost:8080/model/v1 for lm_eval);
+// the sidecar strips /model and forwards to URL. Bearer material: auth_api_key_path if set, else default pod SA token file.
+// TLS: auth_ca_cert_path when set (optional PEM).
+type SidecarModelConfig struct {
+	URL                string        `mapstructure:"url,omitempty" json:"url,omitempty"`
+	AuthAPIKeyPath     string        `mapstructure:"auth_api_key_path,omitempty" json:"auth_api_key_path,omitempty"` // optional; if empty, sidecar uses pod default service account token file
+	AuthCACertPath     string        `mapstructure:"auth_ca_cert_path,omitempty" json:"auth_ca_cert_path,omitempty"` // optional PEM for model TLS (e.g. secret key ca_cert)
+	InsecureSkipVerify bool          `mapstructure:"insecure_skip_verify,omitempty" json:"insecure_skip_verify,omitempty"`
+	HTTPTimeout        time.Duration `mapstructure:"http_timeout,omitempty" json:"http_timeout,omitempty"`
+	TokenCacheTimeout  time.Duration `mapstructure:"token_cache_timeout,omitempty" json:"token_cache_timeout,omitempty"`
 }
 
 // SidecarOCIConfig holds sidecar OCI/registry proxy settings (host from configmap).

--- a/internal/eval_hub/runtimes/k8s/examples/eval-job.yaml
+++ b/internal/eval_hub/runtimes/k8s/examples/eval-job.yaml
@@ -35,7 +35,6 @@ spec:
         eval-hub.github.io/provider_id: "lm_evaluation_harness"
         eval-hub.github.io/benchmark_id: "mmlu"
     spec:
-      serviceAccountName: evalhub-default-job
       restartPolicy: Never
       initContainers:
         - name: sidecar

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -53,18 +53,27 @@ const (
 	envOCIAuthConfigPathName          = "OCI_AUTH_CONFIG_PATH"
 	modelAuthVolumeName               = "model-auth"
 	modelAuthMountPath                = "/var/run/secrets/model"
-	testDataSecretVolumeName          = "test-data-secret"
-	testDataSecretMountPath           = "/var/run/secrets/test-data"
-	serviceCABundleFile               = "service-ca.crt"
-	envMLFlowCertPathName             = "MLFLOW_TRACKING_SERVER_CERT_PATH"
-	envEvalHubModeName                = "EVALHUB_MODE"
-	envTestDataS3BucketName           = "TEST_DATA_S3_BUCKET"
-	envTestDataS3KeyName              = "TEST_DATA_S3_KEY"
-	defaultInitCPURequest             = "100m"
-	defaultInitCPULimit               = "500m"
-	defaultInitMemoryRequest          = "128Mi"
-	defaultInitMemoryLimit            = "512Mi"
-	defaultAllowPrivilegeEscalation   = false
+	sidecarSATokenVolumeName          = "sidecar-sa-token"
+	sidecarSATokenMountPath           = "/var/run/secrets/kubernetes.io/serviceaccount"
+	sidecarSATokenFile                = "token"
+	// modelAuthSecretAPIKeyFile and modelAuthSecretCACertFile are Kubernetes Secret data keys (filenames under modelAuthMountPath).
+	modelAuthSecretAPIKeyFile = "api-key"
+	modelAuthSecretCACertFile = "ca_cert"
+	testDataSecretVolumeName  = "test-data-secret"
+	testDataSecretMountPath   = "/var/run/secrets/test-data"
+	serviceCABundleFile       = "service-ca.crt"
+	envMLFlowCertPathName     = "MLFLOW_TRACKING_SERVER_CERT_PATH"
+	envEvalHubModeName        = "EVALHUB_MODE"
+	// POD_NAMESPACE is read by eval-hub-sdk (adapter callbacks) to set X-Tenant when
+	// AutomountServiceAccountToken is false (no /var/run/.../namespace file in the adapter).
+	envPodNamespaceName             = "POD_NAMESPACE"
+	envTestDataS3BucketName         = "TEST_DATA_S3_BUCKET"
+	envTestDataS3KeyName            = "TEST_DATA_S3_KEY"
+	defaultInitCPURequest           = "100m"
+	defaultInitCPULimit             = "500m"
+	defaultInitMemoryRequest        = "128Mi"
+	defaultInitMemoryLimit          = "512Mi"
+	defaultAllowPrivilegeEscalation = false
 	//defaultRunAsUser                = int64(1000)
 	//defaultRunAsGroup               = int64(1000)
 	labelAppKey       = "app"
@@ -253,8 +262,16 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 		TerminationMessagePath: config.SidecarTerminationFilePath,
 	})
 
-	// Set ServiceAccount if configured
-	// applied below in template spec
+	podSpec := corev1.PodSpec{
+		RestartPolicy:  corev1.RestartPolicyNever,
+		InitContainers: initContainers,
+		Containers:     containers,
+		Volumes:        jobVolumes,
+	}
+	if !cfg.localMode {
+		automount := false
+		podSpec.AutomountServiceAccountToken = &automount
+	}
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -271,13 +288,7 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 					Labels:      labels,
 					Annotations: annotations,
 				},
-				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyNever,
-					InitContainers:     initContainers,
-					Containers:         containers,
-					Volumes:            jobVolumes,
-					ServiceAccountName: cfg.serviceAccountName,
-				},
+				Spec: podSpec,
 			},
 		},
 	}, nil
@@ -374,23 +385,6 @@ func buildRuntimeContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 			Name:      ociCredentialsVolumeName,
 			MountPath: ociCredentialsMountPath,
 			SubPath:   ociCredentialsSubPath,
-			ReadOnly:  true,
-		})
-	}
-
-	// Add model auth secret when configured.
-	if cfg.modelAuthSecretRef != "" {
-		volumes = append(volumes, corev1.Volume{
-			Name: modelAuthVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: cfg.modelAuthSecretRef,
-				},
-			},
-		})
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      modelAuthVolumeName,
-			MountPath: modelAuthMountPath,
 			ReadOnly:  true,
 		})
 	}
@@ -504,6 +498,46 @@ func buildSidecarContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 			Name:      ociCredentialsVolumeName,
 			MountPath: ociCredentialsMountPath,
 			SubPath:   ociCredentialsSubPath,
+			ReadOnly:  true,
+		})
+	}
+
+	// Project a pod ServiceAccount token at the default path for eval-hub / model-proxy (adapter does not mount it).
+	expSeconds := int64(3600)
+	volumes = append(volumes, corev1.Volume{
+		Name: sidecarSATokenVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Path:              sidecarSATokenFile,
+							ExpirationSeconds: &expSeconds,
+						},
+					},
+				},
+			},
+		},
+	})
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      sidecarSATokenVolumeName,
+		MountPath: sidecarSATokenMountPath,
+		ReadOnly:  true,
+	})
+
+	// Mount model auth secret on the sidecar only (not on the adapter).
+	if cfg.modelAuthSecretRef != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name: modelAuthVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: cfg.modelAuthSecretRef,
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      modelAuthVolumeName,
+			MountPath: modelAuthMountPath,
 			ReadOnly:  true,
 		})
 	}
@@ -655,14 +689,29 @@ func buildEnvVars(cfg *jobConfig) []corev1.EnvVar {
 	var env []corev1.EnvVar
 	seen := map[string]bool{}
 
+	evalHubMode := "k8s"
+	if cfg.localMode {
+		evalHubMode = "local"
+	}
 	env = append(env, corev1.EnvVar{
 		Name:  envEvalHubModeName,
-		Value: "k8s",
+		Value: evalHubMode,
 	})
 	seen[envEvalHubModeName] = true
 
+	if strings.TrimSpace(cfg.namespace) != "" {
+		env = append(env, corev1.EnvVar{
+			Name:  envPodNamespaceName,
+			Value: cfg.namespace,
+		})
+		seen[envPodNamespaceName] = true
+	}
+
+	mlflowTrackingURI := cfg.mlflowTrackingURI
 	// When sidecar is at play, mlflow calls are proxied through the sidecar.
-	mlflowTrackingURI := cfg.sidecarBaseURL
+	if !cfg.localMode {
+		mlflowTrackingURI = cfg.sidecarBaseURL
+	}
 	// Add MLFlow environment variables if tracking is configured
 	if cfg.mlflowTrackingURI != "" {
 		env = append(env, corev1.EnvVar{

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -57,16 +57,13 @@ const (
 	sidecarSATokenMountPath           = "/var/run/secrets/kubernetes.io/serviceaccount"
 	sidecarSATokenFile                = "token"
 	// modelAuthSecretAPIKeyFile and modelAuthSecretCACertFile are Kubernetes Secret data keys (filenames under modelAuthMountPath).
-	modelAuthSecretAPIKeyFile = "api-key"
-	modelAuthSecretCACertFile = "ca_cert"
-	testDataSecretVolumeName  = "test-data-secret"
-	testDataSecretMountPath   = "/var/run/secrets/test-data"
-	serviceCABundleFile       = "service-ca.crt"
-	envMLFlowCertPathName     = "MLFLOW_TRACKING_SERVER_CERT_PATH"
-	envEvalHubModeName        = "EVALHUB_MODE"
-	// POD_NAMESPACE is read by eval-hub-sdk (adapter callbacks) to set X-Tenant when
-	// AutomountServiceAccountToken is false (no /var/run/.../namespace file in the adapter).
-	envPodNamespaceName             = "POD_NAMESPACE"
+	modelAuthSecretAPIKeyFile       = "api-key"
+	modelAuthSecretCACertFile       = "ca_cert"
+	testDataSecretVolumeName        = "test-data-secret"
+	testDataSecretMountPath         = "/var/run/secrets/test-data"
+	serviceCABundleFile             = "service-ca.crt"
+	envMLFlowCertPathName           = "MLFLOW_TRACKING_SERVER_CERT_PATH"
+	envEvalHubModeName              = "EVALHUB_MODE"
 	envTestDataS3BucketName         = "TEST_DATA_S3_BUCKET"
 	envTestDataS3KeyName            = "TEST_DATA_S3_KEY"
 	defaultInitCPURequest           = "100m"
@@ -268,10 +265,9 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 		Containers:     containers,
 		Volumes:        jobVolumes,
 	}
-	if !cfg.localMode {
-		automount := false
-		podSpec.AutomountServiceAccountToken = &automount
-	}
+	automount := false
+	podSpec.AutomountServiceAccountToken = &automount
+	podSpec.ServiceAccountName = cfg.serviceAccountName
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -684,7 +680,8 @@ func boolPtr(value bool) *bool {
 	return &value
 }
 
-// buildEnvVars builds environment variables for the adapter container.
+// buildEnvVars builds environment variables for a container. evalHubURLValue is the value for EVALHUB_URL
+// (adapter: cfg.evalHubURL in local mode, cfg.sidecarBaseURL otherwise; sidecar: always cfg.evalHubURL).
 func buildEnvVars(cfg *jobConfig) []corev1.EnvVar {
 	var env []corev1.EnvVar
 	seen := map[string]bool{}
@@ -698,14 +695,6 @@ func buildEnvVars(cfg *jobConfig) []corev1.EnvVar {
 		Value: evalHubMode,
 	})
 	seen[envEvalHubModeName] = true
-
-	if strings.TrimSpace(cfg.namespace) != "" {
-		env = append(env, corev1.EnvVar{
-			Name:  envPodNamespaceName,
-			Value: cfg.namespace,
-		})
-		seen[envPodNamespaceName] = true
-	}
 
 	mlflowTrackingURI := cfg.mlflowTrackingURI
 	// When sidecar is at play, mlflow calls are proxied through the sidecar.

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -56,14 +56,17 @@ const (
 	sidecarSATokenVolumeName          = "sidecar-sa-token"
 	sidecarSATokenMountPath           = "/var/run/secrets/kubernetes.io/serviceaccount"
 	sidecarSATokenFile                = "token"
-	// modelAuthSecretAPIKeyFile and modelAuthSecretCACertFile are Kubernetes Secret data keys (filenames under modelAuthMountPath).
+	// modelAuthSecretAPIKeyFile, modelAuthSecretCACertFile, and modelAuthSecretHFTokenFile are Kubernetes Secret
+	// data keys (filenames under modelAuthMountPath). hf-token is used for Hugging Face Hub gated assets (see lm-evaluation-harness).
 	modelAuthSecretAPIKeyFile       = "api-key"
 	modelAuthSecretCACertFile       = "ca_cert"
+	modelAuthSecretHFTokenFile      = "hf-token"
 	testDataSecretVolumeName        = "test-data-secret"
 	testDataSecretMountPath         = "/var/run/secrets/test-data"
 	serviceCABundleFile             = "service-ca.crt"
 	envMLFlowCertPathName           = "MLFLOW_TRACKING_SERVER_CERT_PATH"
-	envEvalHubModeName              = "EVALHUB_MODE"
+	envHFEndpointName  = "HF_ENDPOINT" // huggingface_hub Hub API base; adapter targets eval-runtime-sidecar /huggingface
+	envEvalHubModeName = "EVALHUB_MODE"
 	envTestDataS3BucketName         = "TEST_DATA_S3_BUCKET"
 	envTestDataS3KeyName            = "TEST_DATA_S3_KEY"
 	defaultInitCPURequest           = "100m"
@@ -695,6 +698,19 @@ func buildEnvVars(cfg *jobConfig) []corev1.EnvVar {
 		Value: evalHubMode,
 	})
 	seen[envEvalHubModeName] = true
+
+	// Hugging Face Hub traffic (tokenizers, datasets) via eval-runtime-sidecar /huggingface proxy.
+	// Uses cfg.sidecarBaseURL — same origin as the /model proxy — not model.url (job spec field).
+	if !cfg.localMode {
+		base := strings.TrimSuffix(strings.TrimSpace(cfg.sidecarBaseURL), "/")
+		if base != "" {
+			env = append(env, corev1.EnvVar{
+				Name:  envHFEndpointName,
+				Value: base + "/huggingface",
+			})
+			seen[envHFEndpointName] = true
+		}
+	}
 
 	mlflowTrackingURI := cfg.mlflowTrackingURI
 	// When sidecar is at play, mlflow calls are proxied through the sidecar.

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -204,6 +204,65 @@ func TestBuildJobAdapterEvalHubModeEnv(t *testing.T) {
 			t.Fatalf("expected empty ServiceAccountName when cfg.serviceAccountName is unset, got %q", job.Spec.Template.Spec.ServiceAccountName)
 		}
 	})
+	t.Run("k8s sets HF_ENDPOINT to sidecar huggingface proxy from sidecarBaseURL", func(t *testing.T) {
+		cfg := &jobConfig{
+			jobID:          "job-hf",
+			resourceGUID:   "guid-hf",
+			benchmarkIndex: 0,
+			namespace:      "default",
+			providerID:     "provider-1",
+			benchmarkID:    "bench-1",
+			adapterImage:   "adapter:latest",
+			defaultEnv:     []api.EnvVar{},
+			sidecarBaseURL: "http://127.0.0.1:8080",
+			localMode:      false,
+		}
+		job, err := buildJob(cfg)
+		if err != nil {
+			t.Fatalf("buildJob: %v", err)
+		}
+		adapter := job.Spec.Template.Spec.Containers[0]
+		var got string
+		var found bool
+		for _, e := range adapter.Env {
+			if e.Name == envHFEndpointName {
+				found = true
+				got = e.Value
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("adapter missing env %q", envHFEndpointName)
+		}
+		want := "http://127.0.0.1:8080/huggingface"
+		if got != want {
+			t.Fatalf("HF_ENDPOINT = %q, want %q", got, want)
+		}
+	})
+	t.Run("local mode does not set HF_ENDPOINT", func(t *testing.T) {
+		cfg := &jobConfig{
+			jobID:          "job-hf-local",
+			resourceGUID:   "guid-hf-l",
+			benchmarkIndex: 0,
+			namespace:      "default",
+			providerID:     "provider-1",
+			benchmarkID:    "bench-1",
+			adapterImage:   "adapter:latest",
+			defaultEnv:     []api.EnvVar{},
+			sidecarBaseURL: "http://127.0.0.1:8080",
+			localMode:      true,
+		}
+		job, err := buildJob(cfg)
+		if err != nil {
+			t.Fatalf("buildJob: %v", err)
+		}
+		adapter := job.Spec.Template.Spec.Containers[0]
+		for _, e := range adapter.Env {
+			if e.Name == envHFEndpointName {
+				t.Fatalf("did not want HF_ENDPOINT in local mode, got %q", e.Value)
+			}
+		}
+	})
 	t.Run("k8s sets ServiceAccountName when configured", func(t *testing.T) {
 		cfg := &jobConfig{
 			jobID:              "job-sa",

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -200,20 +200,29 @@ func TestBuildJobAdapterEvalHubModeEnv(t *testing.T) {
 		if got != "k8s" {
 			t.Fatalf("EVALHUB_MODE = %q, want k8s", got)
 		}
-		var podNS string
-		var podNSFound bool
-		for _, e := range adapter.Env {
-			if e.Name == envPodNamespaceName {
-				podNSFound = true
-				podNS = e.Value
-				break
-			}
+		if job.Spec.Template.Spec.ServiceAccountName != "" {
+			t.Fatalf("expected empty ServiceAccountName when cfg.serviceAccountName is unset, got %q", job.Spec.Template.Spec.ServiceAccountName)
 		}
-		if !podNSFound {
-			t.Fatalf("adapter missing env %q (needed for X-Tenant when SA token is not automounted)", envPodNamespaceName)
+	})
+	t.Run("k8s sets ServiceAccountName when configured", func(t *testing.T) {
+		cfg := &jobConfig{
+			jobID:              "job-sa",
+			resourceGUID:       "guid-sa",
+			benchmarkIndex:     0,
+			namespace:          "tenant-ns",
+			providerID:         "provider-1",
+			benchmarkID:        "bench-1",
+			adapterImage:       "adapter:latest",
+			defaultEnv:         []api.EnvVar{},
+			localMode:          false,
+			serviceAccountName: "evalhub-inst-instns-job",
 		}
-		if podNS != "default" {
-			t.Fatalf("%s = %q, want default", envPodNamespaceName, podNS)
+		job, err := buildJob(cfg)
+		if err != nil {
+			t.Fatalf("buildJob: %v", err)
+		}
+		if job.Spec.Template.Spec.ServiceAccountName != "evalhub-inst-instns-job" {
+			t.Fatalf("ServiceAccountName = %q, want evalhub-inst-instns-job", job.Spec.Template.Spec.ServiceAccountName)
 		}
 	})
 	t.Run("local when local mode", func(t *testing.T) {
@@ -250,21 +259,6 @@ func TestBuildJobAdapterEvalHubModeEnv(t *testing.T) {
 		}
 		if got != "local" {
 			t.Fatalf("EVALHUB_MODE = %q, want local", got)
-		}
-		var podNS string
-		var podNSFound bool
-		for _, e := range adapter.Env {
-			if e.Name == envPodNamespaceName {
-				podNSFound = true
-				podNS = e.Value
-				break
-			}
-		}
-		if !podNSFound {
-			t.Fatalf("adapter missing env %q", envPodNamespaceName)
-		}
-		if podNS != "default" {
-			t.Fatalf("%s = %q, want default", envPodNamespaceName, podNS)
 		}
 	})
 }

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -169,36 +169,104 @@ func TestBuildJobRequiresAdapterImage(t *testing.T) {
 }
 
 func TestBuildJobAdapterEvalHubModeEnv(t *testing.T) {
-	cfg := &jobConfig{
-		jobID:          "job-mode",
-		resourceGUID:   "guid-mode",
-		benchmarkIndex: 0,
-		namespace:      "default",
-		providerID:     "provider-1",
-		benchmarkID:    "bench-1",
-		adapterImage:   "adapter:latest",
-		defaultEnv:     []api.EnvVar{},
-	}
-	job, err := buildJob(cfg)
-	if err != nil {
-		t.Fatalf("buildJob: %v", err)
-	}
-	adapter := job.Spec.Template.Spec.Containers[0]
-	var got string
-	var found bool
-	for _, e := range adapter.Env {
-		if e.Name == envEvalHubModeName {
-			found = true
-			got = e.Value
-			break
+	t.Run("k8s when not local mode", func(t *testing.T) {
+		cfg := &jobConfig{
+			jobID:          "job-mode",
+			resourceGUID:   "guid-mode",
+			benchmarkIndex: 0,
+			namespace:      "default",
+			providerID:     "provider-1",
+			benchmarkID:    "bench-1",
+			adapterImage:   "adapter:latest",
+			defaultEnv:     []api.EnvVar{},
 		}
-	}
-	if !found {
-		t.Fatalf("adapter missing env %q", envEvalHubModeName)
-	}
-	if got != "k8s" {
-		t.Fatalf("EVALHUB_MODE = %q, want k8s", got)
-	}
+		job, err := buildJob(cfg)
+		if err != nil {
+			t.Fatalf("buildJob: %v", err)
+		}
+		adapter := job.Spec.Template.Spec.Containers[0]
+		var got string
+		var found bool
+		for _, e := range adapter.Env {
+			if e.Name == envEvalHubModeName {
+				found = true
+				got = e.Value
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("adapter missing env %q", envEvalHubModeName)
+		}
+		if got != "k8s" {
+			t.Fatalf("EVALHUB_MODE = %q, want k8s", got)
+		}
+		var podNS string
+		var podNSFound bool
+		for _, e := range adapter.Env {
+			if e.Name == envPodNamespaceName {
+				podNSFound = true
+				podNS = e.Value
+				break
+			}
+		}
+		if !podNSFound {
+			t.Fatalf("adapter missing env %q (needed for X-Tenant when SA token is not automounted)", envPodNamespaceName)
+		}
+		if podNS != "default" {
+			t.Fatalf("%s = %q, want default", envPodNamespaceName, podNS)
+		}
+	})
+	t.Run("local when local mode", func(t *testing.T) {
+		cfg := &jobConfig{
+			jobID:          "job-mode-local",
+			resourceGUID:   "guid-mode-l",
+			benchmarkIndex: 0,
+			namespace:      "default",
+			providerID:     "provider-1",
+			benchmarkID:    "bench-1",
+			adapterImage:   "adapter:latest",
+			defaultEnv:     []api.EnvVar{},
+			localMode:      true,
+		}
+		job, err := buildJob(cfg)
+		if err != nil {
+			t.Fatalf("buildJob: %v", err)
+		}
+		if len(job.Spec.Template.Spec.Containers) != 1 {
+			t.Fatalf("expected single adapter container in local mode, got %d", len(job.Spec.Template.Spec.Containers))
+		}
+		adapter := job.Spec.Template.Spec.Containers[0]
+		var got string
+		var found bool
+		for _, e := range adapter.Env {
+			if e.Name == envEvalHubModeName {
+				found = true
+				got = e.Value
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("adapter missing env %q", envEvalHubModeName)
+		}
+		if got != "local" {
+			t.Fatalf("EVALHUB_MODE = %q, want local", got)
+		}
+		var podNS string
+		var podNSFound bool
+		for _, e := range adapter.Env {
+			if e.Name == envPodNamespaceName {
+				podNSFound = true
+				podNS = e.Value
+				break
+			}
+		}
+		if !podNSFound {
+			t.Fatalf("adapter missing env %q", envPodNamespaceName)
+		}
+		if podNS != "default" {
+			t.Fatalf("%s = %q, want default", envPodNamespaceName, podNS)
+		}
+	})
 }
 
 func TestBuildJobSecurityContext(t *testing.T) {
@@ -396,6 +464,11 @@ func TestBuildJobTerminationFileVolume(t *testing.T) {
 	}
 	if !adapterMount {
 		t.Fatalf("adapter should mount %q at %q", terminationFileVolumeName, adapterTerminationSharedMountPath)
+	}
+	for _, m := range adapter.VolumeMounts {
+		if m.MountPath == sidecarConfigMountPath {
+			t.Fatalf("adapter must not mount sidecar config at %q (model proxy base comes from job.json callback_url)", sidecarConfigMountPath)
+		}
 	}
 	sidecar := findContainer(job.Spec.Template.Spec.InitContainers, sidecarContainerName)
 	if sidecar == nil {
@@ -625,20 +698,44 @@ func TestBuildJobWithModelAuthSecret(t *testing.T) {
 	}
 
 	container := job.Spec.Template.Spec.Containers[0]
-	var foundMount bool
 	for _, m := range container.VolumeMounts {
 		if m.Name == modelAuthVolumeName {
-			foundMount = true
-			if m.MountPath != modelAuthMountPath {
-				t.Fatalf("expected mount path %q, got %q", modelAuthMountPath, m.MountPath)
-			}
-			if !m.ReadOnly {
-				t.Fatalf("expected mount to be read-only")
+			t.Fatalf("adapter must not mount %s (sidecar-only)", modelAuthVolumeName)
+		}
+	}
+
+	if job.Spec.Template.Spec.AutomountServiceAccountToken == nil || *job.Spec.Template.Spec.AutomountServiceAccountToken {
+		t.Fatalf("expected AutomountServiceAccountToken false on adapter+sidecar jobs")
+	}
+
+	sidecar := findContainer(job.Spec.Template.Spec.InitContainers, sidecarContainerName)
+	if sidecar == nil {
+		t.Fatalf("expected sidecar init container %q", sidecarContainerName)
+	}
+	var sidecarModelMount bool
+	for _, m := range sidecar.VolumeMounts {
+		if m.Name == modelAuthVolumeName {
+			sidecarModelMount = true
+			if m.MountPath != modelAuthMountPath || !m.ReadOnly {
+				t.Fatalf("sidecar: expected read-only model auth mount at %q", modelAuthMountPath)
 			}
 		}
 	}
-	if !foundMount {
-		t.Fatalf("expected volume mount %s to be present", modelAuthVolumeName)
+	if !sidecarModelMount {
+		t.Fatalf("expected sidecar to mount volume %s for model proxy auth", modelAuthVolumeName)
+	}
+
+	var sidecarSATokenMount bool
+	for _, m := range sidecar.VolumeMounts {
+		if m.Name == sidecarSATokenVolumeName {
+			sidecarSATokenMount = true
+			if m.MountPath != sidecarSATokenMountPath || !m.ReadOnly {
+				t.Fatalf("sidecar: expected read-only SA token mount at %q", sidecarSATokenMountPath)
+			}
+		}
+	}
+	if !sidecarSATokenMount {
+		t.Fatalf("expected sidecar to mount %s for eval-hub / model SA token fallback", sidecarSATokenVolumeName)
 	}
 
 	for _, e := range container.Env {

--- a/internal/eval_hub/runtimes/k8s/job_config.go
+++ b/internal/eval_hub/runtimes/k8s/job_config.go
@@ -170,8 +170,6 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 	}
 
 	localMode := serviceConfig != nil && serviceConfig.Service != nil && serviceConfig.Service.LocalMode
-	// job.json model.url points at the sidecar /model path; the real upstream is still
-	// upstreamModelURL and is passed to sidecarForJobPod (not stored on jobConfig).
 	if upstreamModelURL != "" {
 		spec.Model.URL = sidecarModelProxyURL(sidecarBaseURL, upstreamModelURL)
 		spec.Model.Auth = nil

--- a/internal/eval_hub/runtimes/k8s/job_config.go
+++ b/internal/eval_hub/runtimes/k8s/job_config.go
@@ -3,6 +3,7 @@ package k8s
 // Contains the configuration logic that prepares the data needed by the builders
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -68,6 +69,8 @@ type jobConfig struct {
 	// queueKind and queueName come from evaluation.Queue when set (API layer normalizes empty kind to kueue).
 	queueKind string
 	queueName string
+	// localMode is true when the service is configured for local execution (see config.Service.LocalMode).
+	localMode bool
 }
 
 type s3TestDataConfig struct {
@@ -93,6 +96,7 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 	if evaluation.Model.URL == "" || evaluation.Model.Name == "" {
 		return nil, fmt.Errorf("model url and name are required")
 	}
+	upstreamModelURL := strings.TrimSpace(evaluation.Model.URL)
 
 	port := defaultSidecarPort
 	sidecarBaseURL := ""
@@ -165,6 +169,14 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 		return nil, err
 	}
 
+	localMode := serviceConfig != nil && serviceConfig.Service != nil && serviceConfig.Service.LocalMode
+	// job.json model.url points at the sidecar /model path; the real upstream is still
+	// upstreamModelURL and is passed to sidecarForJobPod (not stored on jobConfig).
+	if upstreamModelURL != "" {
+		spec.Model.URL = sidecarModelProxyURL(sidecarBaseURL, upstreamModelURL)
+		spec.Model.Auth = nil
+	}
+
 	var testDataS3Bucket, testDataS3Key, testDataS3SecretRef string
 	if benchmarkConfig.TestDataRef != nil && benchmarkConfig.TestDataRef.S3 != nil {
 		testDataS3Bucket = strings.TrimSpace(benchmarkConfig.TestDataRef.S3.Bucket)
@@ -207,13 +219,14 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 		evalHubURL:           evalHubURL,
 		queueKind:            queueKind,
 		queueName:            queueName,
+		localMode:            localMode,
 		testDataS3: s3TestDataConfig{
 			bucket:    testDataS3Bucket,
 			key:       testDataS3Key,
 			secretRef: testDataS3SecretRef,
 		},
 	}
-	sidecarJSON, err := sidecarForJobPod(serviceConfig, out)
+	sidecarJSON, err := sidecarForJobPod(serviceConfig, out, upstreamModelURL)
 	if err != nil {
 		return nil, fmt.Errorf("sidecar config json: %w", err)
 	}
@@ -330,4 +343,20 @@ func readInClusterNamespace() string {
 		return ""
 	}
 	return strings.TrimSpace(string(content))
+}
+
+// sidecarModelProxyURL is the model base URL written to job.json for in-cluster runs: the adapter
+// talks to the sidecar, which forwards to the upstream from sidecar_config.json model.url.
+// Format: {sidecarBase}/model{path} where path comes from the evaluation URL (e.g. /v1), defaulting to /v1.
+func sidecarModelProxyURL(sidecarBase, upstreamModelURL string) string {
+	base := strings.TrimRight(strings.TrimSpace(sidecarBase), "/")
+	u, err := url.Parse(strings.TrimSpace(upstreamModelURL))
+	if err != nil {
+		return base + "/model/v1"
+	}
+	path := u.Path
+	if path == "" || path == "/" {
+		path = "/v1"
+	}
+	return base + "/model" + path
 }

--- a/internal/eval_hub/runtimes/k8s/job_config_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_config_test.go
@@ -97,6 +97,12 @@ func TestBuildJobConfigDefaults(t *testing.T) {
 	if callback == nil || *callback != callbackURL {
 		t.Fatalf("expected job spec json callback_url to be %q, got %v", callbackURL, callback)
 	}
+	if spec.Model.URL != "http://localhost:8080/model/v1" {
+		t.Fatalf("expected job spec model url to be sidecar proxy base, got %q", spec.Model.URL)
+	}
+	if cfg.sidecarConfig == nil || cfg.sidecarConfig.Model == nil || cfg.sidecarConfig.Model.URL != "http://model" {
+		t.Fatalf("expected sidecar_config model.url to be evaluation upstream, got %+v", cfg.sidecarConfig)
+	}
 }
 
 func TestBuildJobConfigModelAuthSecretRefPresent(t *testing.T) {
@@ -134,6 +140,12 @@ func TestBuildJobConfigModelAuthSecretRefPresent(t *testing.T) {
 	}
 	if cfg.modelAuthSecretRef != "my-secret" {
 		t.Fatalf("expected modelAuthSecretRef %q, got %q", "my-secret", cfg.modelAuthSecretRef)
+	}
+	if cfg.jobSpec.Model.Auth != nil {
+		t.Fatalf("expected auth omitted from job spec (handled by sidecar), got %+v", cfg.jobSpec.Model.Auth)
+	}
+	if cfg.sidecarConfig == nil || cfg.sidecarConfig.Model == nil || cfg.sidecarConfig.Model.AuthAPIKeyPath == "" {
+		t.Fatalf("expected sidecar model auth mount path when secret_ref set, got %+v", cfg.sidecarConfig)
 	}
 }
 
@@ -711,4 +723,22 @@ func TestBuildJobConfigBenchmarkIndexPropagated(t *testing.T) {
 
 func intPtr(value int) *int {
 	return &value
+}
+
+func TestSidecarModelProxyURL(t *testing.T) {
+	tests := []struct {
+		sidecarBase string
+		upstream    string
+		want        string
+	}{
+		{"http://localhost:8080", "https://vllm.example.com/v1", "http://localhost:8080/model/v1"},
+		{"http://localhost:8080", "http://model", "http://localhost:8080/model/v1"},
+		{"http://127.0.0.1:9090", "https://host/path/v1", "http://127.0.0.1:9090/model/path/v1"},
+	}
+	for _, tt := range tests {
+		got := sidecarModelProxyURL(tt.sidecarBase, tt.upstream)
+		if got != tt.want {
+			t.Errorf("sidecarModelProxyURL(%q, %q) = %q, want %q", tt.sidecarBase, tt.upstream, got, tt.want)
+		}
+	}
 }

--- a/internal/eval_hub/runtimes/k8s/job_config_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_config_test.go
@@ -540,6 +540,9 @@ func TestBuildJobConfigUsesTenantNamespace(t *testing.T) {
 	if cfg.namespace != "team-a" {
 		t.Fatalf("expected namespace %q, got %q", "team-a", cfg.namespace)
 	}
+	if cfg.jobSpec.Tenant != "team-a" {
+		t.Fatalf("expected job spec tenant %q, got %q", "team-a", cfg.jobSpec.Tenant)
+	}
 }
 
 func TestBuildJobConfigEmptyTenantFallsBack(t *testing.T) {

--- a/internal/eval_hub/runtimes/k8s/job_config_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_config_test.go
@@ -103,6 +103,12 @@ func TestBuildJobConfigDefaults(t *testing.T) {
 	if cfg.sidecarConfig == nil || cfg.sidecarConfig.Model == nil || cfg.sidecarConfig.Model.URL != "http://model" {
 		t.Fatalf("expected sidecar_config model.url to be evaluation upstream, got %+v", cfg.sidecarConfig)
 	}
+	if cfg.sidecarConfig.HuggingFace == nil || cfg.sidecarConfig.HuggingFace.URL != "https://huggingface.co" {
+		t.Fatalf("expected sidecar huggingface default url, got %+v", cfg.sidecarConfig.HuggingFace)
+	}
+	if cfg.sidecarConfig.HuggingFace.TokenPath != "" {
+		t.Fatalf("expected no huggingface token_path without model auth secret, got %q", cfg.sidecarConfig.HuggingFace.TokenPath)
+	}
 }
 
 func TestBuildJobConfigModelAuthSecretRefPresent(t *testing.T) {
@@ -146,6 +152,13 @@ func TestBuildJobConfigModelAuthSecretRefPresent(t *testing.T) {
 	}
 	if cfg.sidecarConfig == nil || cfg.sidecarConfig.Model == nil || cfg.sidecarConfig.Model.AuthAPIKeyPath == "" {
 		t.Fatalf("expected sidecar model auth mount path when secret_ref set, got %+v", cfg.sidecarConfig)
+	}
+	if cfg.sidecarConfig.HuggingFace == nil || cfg.sidecarConfig.HuggingFace.URL != "https://huggingface.co" {
+		t.Fatalf("expected sidecar huggingface default url, got %+v", cfg.sidecarConfig.HuggingFace)
+	}
+	wantHFToken := modelAuthMountPath + "/" + modelAuthSecretHFTokenFile
+	if cfg.sidecarConfig.HuggingFace.TokenPath != wantHFToken {
+		t.Fatalf("expected sidecar huggingface token_path %q, got %q", wantHFToken, cfg.sidecarConfig.HuggingFace.TokenPath)
 	}
 }
 

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_test.go
@@ -430,11 +430,12 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnvIntegration(t *testing
 		t.Fatalf("expected 1 job, got %d", len(jobs.Items))
 	}
 	job := jobs.Items[0]
-	adapter := job.Spec.Template.Spec.Containers[0]
-	if len(job.Spec.Template.Spec.Containers) < 2 {
+	containers := job.Spec.Template.Spec.Containers
+	if len(containers) < 2 {
 		t.Fatalf("expected adapter and sidecar containers")
 	}
-	sidecar := job.Spec.Template.Spec.Containers[1]
+	adapter := containers[0]
+	sidecar := containers[1]
 
 	for _, mount := range adapter.VolumeMounts {
 		if mount.Name == modelAuthVolumeName {

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_test.go
@@ -430,7 +430,17 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnvIntegration(t *testing
 		t.Fatalf("expected 1 job, got %d", len(jobs.Items))
 	}
 	job := jobs.Items[0]
-	container := job.Spec.Template.Spec.Containers[0]
+	adapter := job.Spec.Template.Spec.Containers[0]
+	if len(job.Spec.Template.Spec.Containers) < 2 {
+		t.Fatalf("expected adapter and sidecar containers")
+	}
+	sidecar := job.Spec.Template.Spec.Containers[1]
+
+	for _, mount := range adapter.VolumeMounts {
+		if mount.Name == modelAuthVolumeName {
+			t.Fatalf("adapter must not mount model auth secret (sidecar-only)")
+		}
+	}
 
 	var foundVolume bool
 	for _, volume := range job.Spec.Template.Spec.Volumes {
@@ -446,7 +456,7 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnvIntegration(t *testing
 	}
 
 	var foundMount bool
-	for _, mount := range container.VolumeMounts {
+	for _, mount := range sidecar.VolumeMounts {
 		if mount.Name == modelAuthVolumeName {
 			foundMount = true
 			if mount.MountPath != modelAuthMountPath {
@@ -455,7 +465,7 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnvIntegration(t *testing
 		}
 	}
 	if !foundMount {
-		t.Fatalf("expected volume mount %s to be present", modelAuthVolumeName)
+		t.Fatalf("expected sidecar volume mount %s to be present", modelAuthVolumeName)
 	}
 
 }

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
 	"github.com/eval-hub/eval-hub/pkg/api"
-	corev1 "k8s.io/api/core/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -307,16 +306,8 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
 	if len(job.Spec.Template.Spec.Containers) != 1 {
 		t.Fatalf("expected single adapter container, got %d", len(job.Spec.Template.Spec.Containers))
 	}
-	var sidecar corev1.Container
-	var foundSidecar bool
-	for _, c := range job.Spec.Template.Spec.InitContainers {
-		if c.Name == sidecarContainerName {
-			sidecar = c
-			foundSidecar = true
-			break
-		}
-	}
-	if !foundSidecar {
+	sidecar := findContainer(job.Spec.Template.Spec.InitContainers, sidecarContainerName)
+	if sidecar == nil {
 		t.Fatalf("expected sidecar init container %q", sidecarContainerName)
 	}
 

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
 	"github.com/eval-hub/eval-hub/pkg/api"
+	corev1 "k8s.io/api/core/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -302,7 +303,28 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
 		t.Fatalf("expected 1 job, got %d", len(jobs))
 	}
 	job := jobs[0]
-	container := job.Spec.Template.Spec.Containers[0]
+	adapter := job.Spec.Template.Spec.Containers[0]
+	if len(job.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf("expected single adapter container, got %d", len(job.Spec.Template.Spec.Containers))
+	}
+	var sidecar corev1.Container
+	var foundSidecar bool
+	for _, c := range job.Spec.Template.Spec.InitContainers {
+		if c.Name == sidecarContainerName {
+			sidecar = c
+			foundSidecar = true
+			break
+		}
+	}
+	if !foundSidecar {
+		t.Fatalf("expected sidecar init container %q", sidecarContainerName)
+	}
+
+	for _, mount := range adapter.VolumeMounts {
+		if mount.Name == modelAuthVolumeName {
+			t.Fatalf("adapter must not mount model auth secret (sidecar-only)")
+		}
+	}
 
 	var foundVolume bool
 	for _, volume := range job.Spec.Template.Spec.Volumes {
@@ -318,7 +340,7 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
 	}
 
 	var foundMount bool
-	for _, mount := range container.VolumeMounts {
+	for _, mount := range sidecar.VolumeMounts {
 		if mount.Name == modelAuthVolumeName {
 			foundMount = true
 			if mount.MountPath != modelAuthMountPath {
@@ -327,11 +349,11 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
 		}
 	}
 	if !foundMount {
-		t.Fatalf("expected volume mount %s to be present", modelAuthVolumeName)
+		t.Fatalf("expected sidecar volume mount %s to be present", modelAuthVolumeName)
 	}
 
-	envKeys := make(map[string]struct{}, len(container.Env))
-	for _, env := range container.Env {
+	envKeys := make(map[string]struct{}, len(adapter.Env))
+	for _, env := range adapter.Env {
 		envKeys[env.Name] = struct{}{}
 	}
 	legacyModelAuthKeys := []string{

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
@@ -66,6 +66,19 @@ func sidecarForJobPod(cfg *config.Config, jc *jobConfig, evaluationModelURL stri
 				export.Model.AuthCACertPath = modelAuthMountPath + "/" + modelAuthSecretCACertFile
 			}
 		}
+
+		// Hugging Face Hub proxy: default public Hub URL; optional hf-token from model.auth.secret_ref (gated assets).
+		if strings.TrimSpace(evaluationModelURL) != "" || jc.modelAuthSecretRef != "" {
+			if export.HuggingFace == nil {
+				export.HuggingFace = &config.SidecarHuggingFaceConfig{}
+			}
+			if strings.TrimSpace(export.HuggingFace.URL) == "" {
+				export.HuggingFace.URL = "https://huggingface.co"
+			}
+			if jc.modelAuthSecretRef != "" {
+				export.HuggingFace.TokenPath = modelAuthMountPath + "/" + modelAuthSecretHFTokenFile
+			}
+		}
 	}
 
 	return export, nil
@@ -87,6 +100,10 @@ func cloneSidecarConfig(sc *config.SidecarConfig) *config.SidecarConfig {
 	if sc.Model != nil {
 		md := *sc.Model
 		out.Model = &md
+	}
+	if sc.HuggingFace != nil {
+		hf := *sc.HuggingFace
+		out.HuggingFace = &hf
 	}
 	if sc.OCI != nil {
 		oci := *sc.OCI

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
@@ -65,9 +65,6 @@ func sidecarForJobPod(cfg *config.Config, jc *jobConfig, evaluationModelURL stri
 				export.Model.AuthAPIKeyPath = modelAuthMountPath + "/" + modelAuthSecretAPIKeyFile
 				export.Model.AuthCACertPath = modelAuthMountPath + "/" + modelAuthSecretCACertFile
 			}
-			if cfg != nil && cfg.MLFlow != nil && cfg.MLFlow.HTTPTimeout > 0 {
-				export.Model.HTTPTimeout = cfg.MLFlow.HTTPTimeout
-			}
 		}
 	}
 

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
@@ -1,13 +1,17 @@
 package k8s
 
 import (
+	"strings"
+
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 )
 
 // sidecarForJobPod builds sidecar_config.json for the job ConfigMap from server
 // sidecar YAML plus per-job fields. Omits sidecar_container (image/resources); that is only for job spec.
-func sidecarForJobPod(cfg *config.Config, jc *jobConfig) (*config.SidecarConfig, error) {
-	if cfg != nil && cfg.Sidecar == nil && jc != nil && jc.evalHubURL == "" && jc.mlflowTrackingURI == "" {
+// evaluationModelURL is the model endpoint from the evaluation request (upstream for the sidecar proxy).
+// jobSpec.Model.URL may be rewritten to the in-pod /model path for adapters; it is not used here.
+func sidecarForJobPod(cfg *config.Config, jc *jobConfig, evaluationModelURL string) (*config.SidecarConfig, error) {
+	if cfg != nil && cfg.Sidecar == nil && jc != nil && jc.evalHubURL == "" && jc.mlflowTrackingURI == "" && strings.TrimSpace(evaluationModelURL) == "" {
 		return nil, nil
 	}
 
@@ -51,6 +55,20 @@ func sidecarForJobPod(cfg *config.Config, jc *jobConfig) (*config.SidecarConfig,
 				export.MLFlow.CACertPath = serviceCAMountPath + "/" + serviceCABundleFile
 			}
 		}
+
+		if strings.TrimSpace(evaluationModelURL) != "" {
+			if export.Model == nil {
+				export.Model = &config.SidecarModelConfig{}
+			}
+			export.Model.URL = strings.TrimSpace(evaluationModelURL)
+			if jc.modelAuthSecretRef != "" {
+				export.Model.AuthAPIKeyPath = modelAuthMountPath + "/" + modelAuthSecretAPIKeyFile
+				export.Model.AuthCACertPath = modelAuthMountPath + "/" + modelAuthSecretCACertFile
+			}
+			if cfg != nil && cfg.MLFlow != nil && cfg.MLFlow.HTTPTimeout > 0 {
+				export.Model.HTTPTimeout = cfg.MLFlow.HTTPTimeout
+			}
+		}
 	}
 
 	return export, nil
@@ -68,6 +86,10 @@ func cloneSidecarConfig(sc *config.SidecarConfig) *config.SidecarConfig {
 	if sc.MLFlow != nil {
 		mf := *sc.MLFlow
 		out.MLFlow = &mf
+	}
+	if sc.Model != nil {
+		md := *sc.Model
+		out.Model = &md
 	}
 	if sc.OCI != nil {
 		oci := *sc.OCI

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json_test.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json_test.go
@@ -1,0 +1,57 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+)
+
+func TestSidecarForJobPodModelHTTPTimeoutPreservesSidecarModel(t *testing.T) {
+	modelTimeout := 7 * time.Minute
+	mlflowTimeout := 2 * time.Minute
+
+	cfg := &config.Config{
+		MLFlow: &config.MLFlowConfig{HTTPTimeout: mlflowTimeout},
+		Sidecar: &config.SidecarConfig{
+			Model: &config.SidecarModelConfig{
+				HTTPTimeout: modelTimeout,
+			},
+		},
+	}
+	jc := &jobConfig{}
+
+	out, err := sidecarForJobPod(cfg, jc, "http://upstream/v1")
+	if err != nil {
+		t.Fatalf("sidecarForJobPod: %v", err)
+	}
+	if out == nil || out.Model == nil {
+		t.Fatalf("expected non-nil export.Model")
+	}
+	if out.Model.HTTPTimeout != modelTimeout {
+		t.Fatalf("expected sidecar model http_timeout %v to be preserved, got %v", modelTimeout, out.Model.HTTPTimeout)
+	}
+}
+
+func TestSidecarForJobPodModelHTTPTimeoutDoesNotCopyMLFlow(t *testing.T) {
+	mlflowTimeout := 3 * time.Minute
+
+	cfg := &config.Config{
+		MLFlow: &config.MLFlowConfig{HTTPTimeout: mlflowTimeout},
+		Sidecar: &config.SidecarConfig{
+			Model: &config.SidecarModelConfig{},
+		},
+	}
+	jc := &jobConfig{}
+
+	out, err := sidecarForJobPod(cfg, jc, "http://upstream/v1")
+	if err != nil {
+		t.Fatalf("sidecarForJobPod: %v", err)
+	}
+	if out == nil || out.Model == nil {
+		t.Fatalf("expected non-nil export.Model")
+	}
+	if out.Model.HTTPTimeout != 0 {
+		t.Fatalf("expected model http_timeout unset (0) so sidecar uses default; mlflow timeout must not apply, got %v", out.Model.HTTPTimeout)
+	}
+}

--- a/internal/eval_hub/runtimes/shared/jobspec.go
+++ b/internal/eval_hub/runtimes/shared/jobspec.go
@@ -8,10 +8,12 @@ import (
 
 // JobSpec is the JSON structure written to job.json for benchmark adapters to consume.
 type JobSpec struct {
-	JobID          string              `json:"id"`
-	ProviderID     string              `json:"provider_id"`
-	BenchmarkID    string              `json:"benchmark_id"`
-	BenchmarkIndex int                 `json:"benchmark_index"`
+	JobID          string `json:"id"`
+	ProviderID     string `json:"provider_id"`
+	BenchmarkID    string `json:"benchmark_id"`
+	BenchmarkIndex int    `json:"benchmark_index"`
+	// Tenant is the API evaluation tenant (X-Tenant scope); adapters/SDKs should prefer this over inferring from the pod namespace.
+	Tenant         string              `json:"tenant,omitempty"`
 	Model          api.ModelRef        `json:"model"`
 	NumExamples    *int                `json:"num_examples,omitempty"`
 	Parameters     map[string]any      `json:"parameters"`
@@ -55,6 +57,9 @@ func BuildJobSpec(
 		NumExamples:    numExamples,
 		Parameters:     benchmarkParams,
 		CallbackURL:    callbackURL,
+	}
+	if !evaluation.Resource.Tenant.IsEmpty() {
+		spec.Tenant = evaluation.Resource.Tenant.String()
 	}
 	if evaluation.Experiment != nil {
 		spec.ExperimentName = evaluation.Experiment.Name

--- a/internal/eval_hub/runtimes/shared/jobspec_test.go
+++ b/internal/eval_hub/runtimes/shared/jobspec_test.go
@@ -178,6 +178,22 @@ func TestBuildJobSpecJSONHappyPath(t *testing.T) {
 	if spec.CallbackURL == nil || *spec.CallbackURL != callbackURL {
 		t.Fatalf("expected CallbackURL %q, got %v", callbackURL, spec.CallbackURL)
 	}
+	if spec.Tenant != "" {
+		t.Fatalf("expected empty Tenant when evaluation has no tenant, got %q", spec.Tenant)
+	}
+}
+
+func TestBuildJobSpecIncludesTenant(t *testing.T) {
+	eval := baseEvaluation()
+	eval.Resource.Tenant = "team-a"
+	callbackURL := "http://callback.example/status"
+	spec, err := shared.BuildJobSpec(eval, "provider-1", &eval.Benchmarks[0], 0, &callbackURL)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if spec.Tenant != "team-a" {
+		t.Fatalf("expected Tenant %q, got %q", "team-a", spec.Tenant)
+	}
 }
 
 func TestBuildJobSpecJSONNilCallbackURL(t *testing.T) {

--- a/internal/eval_runtime_sidecar/handlers/handlers.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers.go
@@ -38,6 +38,7 @@ type Handlers struct {
 	serviceConfig    *config.Config
 	evalHubProxy     *httputil.ReverseProxy
 	mlflowProxy      *httputil.ReverseProxy
+	modelProxy       *httputil.ReverseProxy
 	ociProxy         *httputil.ReverseProxy
 	ociTokenProducer *proxy.OCITokenProducer // created once at startup for OCI auth
 	ociRepository    string                  // from job spec; used to route requests to /registry/{ociRepository}
@@ -54,6 +55,11 @@ func New(config *config.Config, logger *slog.Logger) (*Handlers, error) {
 		return nil, err
 	}
 
+	modelProxy, err := newModelProxy(config, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	ociProxy, ociTokenProducer, ociRepository, err := newOciProxy(config, logger)
 	if err != nil {
 		return nil, err
@@ -64,6 +70,7 @@ func New(config *config.Config, logger *slog.Logger) (*Handlers, error) {
 		serviceConfig:    config,
 		evalHubProxy:     evalHubProxy,
 		mlflowProxy:      mlflowProxy,
+		modelProxy:       modelProxy,
 		ociProxy:         ociProxy,
 		ociTokenProducer: ociTokenProducer,
 		ociRepository:    ociRepository,
@@ -91,6 +98,39 @@ func newMlflowProxy(config *config.Config, logger *slog.Logger) (*httputil.Rever
 
 	mlflowProxy := proxy.NewReverseProxy(mlflowTarget, mlflowHTTPClient, logger, nil)
 	return mlflowProxy, nil
+}
+
+func sidecarModel(cfg *config.Config) *config.SidecarModelConfig {
+	if cfg == nil || cfg.Sidecar == nil {
+		return nil
+	}
+	return cfg.Sidecar.Model
+}
+
+func newModelProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, error) {
+	m := sidecarModel(config)
+	if m == nil || strings.TrimSpace(m.URL) == "" {
+		logger.Debug("model proxy is not configured (no model url)")
+		return nil, nil
+	}
+	raw := strings.TrimSpace(m.URL)
+	upstream, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid model url: %w", err)
+	}
+	if upstream.Scheme == "" || upstream.Host == "" {
+		return nil, fmt.Errorf("model url must include scheme and host")
+	}
+	target := &url.URL{Scheme: upstream.Scheme, Host: upstream.Host}
+
+	httpClient, err := proxy.NewModelProxyHTTPClient(config, config.IsOTELEnabled(), logger)
+	if err != nil {
+		return nil, err
+	}
+	if httpClient == nil {
+		return nil, fmt.Errorf("model proxy HTTP client is required when model url is set")
+	}
+	return proxy.NewModelReverseProxy(target, httpClient, logger), nil
 }
 
 func newEvalhubProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, error) {
@@ -254,6 +294,21 @@ func (h *Handlers) parseProxyCall(r *http.Request) (*httputil.ReverseProxy, *pro
 			}, nil
 		}
 		return nil, nil, fmt.Errorf("eval-hub proxy is not configured")
+
+	case proxy.IsModelProxyPath(requestPathForRouting(r.RequestURI)):
+		mp := sidecarModel(h.serviceConfig)
+		if h.modelProxy != nil && mp != nil && strings.TrimSpace(mp.URL) != "" {
+			tokenPath := strings.TrimSpace(mp.AuthAPIKeyPath)
+			if tokenPath == "" {
+				tokenPath = ServiceAccountTokenPathDefault
+			}
+			return h.modelProxy, &proxy.AuthTokenInput{
+				TargetEndpoint:    "model",
+				AuthTokenPath:     tokenPath,
+				TokenCacheTimeout: mp.TokenCacheTimeout,
+			}, nil
+		}
+		return nil, nil, fmt.Errorf("model proxy is not configured")
 
 	case isMLflowProxyPath(requestPathForRouting(r.RequestURI)):
 		if h.serviceConfig.MLFlow != nil && strings.TrimSpace(h.serviceConfig.MLFlow.TrackingURI) != "" && h.mlflowProxy != nil {

--- a/internal/eval_runtime_sidecar/handlers/handlers.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers.go
@@ -39,6 +39,7 @@ type Handlers struct {
 	evalHubProxy     *httputil.ReverseProxy
 	mlflowProxy      *httputil.ReverseProxy
 	modelProxy       *httputil.ReverseProxy
+	huggingFaceProxy *httputil.ReverseProxy
 	ociProxy         *httputil.ReverseProxy
 	ociTokenProducer *proxy.OCITokenProducer // created once at startup for OCI auth
 	ociRepository    string                  // from job spec; used to route requests to /registry/{ociRepository}
@@ -60,6 +61,11 @@ func New(config *config.Config, logger *slog.Logger) (*Handlers, error) {
 		return nil, err
 	}
 
+	huggingFaceProxy, err := newHuggingFaceProxy(config, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	ociProxy, ociTokenProducer, ociRepository, err := newOciProxy(config, logger)
 	if err != nil {
 		return nil, err
@@ -71,6 +77,7 @@ func New(config *config.Config, logger *slog.Logger) (*Handlers, error) {
 		evalHubProxy:     evalHubProxy,
 		mlflowProxy:      mlflowProxy,
 		modelProxy:       modelProxy,
+		huggingFaceProxy: huggingFaceProxy,
 		ociProxy:         ociProxy,
 		ociTokenProducer: ociTokenProducer,
 		ociRepository:    ociRepository,
@@ -131,6 +138,42 @@ func newModelProxy(config *config.Config, logger *slog.Logger) (*httputil.Revers
 		return nil, fmt.Errorf("model proxy HTTP client is required when model url is set")
 	}
 	return proxy.NewModelReverseProxy(target, httpClient, logger), nil
+}
+
+func sidecarHuggingFace(cfg *config.Config) *config.SidecarHuggingFaceConfig {
+	if cfg == nil || cfg.Sidecar == nil {
+		return nil
+	}
+	return cfg.Sidecar.HuggingFace
+}
+
+func newHuggingFaceProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, error) {
+	hf := sidecarHuggingFace(config)
+	if hf == nil {
+		logger.Debug("Hugging Face proxy is not configured (no sidecar.huggingface)")
+		return nil, nil
+	}
+	raw := strings.TrimSpace(hf.URL)
+	if raw == "" {
+		raw = "https://huggingface.co"
+	}
+	upstream, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid huggingface url: %w", err)
+	}
+	if upstream.Scheme == "" || upstream.Host == "" {
+		return nil, fmt.Errorf("huggingface url must include scheme and host")
+	}
+	target := &url.URL{Scheme: upstream.Scheme, Host: upstream.Host}
+
+	httpClient, err := proxy.NewHuggingFaceProxyHTTPClient(config, config.IsOTELEnabled(), logger)
+	if err != nil {
+		return nil, err
+	}
+	if httpClient == nil {
+		return nil, fmt.Errorf("Hugging Face proxy HTTP client is required when sidecar.huggingface is set")
+	}
+	return proxy.NewHuggingFaceReverseProxy(target, httpClient, logger), nil
 }
 
 func newEvalhubProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, error) {
@@ -309,6 +352,20 @@ func (h *Handlers) parseProxyCall(r *http.Request) (*httputil.ReverseProxy, *pro
 			}, nil
 		}
 		return nil, nil, fmt.Errorf("model proxy is not configured")
+
+	case proxy.IsHuggingFaceProxyPath(requestPathForRouting(r.RequestURI)):
+		hf := sidecarHuggingFace(h.serviceConfig)
+		if h.huggingFaceProxy != nil && hf != nil {
+			// Empty token_path => anonymous Hub access (no Authorization). Gated assets use token_path from
+			// model.auth.secret_ref key "hf-token" (see sidecar_config.json from job builder).
+			tokenPath := strings.TrimSpace(hf.TokenPath)
+			return h.huggingFaceProxy, &proxy.AuthTokenInput{
+				TargetEndpoint:    "huggingface",
+				AuthTokenPath:     tokenPath,
+				TokenCacheTimeout: hf.TokenCacheTimeout,
+			}, nil
+		}
+		return nil, nil, fmt.Errorf("huggingface proxy is not configured")
 
 	case isMLflowProxyPath(requestPathForRouting(r.RequestURI)):
 		if h.serviceConfig.MLFlow != nil && strings.TrimSpace(h.serviceConfig.MLFlow.TrackingURI) != "" && h.mlflowProxy != nil {

--- a/internal/eval_runtime_sidecar/handlers/handlers_test.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers_test.go
@@ -53,6 +53,32 @@ func TestNew(t *testing.T) {
 		if h.mlflowProxy == nil {
 			t.Error("expected non-nil mlflowProxy")
 		}
+		if h.modelProxy != nil {
+			t.Error("expected nil modelProxy when model proxy not configured")
+		}
+	})
+
+	t.Run("returns Handlers with model proxy when model url set", func(t *testing.T) {
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				EvalHub: &config.EvalHubClientConfig{
+					BaseURL:            "http://localhost:8080",
+					InsecureSkipVerify: true,
+				},
+				Model: &config.SidecarModelConfig{
+					URL:                "http://127.0.0.1:9999/v1",
+					InsecureSkipVerify: true,
+				},
+			},
+			MLFlow: &config.MLFlowConfig{TrackingURI: "http://localhost:5000"},
+		}
+		h, err := New(cfg, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if h.modelProxy == nil {
+			t.Fatal("expected non-nil modelProxy")
+		}
 	})
 }
 

--- a/internal/eval_runtime_sidecar/handlers/handlers_test.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_runtime_sidecar/proxy"
 )
 
 func TestNew(t *testing.T) {
@@ -80,6 +81,31 @@ func TestNew(t *testing.T) {
 		}
 		if h.modelProxy == nil {
 			t.Fatal("expected non-nil modelProxy")
+		}
+		if h.huggingFaceProxy != nil {
+			t.Error("expected nil huggingFaceProxy when Hugging Face proxy not configured")
+		}
+	})
+
+	t.Run("returns Handlers with Hugging Face proxy when sidecar.huggingface set", func(t *testing.T) {
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				EvalHub: &config.EvalHubClientConfig{
+					BaseURL:            "http://localhost:8080",
+					InsecureSkipVerify: true,
+				},
+				HuggingFace: &config.SidecarHuggingFaceConfig{
+					InsecureSkipVerify: true,
+				},
+			},
+			MLFlow: &config.MLFlowConfig{TrackingURI: "http://localhost:5000"},
+		}
+		h, err := New(cfg, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if h.huggingFaceProxy == nil {
+			t.Fatal("expected non-nil huggingFaceProxy")
 		}
 	})
 }
@@ -243,6 +269,89 @@ func TestHandlers_HandleProxyCall(t *testing.T) {
 		}
 		if gotAuth != "Bearer secret-from-file" {
 			t.Fatalf("Authorization = %q, want Bearer secret-from-file", gotAuth)
+		}
+	})
+
+	t.Run("Hugging Face proxy with token_path sends bearer from file", func(t *testing.T) {
+		dir := t.TempDir()
+		keyFile := filepath.Join(dir, "hftoken")
+		if err := os.WriteFile(keyFile, []byte("hf-secret\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var gotAuth string
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			if r.URL.Path != "/api/models" {
+				t.Errorf("upstream path = %q, want /api/models", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(upstream.Close)
+
+		u := upstream.URL
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				EvalHub: &config.EvalHubClientConfig{
+					BaseURL:            "http://localhost:8080",
+					InsecureSkipVerify: true,
+				},
+				HuggingFace: &config.SidecarHuggingFaceConfig{
+					URL:                u,
+					InsecureSkipVerify: true,
+					TokenPath:          keyFile,
+				},
+			},
+			MLFlow: &config.MLFlowConfig{TrackingURI: "http://localhost:5000"},
+		}
+		hhf, err := New(cfg, logger)
+		if err != nil {
+			t.Fatalf("New() error: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodGet, "/huggingface/api/models", nil)
+		rw := httptest.NewRecorder()
+		hhf.HandleProxyCall(rw, req)
+		if rw.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %q", rw.Code, rw.Body.String())
+		}
+		if gotAuth != "Bearer hf-secret" {
+			t.Fatalf("Authorization = %q, want Bearer hf-secret", gotAuth)
+		}
+	})
+
+	t.Run("Hugging Face proxy without token_path sends no authorization", func(t *testing.T) {
+		proxy.UpdateCachedToken(proxy.AuthTokenInput{TargetEndpoint: "huggingface"}, "")
+		var gotAuth string
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(upstream.Close)
+
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				EvalHub: &config.EvalHubClientConfig{
+					BaseURL:            "http://localhost:8080",
+					InsecureSkipVerify: true,
+				},
+				HuggingFace: &config.SidecarHuggingFaceConfig{
+					URL:                upstream.URL,
+					InsecureSkipVerify: true,
+				},
+			},
+			MLFlow: &config.MLFlowConfig{TrackingURI: "http://localhost:5000"},
+		}
+		hhf, err := New(cfg, logger)
+		if err != nil {
+			t.Fatalf("New() error: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodGet, "/huggingface/api/models", nil)
+		rw := httptest.NewRecorder()
+		hhf.HandleProxyCall(rw, req)
+		if rw.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %q", rw.Code, rw.Body.String())
+		}
+		if gotAuth != "" {
+			t.Fatalf("Authorization = %q, want empty for anonymous Hub access", gotAuth)
 		}
 	})
 

--- a/internal/eval_runtime_sidecar/handlers/handlers_test.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers_test.go
@@ -4,6 +4,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -199,6 +201,48 @@ func TestHandlers_HandleProxyCall(t *testing.T) {
 		hNoMLFlow.HandleProxyCall(rw, req)
 		if rw.Code != http.StatusBadRequest {
 			t.Errorf("status = %d, want 400 (mlflow proxy not configured)", rw.Code)
+		}
+	})
+
+	t.Run("model proxy with auth_api_key_path sends bearer from file", func(t *testing.T) {
+		dir := t.TempDir()
+		keyFile := filepath.Join(dir, "apikey")
+		if err := os.WriteFile(keyFile, []byte("secret-from-file\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var gotAuth string
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(upstream.Close)
+
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				EvalHub: &config.EvalHubClientConfig{
+					BaseURL:            "http://localhost:8080",
+					InsecureSkipVerify: true,
+				},
+				Model: &config.SidecarModelConfig{
+					URL:                upstream.URL + "/v1",
+					InsecureSkipVerify: true,
+					AuthAPIKeyPath:     keyFile,
+				},
+			},
+			MLFlow: &config.MLFlowConfig{TrackingURI: "http://localhost:5000"},
+		}
+		hm, err := New(cfg, logger)
+		if err != nil {
+			t.Fatalf("New() error: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodGet, "/model/v1/models", nil)
+		rw := httptest.NewRecorder()
+		hm.HandleProxyCall(rw, req)
+		if rw.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %q", rw.Code, rw.Body.String())
+		}
+		if gotAuth != "Bearer secret-from-file" {
+			t.Fatalf("Authorization = %q, want Bearer secret-from-file", gotAuth)
 		}
 	})
 

--- a/internal/eval_runtime_sidecar/proxy/auth.go
+++ b/internal/eval_runtime_sidecar/proxy/auth.go
@@ -30,6 +30,7 @@ type TokenWithExpiry struct {
 var (
 	evalHubCachedToken atomic.Pointer[TokenWithExpiry]
 	mlflowCachedToken  atomic.Pointer[TokenWithExpiry]
+	modelCachedToken   atomic.Pointer[TokenWithExpiry]
 	ociCachedToken     atomic.Pointer[TokenWithExpiry]
 )
 
@@ -40,6 +41,8 @@ func getTokenPointer(targetEndpoint string) *atomic.Pointer[TokenWithExpiry] {
 		return &evalHubCachedToken
 	case "mlflow":
 		return &mlflowCachedToken
+	case "model":
+		return &modelCachedToken
 	case "oci":
 		return &ociCachedToken
 	default:

--- a/internal/eval_runtime_sidecar/proxy/auth.go
+++ b/internal/eval_runtime_sidecar/proxy/auth.go
@@ -28,10 +28,11 @@ type TokenWithExpiry struct {
 }
 
 var (
-	evalHubCachedToken atomic.Pointer[TokenWithExpiry]
-	mlflowCachedToken  atomic.Pointer[TokenWithExpiry]
-	modelCachedToken   atomic.Pointer[TokenWithExpiry]
-	ociCachedToken     atomic.Pointer[TokenWithExpiry]
+	evalHubCachedToken     atomic.Pointer[TokenWithExpiry]
+	mlflowCachedToken      atomic.Pointer[TokenWithExpiry]
+	modelCachedToken       atomic.Pointer[TokenWithExpiry]
+	huggingfaceCachedToken atomic.Pointer[TokenWithExpiry]
+	ociCachedToken         atomic.Pointer[TokenWithExpiry]
 )
 
 // getTokenPointer returns the cache slot for a known proxy target, or nil if the endpoint is not cacheable.
@@ -43,6 +44,8 @@ func getTokenPointer(targetEndpoint string) *atomic.Pointer[TokenWithExpiry] {
 		return &mlflowCachedToken
 	case "model":
 		return &modelCachedToken
+	case "huggingface":
+		return &huggingfaceCachedToken
 	case "oci":
 		return &ociCachedToken
 	default:
@@ -128,7 +131,7 @@ func resolveEvalHubOrMLflowToken(logger *slog.Logger, input AuthTokenInput) stri
 	return token
 }
 
-// UpdateCachedToken stores token for the target in input.TargetEndpoint (eval-hub, mlflow, or oci).
+// UpdateCachedToken stores token for the target in input.TargetEndpoint (eval-hub, mlflow, model, huggingface, or oci).
 // TTL is input.TokenCacheTimeout or defaultAuthTokenCacheTTL. An empty token clears the cache slot.
 func UpdateCachedToken(input AuthTokenInput, token string) {
 	tokenPointer := getTokenPointer(input.TargetEndpoint)

--- a/internal/eval_runtime_sidecar/proxy/auth_test.go
+++ b/internal/eval_runtime_sidecar/proxy/auth_test.go
@@ -12,6 +12,7 @@ func resetAuthTokenCachesForTest() {
 	evalHubCachedToken.Store(nil)
 	mlflowCachedToken.Store(nil)
 	modelCachedToken.Store(nil)
+	huggingfaceCachedToken.Store(nil)
 	ociCachedToken.Store(nil)
 }
 

--- a/internal/eval_runtime_sidecar/proxy/auth_test.go
+++ b/internal/eval_runtime_sidecar/proxy/auth_test.go
@@ -11,6 +11,7 @@ import (
 func resetAuthTokenCachesForTest() {
 	evalHubCachedToken.Store(nil)
 	mlflowCachedToken.Store(nil)
+	modelCachedToken.Store(nil)
 	ociCachedToken.Store(nil)
 }
 

--- a/internal/eval_runtime_sidecar/proxy/http_client.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
@@ -152,5 +153,48 @@ func NewOCIHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger *
 		return nil, err
 	}
 	client := newHTTPClient(timeout, tlsConfig, isOTELEnabled, logger, "OCI")
+	return client, nil
+}
+
+// resolveCACertPathIfPresent returns the first non-empty path that exists on disk, or empty if none exist.
+func resolveCACertPathIfPresent(paths []string, logger *slog.Logger) string {
+	for _, p := range paths {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+		if logger != nil {
+			logger.Debug("model proxy: CA path not found, trying next", "path", p)
+		}
+	}
+	return ""
+}
+
+// NewModelProxyHTTPClient builds an HTTP client for the model upstream (TLS, timeout).
+// Returns (nil, nil) when sidecar model is not configured or URL is empty.
+func NewModelProxyHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger *slog.Logger) (*http.Client, error) {
+	var mp *config.SidecarModelConfig
+	if serviceConfig != nil && serviceConfig.Sidecar != nil {
+		mp = serviceConfig.Sidecar.Model
+	}
+	if mp == nil || strings.TrimSpace(mp.URL) == "" {
+		return nil, nil
+	}
+
+	timeout := DefaultHTTPTimeout
+	if mp.HTTPTimeout > 0 {
+		timeout = mp.HTTPTimeout
+	}
+
+	caPath := resolveCACertPathIfPresent([]string{mp.AuthCACertPath}, logger)
+	tlsConfig, err := buildTLSConfig(caPath, mp.InsecureSkipVerify, logger, "Model")
+	if err != nil {
+		return nil, err
+	}
+
+	client := newHTTPClient(timeout, tlsConfig, isOTELEnabled, logger, "Model")
 	return client, nil
 }

--- a/internal/eval_runtime_sidecar/proxy/http_client.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client.go
@@ -39,6 +39,31 @@ func newHTTPClient(timeout time.Duration, tlsConfig *tls.Config, isOTELEnabled b
 	return client
 }
 
+// newHuggingFaceUpstreamHTTPClient builds the HTTP client used by the Hugging Face reverse proxy to call
+// huggingface.co. DisableCompression is true so the Hub response body matches Content-Length / x-linked-size
+// metadata that huggingface_hub uses for consistency checks; automatic gzip decompression can otherwise
+// make written file size disagree with expected_size from HEAD/metadata (e.g. 264 vs 2539 for tokenizer_config.json).
+func newHuggingFaceUpstreamHTTPClient(timeout time.Duration, tlsConfig *tls.Config, isOTELEnabled bool, logger *slog.Logger) *http.Client {
+	transport := &http.Transport{
+		DisableCompression: true,
+	}
+	if tlsConfig != nil {
+		transport.TLSClientConfig = tlsConfig
+	}
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+	if isOTELEnabled {
+		client = &http.Client{
+			Transport: otelhttp.NewTransport(client.Transport),
+			Timeout:   client.Timeout,
+		}
+		logger.Info("Enabled OTEL transport", "label", "HuggingFace")
+	}
+	return client
+}
+
 // buildTLSConfig creates a TLS config from CA cert path and insecure flag.
 // When insecureSkipVerify is false and caCertPath is non-empty, the CA PEM is loaded into RootCAs
 // (production Eval Hub / MLflow / OCI behavior on cluster).
@@ -196,5 +221,34 @@ func NewModelProxyHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, l
 	}
 
 	client := newHTTPClient(timeout, tlsConfig, isOTELEnabled, logger, "Model")
+	return client, nil
+}
+
+// NewHuggingFaceProxyHTTPClient builds an HTTP client for the Hugging Face Hub upstream (TLS, timeout).
+// Returns (nil, nil) when sidecar.huggingface is not set. Hub uses public CAs unless insecure_skip_verify is set.
+// The client uses http.ErrUseLastResponse so 3xx responses are returned to ModifyResponse on the reverse proxy,
+// which rewrites Location to a relative /huggingface/... path (see rewriteHuggingFaceRedirectLocation).
+// Absolute Location URLs would prevent huggingface_hub's HEAD handler from following redirects; relative URLs
+// preserve correct Content-Length metadata for the resolved file.
+func NewHuggingFaceProxyHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger *slog.Logger) (*http.Client, error) {
+	if serviceConfig == nil || serviceConfig.Sidecar == nil || serviceConfig.Sidecar.HuggingFace == nil {
+		return nil, nil
+	}
+	hf := serviceConfig.Sidecar.HuggingFace
+
+	timeout := DefaultHTTPTimeout
+	if hf.HTTPTimeout > 0 {
+		timeout = hf.HTTPTimeout
+	}
+
+	tlsConfig, err := buildTLSConfig("", hf.InsecureSkipVerify, logger, "HuggingFace")
+	if err != nil {
+		return nil, err
+	}
+
+	client := newHuggingFaceUpstreamHTTPClient(timeout, tlsConfig, isOTELEnabled, logger)
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 	return client, nil
 }

--- a/internal/eval_runtime_sidecar/proxy/http_client_test.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"log/slog"
+	"net/http"
 	"testing"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
@@ -104,6 +105,50 @@ func TestNewMLFlowHTTPClient(t *testing.T) {
 		}
 		if client.Timeout == 0 {
 			t.Error("expected non-zero timeout")
+		}
+	})
+}
+
+func TestNewHuggingFaceProxyHTTPClient(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("returns nil when huggingface is not configured", func(t *testing.T) {
+		client, err := NewHuggingFaceProxyHTTPClient(&config.Config{}, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client != nil {
+			t.Error("expected nil client")
+		}
+	})
+
+	t.Run("HF upstream client passes redirects for Location rewriting", func(t *testing.T) {
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				HuggingFace: &config.SidecarHuggingFaceConfig{
+					URL: "https://huggingface.co",
+				},
+			},
+		}
+		client, err := NewHuggingFaceProxyHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+		if client.CheckRedirect == nil {
+			t.Fatal("expected CheckRedirect for ErrUseLastResponse")
+		}
+		if err := client.CheckRedirect(&http.Request{}, nil); err != http.ErrUseLastResponse {
+			t.Fatalf("CheckRedirect = %v, want http.ErrUseLastResponse", err)
+		}
+		tr, ok := client.Transport.(*http.Transport)
+		if !ok {
+			t.Fatal("expected *http.Transport for HF upstream (OTEL off)")
+		}
+		if !tr.DisableCompression {
+			t.Error("expected DisableCompression on Hugging Face upstream transport")
 		}
 	})
 }

--- a/internal/eval_runtime_sidecar/proxy/huggingface_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/huggingface_proxy.go
@@ -1,0 +1,88 @@
+package proxy
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+const huggingfaceProxyPathPrefix = "/huggingface"
+
+// IsHuggingFaceProxyPath reports whether path should be handled by the Hugging Face reverse proxy
+// (/huggingface or /huggingface/...). It does not match paths like /huggingfaceExtra.
+func IsHuggingFaceProxyPath(path string) bool {
+	if !strings.HasPrefix(path, huggingfaceProxyPathPrefix) {
+		return false
+	}
+	if len(path) == len(huggingfaceProxyPathPrefix) {
+		return true
+	}
+	return path[len(huggingfaceProxyPathPrefix)] == '/'
+}
+
+// stripHuggingFaceProxyPathPrefix removes the /huggingface prefix so the request path matches the upstream Hub path.
+func stripHuggingFaceProxyPathPrefix(p string) string {
+	if p == huggingfaceProxyPathPrefix {
+		return "/"
+	}
+	if strings.HasPrefix(p, huggingfaceProxyPathPrefix+"/") {
+		return strings.TrimPrefix(p, huggingfaceProxyPathPrefix)
+	}
+	return p
+}
+
+// NewHuggingFaceReverseProxy returns a reverse proxy to the Hugging Face origin (scheme + host only).
+// It strips the /huggingface prefix from the request path, then forwards. Authorization is set only when
+// sidecar.huggingface.token_path is non-empty (HF token file, e.g. from model auth secret key "hf-token").
+func NewHuggingFaceReverseProxy(target *url.URL, client *http.Client, logger *slog.Logger) *httputil.ReverseProxy {
+	transport := &roundTripperFromClient{client: client}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.Transport = transport
+
+	proxy.Director = func(req *http.Request) {
+		req.URL.Path = stripHuggingFaceProxyPathPrefix(req.URL.Path)
+		if req.URL.Path == "" {
+			req.URL.Path = "/"
+		}
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.Host = target.Host
+		req.RequestURI = ""
+
+		authInput, ok := AuthInputFromContext(req.Context())
+		if ok {
+			authToken := ResolveAuthToken(logger, authInput)
+			SetAuthHeader(req, authToken)
+		}
+		logger.Info("Hugging Face proxy request", "method", req.Method, "url", req.URL.String(), "headers", headersForLog(req.Header))
+	}
+
+	hubHost := target.Hostname()
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		if resp.Request != nil {
+			logger.Info("Response from Hugging Face proxy", "method", resp.Request.Method, "url", resp.Request.URL.String(), "status", resp.StatusCode)
+		}
+		if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+			return nil
+		}
+		loc := resp.Header.Get("Location")
+		if loc == "" {
+			return nil
+		}
+		newLoc := rewriteHuggingFaceRedirectLocation(loc, hubHost)
+		if newLoc != loc {
+			resp.Header.Set("Location", newLoc)
+			logger.Info("Hugging Face proxy rewritten Location", "from", loc, "to", newLoc)
+		}
+		return nil
+	}
+
+	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
+		logger.Error("Error proxying Hugging Face request", "method", req.Method, "url", req.URL.String(), "error", err)
+		http.Error(w, err.Error(), http.StatusBadGateway)
+	}
+
+	return proxy
+}

--- a/internal/eval_runtime_sidecar/proxy/huggingface_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/huggingface_proxy_test.go
@@ -1,0 +1,32 @@
+package proxy
+
+import "testing"
+
+func TestIsHuggingFaceProxyPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/huggingface", true},
+		{"/huggingface/", true},
+		{"/huggingface//api", true},
+		{"/huggingface/api/models/foo", true},
+		{"/huggingfacev1", false},
+		{"/api/models", false},
+		{"/", false},
+	}
+	for _, tt := range tests {
+		if got := IsHuggingFaceProxyPath(tt.path); got != tt.want {
+			t.Errorf("IsHuggingFaceProxyPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestStripHuggingFaceProxyPathPrefix(t *testing.T) {
+	if got := stripHuggingFaceProxyPathPrefix("/huggingface"); got != "/" {
+		t.Errorf("strip = %q, want /", got)
+	}
+	if got := stripHuggingFaceProxyPathPrefix("/huggingface/api/models"); got != "/api/models" {
+		t.Errorf("strip = %q, want /api/models", got)
+	}
+}

--- a/internal/eval_runtime_sidecar/proxy/huggingface_redirect.go
+++ b/internal/eval_runtime_sidecar/proxy/huggingface_redirect.go
@@ -1,0 +1,87 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ClientOriginFromRequest builds scheme://host as seen by the adapter (pod localhost:8080, etc.).
+func ClientOriginFromRequest(req *http.Request) string {
+	scheme := "http"
+	if req.TLS != nil {
+		scheme = "https"
+	}
+	if p := req.Header.Get("X-Forwarded-Proto"); p != "" {
+		scheme = p
+	}
+	host := req.Host
+	if host == "" {
+		host = "localhost"
+	}
+	return scheme + "://" + host
+}
+
+func joinURLPathQueryFragment(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	s := u.Path
+	if s == "" {
+		s = "/"
+	}
+	if u.RawQuery != "" {
+		s += "?" + u.RawQuery
+	}
+	if u.Fragment != "" {
+		s += "#" + u.Fragment
+	}
+	return s
+}
+
+func isHuggingFaceHubHostname(host, configuredHubHost string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	configuredHubHost = strings.ToLower(strings.TrimSpace(configuredHubHost))
+	if host == "" {
+		return false
+	}
+	if configuredHubHost != "" && host == configuredHubHost {
+		return true
+	}
+	return strings.HasSuffix(host, ".huggingface.co")
+}
+
+// rewriteHuggingFaceRedirectLocation rewrites the Location header on Hub 3xx responses so clients using
+// HF_ENDPOINT (http://pod:8080/huggingface) stay under /huggingface instead of http://pod:8080/api/...
+//
+// huggingface_hub's get_hf_file_metadata uses HEAD with allow_redirects=False and only follows *relative*
+// Location URLs (empty host). Absolute Locations are not followed, so HEAD stops on the 307 and reads
+// wrong Content-Length / x-linked-size; GET then downloads the real file and hits a size mismatch.
+// Emit relative paths such as /huggingface/api/resolve-cache/... so the client follows and metadata matches GET.
+//
+// Rewrites:
+//   - Relative paths such as /api/resolve-cache/... → /huggingface/api/resolve-cache/...
+//   - Absolute https://huggingface.co/... (and *.huggingface.co) → /huggingface/... (relative)
+//
+// Leaves other absolute URLs unchanged (e.g. https://cas-bridge.xethub.hf.co/...) so clients may follow CAS directly.
+func rewriteHuggingFaceRedirectLocation(location, configuredHubHost string) string {
+	u, err := url.Parse(location)
+	if err != nil || strings.TrimSpace(location) == "" {
+		return location
+	}
+	pq := joinURLPathQueryFragment(u)
+	// Relative redirect (common for Hub resolve-cache).
+	if u.Scheme == "" && strings.HasPrefix(u.Path, "/") {
+		if u.Path == huggingfaceProxyPathPrefix || strings.HasPrefix(u.Path, huggingfaceProxyPathPrefix+"/") {
+			return location
+		}
+		return huggingfaceProxyPathPrefix + pq
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return location
+	}
+	if !isHuggingFaceHubHostname(u.Hostname(), configuredHubHost) {
+		return location
+	}
+	return huggingfaceProxyPathPrefix + pq
+}

--- a/internal/eval_runtime_sidecar/proxy/huggingface_redirect_test.go
+++ b/internal/eval_runtime_sidecar/proxy/huggingface_redirect_test.go
@@ -1,0 +1,82 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRewriteHuggingFaceRedirectLocation(t *testing.T) {
+	hub := "huggingface.co"
+
+	tests := []struct {
+		name     string
+		location string
+		want     string
+	}{
+		{
+			name:     "relative resolve-cache",
+			location: "/api/resolve-cache/models/google/flan-t5-small/0fc9ddf78a1e988dac52e2dac162b0ede4fd74ab/config.json?%2Fgoogle%2Fflan-t5-small%2Fresolve%2Fmain%2Fconfig.json=&etag=%221%22",
+			want:     "/huggingface/api/resolve-cache/models/google/flan-t5-small/0fc9ddf78a1e988dac52e2dac162b0ede4fd74ab/config.json?%2Fgoogle%2Fflan-t5-small%2Fresolve%2Fmain%2Fconfig.json=&etag=%221%22",
+		},
+		{
+			name:     "relative parquet path",
+			location: "/datasets/allenai/ai2_arc/resolve/210d026faf9955653af8916fad021475a3f00453/ARC-Easy/train-00000-of-00001.parquet",
+			want:     "/huggingface/datasets/allenai/ai2_arc/resolve/210d026faf9955653af8916fad021475a3f00453/ARC-Easy/train-00000-of-00001.parquet",
+		},
+		{
+			name:     "absolute huggingface.co",
+			location: "https://huggingface.co/api/models/foo",
+			want:     "/huggingface/api/models/foo",
+		},
+		{
+			name:     "subdomain huggingface.co",
+			location: "https://cdn-lfs.huggingface.co/foo/bar",
+			want:     "/huggingface/foo/bar",
+		},
+		{
+			name:     "already under huggingface prefix unchanged",
+			location: "/huggingface/api/resolve-cache/foo",
+			want:     "/huggingface/api/resolve-cache/foo",
+		},
+		{
+			name:     "cas xet unchanged",
+			location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/abc?X-Amz-Algorithm=AWS4-HMAC-SHA256",
+			want:     "https://cas-bridge.xethub.hf.co/xet-bridge-us/abc?X-Amz-Algorithm=AWS4-HMAC-SHA256",
+		},
+		{
+			name:     "empty",
+			location: "",
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rewriteHuggingFaceRedirectLocation(tt.location, hub)
+			if got != tt.want {
+				t.Fatalf("rewriteHuggingFaceRedirectLocation(%q) = %q, want %q", tt.location, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientOriginFromRequest(t *testing.T) {
+	t.Run("X-Forwarded-Proto https", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://10.0.0.1:8080/huggingface/foo", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("X-Forwarded-Proto", "https")
+		if got := ClientOriginFromRequest(req); got != "https://10.0.0.1:8080" {
+			t.Fatalf("got %q", got)
+		}
+	})
+	t.Run("plain http", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/huggingface/foo", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := ClientOriginFromRequest(req); got != "http://localhost:8080" {
+			t.Fatalf("got %q", got)
+		}
+	})
+}

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+const modelProxyPathPrefix = "/model"
+
+// IsModelProxyPath reports whether path should be handled by the model reverse proxy (/model or /model/...).
+// It does not match paths like /modelExtra (no boundary after /model).
+func IsModelProxyPath(path string) bool {
+	if !strings.HasPrefix(path, modelProxyPathPrefix) {
+		return false
+	}
+	if len(path) == len(modelProxyPathPrefix) {
+		return true
+	}
+	return path[len(modelProxyPathPrefix)] == '/'
+}
+
+// stripModelProxyPathPrefix removes the /model prefix so the request path matches the upstream OpenAI base path.
+func stripModelProxyPathPrefix(p string) string {
+	if p == modelProxyPathPrefix {
+		return "/"
+	}
+	if strings.HasPrefix(p, modelProxyPathPrefix+"/") {
+		return strings.TrimPrefix(p, modelProxyPathPrefix)
+	}
+	return p
+}
+
+// NewModelReverseProxy returns a reverse proxy to the model origin (scheme + host only).
+// It strips the /model prefix from the request path, then forwards. Authorization is set in the Director
+// using ResolveAuthToken from context (TargetEndpoint "model").
+func NewModelReverseProxy(target *url.URL, client *http.Client, logger *slog.Logger) *httputil.ReverseProxy {
+	transport := &roundTripperFromClient{client: client}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.Transport = transport
+
+	proxy.Director = func(req *http.Request) {
+		req.URL.Path = stripModelProxyPathPrefix(req.URL.Path)
+		if req.URL.Path == "" {
+			req.URL.Path = "/"
+		}
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.Host = target.Host
+		req.RequestURI = ""
+
+		authInput, ok := AuthInputFromContext(req.Context())
+		if ok {
+			authToken := ResolveAuthToken(logger, authInput)
+			SetAuthHeader(req, authToken)
+		}
+		logger.Info("Model proxy request", "method", req.Method, "url", req.URL.String(), "headers", headersForLog(req.Header))
+	}
+
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		if resp.Request != nil {
+			logger.Info("Response from model proxy", "method", resp.Request.Method, "url", resp.Request.URL.String(), "status", resp.StatusCode)
+		}
+		return nil
+	}
+
+	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
+		logger.Error("Error proxying model request", "method", req.Method, "url", req.URL.String(), "error", err)
+		http.Error(w, err.Error(), http.StatusBadGateway)
+	}
+
+	return proxy
+}

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -35,7 +35,8 @@ func stripModelProxyPathPrefix(p string) string {
 
 // NewModelReverseProxy returns a reverse proxy to the model origin (scheme + host only).
 // It strips the /model prefix from the request path, then forwards. Authorization is set in the Director
-// using ResolveAuthToken from context (TargetEndpoint "model").
+// using ResolveAuthToken from context (TargetEndpoint "model"); when auth_api_key_path is unset, the pod
+// default service account token path is used (see handlers.ServiceAccountTokenPathDefault).
 func NewModelReverseProxy(target *url.URL, client *http.Client, logger *slog.Logger) *httputil.ReverseProxy {
 	transport := &roundTripperFromClient{client: client}
 	proxy := httputil.NewSingleHostReverseProxy(target)

--- a/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
@@ -1,0 +1,35 @@
+package proxy
+
+import "testing"
+
+func TestIsModelProxyPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/model", true},
+		{"/model/", true},
+		{"/model//v1", true},
+		{"/model/v1/completions", true},
+		{"/api/2.0/mlflow", false},
+		{"/modelv1", false},
+		{"/v1/completions", false},
+	}
+	for _, tt := range tests {
+		if got := IsModelProxyPath(tt.path); got != tt.want {
+			t.Errorf("IsModelProxyPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestStripModelProxyPathPrefix(t *testing.T) {
+	if got := stripModelProxyPathPrefix("/model"); got != "/" {
+		t.Errorf("got %q, want /", got)
+	}
+	if got := stripModelProxyPathPrefix("/model/v1/chat/completions"); got != "/v1/chat/completions" {
+		t.Errorf("got %q", got)
+	}
+	if got := stripModelProxyPathPrefix("/other"); got != "/other" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/tests/kubernetes/features/kubernetes_resources.feature
+++ b/tests/kubernetes/features/kubernetes_resources.feature
@@ -58,7 +58,7 @@ Feature: Kubernetes Resources Validation
     And the Job pod template should have volume "data" of type EmptyDir
     And the Job pod template should have volume "termination-file-volume" of type EmptyDir
     And the volume "job-spec" should reference the ConfigMap with suffix "-spec"
-    And the Job pod template should have serviceAccountName derived from service account name
+    And the Job pod template should have evalhub_instance_name label when EvalHub instance is configured
     And the Job pod template should have volume "evalhub-service-ca" of type ConfigMap
     And the volume "evalhub-service-ca" should reference ConfigMap derived from service account name
     And the Job pod template should have container named "adapter"

--- a/tests/kubernetes/features/step_definitions_test.go
+++ b/tests/kubernetes/features/step_definitions_test.go
@@ -291,7 +291,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the container should have memory request set$`, tc.containerShouldHaveMemoryRequestSet)
 	ctx.Step(`^the container should have CPU limit set$`, tc.containerShouldHaveCPULimitSet)
 	ctx.Step(`^the container should have memory limit set$`, tc.containerShouldHaveMemoryLimitSet)
-	ctx.Step(`^the Job pod template should have serviceAccountName derived from service account name$`, tc.jobPodTemplateShouldHaveServiceAccountFromSA)
+	ctx.Step(`^the Job pod template should have evalhub_instance_name label when EvalHub instance is configured$`, tc.jobPodTemplateShouldHaveEvalHubInstanceNameLabel)
 	ctx.Step(`^the volume "([^"]*)" should reference ConfigMap derived from service account name$`, tc.volumeShouldReferenceConfigMapFromSA)
 
 	// Volume & Mount Steps
@@ -1543,11 +1543,11 @@ func (tc *testContext) containerShouldHaveMemoryLimitSet() error {
 	return nil
 }
 
-func (tc *testContext) jobPodTemplateShouldHaveServiceAccountFromSA() error {
+func (tc *testContext) jobPodTemplateShouldHaveEvalHubInstanceNameLabel() error {
 	if tc.currentJob == nil {
 		return fmt.Errorf("no current Job")
 	}
-	_, err := tc.instanceNameFromServiceAccount()
+	_, err := tc.instanceNameFromJobTemplateLabels()
 	return err
 }
 
@@ -1555,7 +1555,7 @@ func (tc *testContext) volumeShouldReferenceConfigMapFromSA(volumeName string) e
 	if tc.currentJob == nil {
 		return fmt.Errorf("no current Job")
 	}
-	envValue, err := tc.instanceNameFromServiceAccount()
+	envValue, err := tc.instanceNameFromJobTemplateLabels()
 	if err != nil {
 		return err
 	}
@@ -1563,17 +1563,19 @@ func (tc *testContext) volumeShouldReferenceConfigMapFromSA(volumeName string) e
 	return tc.volumeShouldReferenceConfigMapByName(volumeName, expected)
 }
 
-func (tc *testContext) instanceNameFromServiceAccount() (string, error) {
+func (tc *testContext) instanceNameFromJobTemplateLabels() (string, error) {
 	if tc.currentJob == nil {
 		return "", fmt.Errorf("no current Job")
 	}
-	serviceAccount := tc.currentJob.Spec.Template.Spec.ServiceAccountName
-	// SA format is "{instanceName}-{namespace}-job"
-	suffix := "-" + tc.namespace + "-job"
-	if !strings.HasSuffix(serviceAccount, suffix) {
-		return "", fmt.Errorf("unable to derive instance name from serviceAccountName %q", serviceAccount)
+	labels := tc.currentJob.Spec.Template.Labels
+	if labels == nil {
+		return "", fmt.Errorf("pod template has no labels")
 	}
-	return strings.TrimSuffix(serviceAccount, suffix), nil
+	name := strings.TrimSpace(labels["evalhub_instance_name"])
+	if name == "" {
+		return "", fmt.Errorf("pod template missing label evalhub_instance_name (expected when EvalHub instance is configured)")
+	}
+	return name, nil
 }
 
 // ============================================================================


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

https://redhat.atlassian.net/browse/RHOAIENG-53360

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidecar adds an optional model reverse-proxy with configurable upstream URL, auth, TLS, and timeouts.

* **Improvements**
  * Model auth secret and service account token mounts are isolated to the sidecar; adapter no longer mounts them.
  * Job pod templates now use an evalhub_instance_name label.
  * Job payloads may include an optional tenant field.

* **Tests**
  * Expanded tests for proxy routing, auth caching, HTTP client/timeouts, mounts, and job-config rewriting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->