### PR TITLE
fix(collections): read benchmark overrides from collection ref, not top-level benchmarks

### DIFF
--- a/internal/eval_hub/handlers/helpers.go
+++ b/internal/eval_hub/handlers/helpers.go
@@ -245,7 +245,7 @@ func GetJobBenchmarks(job *api.EvaluationJobResource, collection *api.Collection
 		}
 		var mergedBenchmarks []api.EvaluationBenchmarkConfig
 		for _, benchmark := range collection.Benchmarks {
-			benchmark := mergeBenchmarkParameters(benchmark, job.Benchmarks)
+			benchmark := mergeBenchmarkParameters(benchmark, job.Collection.Benchmarks)
 			mergedBenchmarks = append(mergedBenchmarks, benchmark)
 		}
 		return mergedBenchmarks, nil

--- a/internal/eval_hub/handlers/job_benchmarks_test.go
+++ b/internal/eval_hub/handlers/job_benchmarks_test.go
@@ -218,15 +218,17 @@ func TestGetJobBenchmarks(t *testing.T) {
 	t.Run("collection resolves and merges job parameters per benchmark", func(t *testing.T) {
 		t.Parallel()
 		job := makeJob()
-		job.Collection = &api.CollectionRef{ID: "col-1"}
-		job.Benchmarks = []api.EvaluationBenchmarkConfig{
-			{
-				ProviderID: "prov-a-ref",
-				Parameters: map[string]any{"shared": "from_job_a", "only_a": 1},
-			},
-			{
-				ProviderID: "prov-b-ref",
-				Parameters: map[string]any{"shared": "from_job_b"},
+		job.Collection = &api.CollectionRef{
+			ID: "col-1",
+			Benchmarks: []api.EvaluationBenchmarkConfig{
+				{
+					ProviderID: "prov-a-ref",
+					Parameters: map[string]any{"shared": "from_job_a", "only_a": 1},
+				},
+				{
+					ProviderID: "prov-b-ref",
+					Parameters: map[string]any{"shared": "from_job_b"},
+				},
 			},
 		}
 		collection := &api.CollectionResource{


### PR DESCRIPTION
## What and why

GetJobBenchmarks was merging per-benchmark parameter overrides from job.Benchmarks (top-level), but when a collection is set the validator rejects top-level benchmarks, making it impossible to pass overrides like tokenizer via collection.benchmarks. The fix reads from job.Collection.Benchmarks instead, which is where the API actually places them.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed benchmark configuration handling for jobs that reference collections, ensuring accurate parameter resolution and merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->