### PR TITLE
refactor(tests): update FVT test and remove local/CI mode checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,18 +157,18 @@ SERVER_URL ?= http://localhost:8080
 
 FVT_TESTS ?= ./tests/features/...
 FVT_OUTPUT ?= --godog.format=junit:${PWD}/$(BIN_DIR)/junit-fvt-report.xml,pretty
-FVT_TAGS ?= --godog.tags=~@ignore && ~@mlflow
+FVT_TAGS ?= "--godog.tags=~@ignore && ~@mlflow && ~@cluster"
 
 test-fvt: $(BIN_DIR) ## Run FVT (Functional Verification Tests) using godog
 	@echo "Running FVT tests..."
-	@bash -c 'set -o pipefail; go test ${FVT_TESTS} ${FVT_OUTPUT} "${FVT_TAGS}" -v -race | ${PWD}/scripts/grcat ${PWD}/.conf.go-integration-test'
+	@bash -c 'set -o pipefail; go test ${FVT_TESTS} ${FVT_OUTPUT} ${FVT_TAGS} -v -race | ${PWD}/scripts/grcat ${PWD}/.conf.go-integration-test'
 
 test-fvt-server: start-service ## Run FVT tests using godog against a running server
 	@SERVER_URL="${SERVER_URL}" make test-fvt; status=$$?; make stop-service; exit $$status
 
 test-fvt-coverage: $(BIN_DIR)## Run integration (FVT) tests with coverage
 	@echo "Running integration (FVT) tests with coverage..."
-	@go test ${FVT_TESTS} ${FVT_OUTPUT} "${FVT_TAGS}" -v -race -coverprofile=$(BIN_DIR)/coverage-fvt.out -covermode=atomic
+	@go test ${FVT_TESTS} ${FVT_OUTPUT} ${FVT_TAGS} -v -race -coverprofile=$(BIN_DIR)/coverage-fvt.out -covermode=atomic
 	@go tool cover -html=$(BIN_DIR)/coverage-fvt.out -o $(BIN_DIR)/coverage-fvt.html
 	@echo "Coverage report generated: $(BIN_DIR)/coverage-fvt.html"
 

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -345,7 +345,7 @@ Feature: Evaluation Jobs
     When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}?hard_delete=true"
     Then the response code should be 204
 
-  Scenario: Collection job with threshold zero
+  Scenario: Create threshold-zero collection then submit job and verify completion
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/collections" with body:
     """
@@ -392,6 +392,14 @@ Feature: Evaluation Jobs
         ]
     }
     """
+    Then the response code should be 201
+    And the "resource.id" field in the response should be saved as "value:collection_id"
+    And the response should contain the value "test-benchmarks-collection-threshold-zero" at path "$.name"
+    And the response should contain the value "test" at path "$.category"
+    And the response should contain the value "Collection of benchmarks for FVT" at path "$.description"
+    And the response should contain the value "0" at path "$.pass_criteria.threshold"
+    And the array at path "$.benchmarks" in the response should have length 2
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_with_collection.json"
     Then the response code should be 202
     And the response should contain the value "evaluation_job_created" at path "$.status.message.message_code"
     And the response should contain the value "pending" at path "$.status.state"

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1,8 +1,8 @@
-@evaluations @cluster
-
+@evaluations
+@cluster
 Feature: Evaluation Jobs
   As a data scientist
-  I want to create evaluation jobs
+  I want to create evaluation jobs against a running cluster
   So that I evaluate models
 
   Background:
@@ -10,7 +10,6 @@ Feature: Evaluation Jobs
 
   Scenario: Verifying results returned for Evaluation job
     Given the service is running
-    When the mode is local or CI then skip this scenario
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
     Then the response code should be 202
     And the response should contain the value "pending" at path "$.status.state"
@@ -39,7 +38,6 @@ Feature: Evaluation Jobs
 
   Scenario: Evaluation job with multiple benchmarks from same provider
     Given the service is running
-    When the mode is local or CI then skip this scenario
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_multiple_benchmark.json"
     Then the response code should be 202
     And the response should contain the value "pending" at path "$.status.state"
@@ -65,7 +63,6 @@ Feature: Evaluation Jobs
 
   Scenario: Multiple jobs can be submitted
     Given the service is running
-    When the mode is local or CI then skip this scenario
     And I set the header "X-User" to "test-user-1"
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
     Then the response code should be 202
@@ -93,7 +90,6 @@ Feature: Evaluation Jobs
 
   Scenario: Multiple jobs share same MLflow experiment
     Given the service is running
-    When the mode is local or CI then skip this scenario
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
       """
       {
@@ -153,7 +149,6 @@ Feature: Evaluation Jobs
 
   Scenario: Collection job completes successfully
     Given the service is running
-    When the mode is local or CI then skip this scenario
     When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
     Then the response code should be 201
     And the "resource.id" field in the response should be saved as "value:collection_id"
@@ -174,7 +169,6 @@ Feature: Evaluation Jobs
 
   Scenario: Evaluation job completes with multi-benchmark collection
     Given the service is running
-    When the mode is local or CI then skip this scenario
     When I send a POST request to "/api/v1/evaluations/collections" with body:
       """
       {
@@ -228,7 +222,6 @@ Feature: Evaluation Jobs
 
   Scenario: Multiple jobs sharing same collection can be submitted
     Given the service is running
-    When the mode is local or CI then skip this scenario
     When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
     Then the response code should be 201
     And the "resource.id" field in the response should be saved as "value:collection_id"
@@ -255,7 +248,6 @@ Feature: Evaluation Jobs
 
   Scenario: Collection jobs share same MLflow experiments
     Given the service is running
-    When the mode is local or CI then skip this scenario
     When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
     Then the response code should be 201
     And the "resource.id" field in the response should be saved as "value:collection_id"
@@ -314,7 +306,6 @@ Feature: Evaluation Jobs
 
   Scenario: Collection job with parameters
     Given the service is running
-    When the mode is local or CI then skip this scenario
     When I send a POST request to "/api/v1/evaluations/collections" with body:
       """
       {
@@ -353,3 +344,91 @@ Feature: Evaluation Jobs
     Then the response code should be 204
     When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}?hard_delete=true"
     Then the response code should be 204
+
+  Scenario: Collection job with threshold zero
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/collections" with body:
+    """
+    {
+        "name": "test-benchmarks-collection-threshold-zero",
+        "category": "test",
+        "description": "Collection of benchmarks for FVT",
+        "pass_criteria": {
+            "threshold": 0
+        },
+        "benchmarks": [
+            {
+                "id": "arc_easy",
+                "provider_id": "lm_evaluation_harness",
+                "primary_score": {
+                    "metric": "acc_norm",
+                    "lower_is_better": false
+                },
+                "pass_criteria": {
+                    "threshold": 0.5
+                },
+                "parameters": {
+                    "limit": 10,
+                    "num_fewshot": 0,
+                    "tokenizer": "google/flan-t5-small"
+                }
+            },
+            {
+                "id": "arc_easy",
+                "provider_id": "lm_evaluation_harness",
+                "primary_score": {
+                    "metric": "acc_norm",
+                    "lower_is_better": false
+                },
+                "pass_criteria": {
+                    "threshold": 0.5
+                },
+                "parameters": {
+                    "limit": 10,
+                    "num_fewshot": 0,
+                    "tokenizer": "google/flan-t5-small"
+                }
+            }
+        ]
+    }
+    """
+    Then the response code should be 202
+    And the response should contain the value "evaluation_job_created" at path "$.status.message.message_code"
+    And the response should contain the value "pending" at path "$.status.state"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the response should contain the value "completed" at path "$.status.state"
+    And the response should contain "results"
+    And the response should contain the value "{{value:collection_id}}" at path "$.collection.id"
+
+  Scenario: Create evaluation job with Collection
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
+    Then the response code should be 201
+    And the "resource.id" field in the response should be saved as "value:collection_id"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_with_collection.json"
+    Then the response code should be 202
+    And the response should contain the value "evaluation_job_created" at path "$.status.message.message_code"
+    And the response should contain the value "pending" at path "$.status.state"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the response should contain the value "{{value:collection_id}}" at path "$.collection.id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+    When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}"
+    Then the response code should be 204
+
+  Scenario: Create an evaluation job and wait for completion
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
+    Then the response code should be 202
+    And I wait for the evaluation job status to be "completed"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 404
+    And the response should contain the value "resource_not_found" at path "$.message_code"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 404

--- a/tests/features/evaluations.feature
+++ b/tests/features/evaluations.feature
@@ -52,21 +52,6 @@ Feature: Evaluations Endpoint
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
 
-  @cluster
-  Scenario: Create an evaluation job and wait for completion
-    Given the service is running
-    When the mode is local or CI then skip this scenario
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
-    Then the response code should be 202
-    And I wait for the evaluation job status to be "completed"
-    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
-    Then the response code should be 204
-    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
-    Then the response code should be 404
-    And the response should contain the value "resource_not_found" at path "$.message_code"
-    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
-    Then the response code should be 404
-
   Scenario: Create evaluation job missing name
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_missing_name.json"
@@ -196,26 +181,6 @@ Feature: Evaluations Endpoint
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_missing_provider_id.json"
     Then the response code should be 400
     And the response should contain the value "request_validation_failed" at path "$.message_code"
-
-  @cluster
-  Scenario: Create evaluation job with Collection
-    Given the service is running
-    When the mode is local or CI then skip this scenario
-    When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
-    Then the response code should be 201
-    And the "resource.id" field in the response should be saved as "value:collection_id"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_with_collection.json"
-    Then the response code should be 202
-    And the response should contain the value "evaluation_job_created" at path "$.status.message.message_code"
-    And the response should contain the value "pending" at path "$.status.state"
-    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
-    Then the response code should be 200
-    And the response should contain the value "{{value:collection_id}}" at path "$.collection.id"
-    And I wait for the evaluation job status to be "completed"
-    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
-    Then the response code should be 204
-    When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}"
-    Then the response code should be 204
 
   Scenario: List evaluation jobs
     Given the service is running

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -477,34 +477,6 @@ func (tc *scenarioConfig) iSendARequestTo(method, path string) error {
 	return tc.iSendARequestToWithBody(method, path, "")
 }
 
-// isLocalOrCIMode returns true when the test cannot reliably wait for evaluation job
-// completion (e.g. GitHub Actions, localhost, or in-process server). Scenarios that
-// require waiting for job completion should use the explicit step "When the mode is local or CI then skip this scenario" at the start.
-func (tc *scenarioConfig) isLocalOrCIMode() bool {
-	githubActions := os.Getenv("GITHUB_ACTIONS")
-	serverURL := os.Getenv("SERVER_URL")
-	isLocalhost := false
-	if serverURL != "" {
-		host := serverURL
-		if parsed, err := url.Parse(serverURL); err == nil && parsed.Hostname() != "" {
-			host = parsed.Hostname()
-		}
-		isLocalhost = host == "localhost" || host == "127.0.0.1" || host == "::1"
-	}
-	isLocalMode := serverURL == "" || (tc.apiFeature != nil && tc.apiFeature.server != nil)
-	return githubActions == "true" || isLocalhost || isLocalMode
-}
-
-// whenTheModeIsLocalOrCIThenSkipThisScenario skips the scenario when running in local or CI
-// mode so that scenarios requiring job completion are explicitly skipped instead of failing or timing out.
-func (tc *scenarioConfig) whenTheModeIsLocalOrCIThenSkipThisScenario() error {
-	if tc.isLocalOrCIMode() {
-		tc.logDebug("Skipping scenario: mode is local or CI (cannot wait for job completion)\n")
-		return godog.ErrSkip
-	}
-	return nil
-}
-
 func (tc *scenarioConfig) iWaitForEvaluationJobStatus(expectedStatus string) error {
 	deadline := time.Now().Add(2 * time.Minute)
 	var lastErr error
@@ -1391,7 +1363,6 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the array at path "([^"]*)" in the response should have length at least (\d+)$`, tc.theArrayAtPathInResponseShouldHaveLengthAtLeast)
 	ctx.Step(`^the array at path "([^"]*)" in the response should have length at least "([^"]*)"$`, tc.theArrayAtPathInResponseShouldHaveLengthAtLeast)
 	ctx.Step(`^I wait for the evaluation job status to be "([^"]*)"$`, tc.iWaitForEvaluationJobStatus)
-	ctx.Step(`^the mode is local or CI then skip this scenario$`, tc.whenTheModeIsLocalOrCIThenSkipThisScenario)
 	// Other steps
 	ctx.Step(`^fix this step$`, tc.fixThisStep)
 }


### PR DESCRIPTION
## What and why

Reorganize tests so that we just use godog tags for test filtering:
- Updated the FVT test commands in the Makefile to use a new tagging format for better filtering.
- Removed checks for local or CI mode from feature tests, simplifying the scenarios and ensuring they run consistently.
- Added new scenarios for evaluation jobs, including handling collections and waiting for job completion.

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Separated cluster-specific scenarios from the main test suite.
  * Removed conditional skipping for local/CI runs so those scenarios now execute consistently.
  * Added new end-to-end scenarios covering evaluation job lifecycle: creation, waiting for completion, and deletion.
  * Adjusted test tag handling so cluster-scoped scenarios are excluded by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->