### PR TITLE
fix(deps): update Go to 1.25.9 to fix stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eval-hub/eval-hub
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1


### PR DESCRIPTION
## Summary

- Updates Go from 1.25.8 to 1.25.9 to fix 4 actively-called standard library CVEs:
  - **GO-2026-4947**: `crypto/x509` - Unexpected work during chain building (called via `auth/authentication.go`)
  - **GO-2026-4946**: `crypto/x509` - Inefficient policy validation (called via `auth/authentication.go`)
  - **GO-2026-4870**: `crypto/tls` - DoS via unauthenticated TLS 1.3 KeyUpdate record (called via server, sidecar)
  - **GO-2026-4865**: `html/template` - XSS via JsBraceDepth context tracking bugs (called via config loader, server)
- Also resolves 2 additional CVEs at package/module level (not directly called but present in imports):
  - **GO-2026-4864**: `os` - TOCTOU root escape on Linux
  - **GO-2026-4869**: `archive/tar` - Unbounded allocation for old GNU sparse

### go-toolset note

Go 1.25.9 is **not yet available** in `registry.access.redhat.com/ubi9/go-toolset` (latest is 1.25.8). The Containerfile uses the floating `go-toolset:1.25` tag, which will automatically pick up Go 1.25.9 once Red Hat publishes it. CI workflows use `actions/setup-go` with `go-version-file: "go.mod"`, which downloads Go directly from golang.org and will use 1.25.9 immediately.

### Unfixable CVEs (no patch available)

- **GO-2026-4772** (CVE-2026-33816) in `github.com/jackc/pgx/v5@v5.9.1` - No fix released yet
- **GO-2026-4771** (CVE-2026-33815) in `github.com/jackc/pgx/v5@v5.9.1` - No fix released yet

These pgx CVEs are at the package level (imported but vulnerable symbols are not called by this project's code). v5.9.1 is the latest release.

## Test plan

- [x] All unit tests pass with Go 1.25.9
- [x] `govulncheck` confirms 0 symbol-level vulnerabilities after upgrade
- [ ] Verify CI quality-checks pass
- [ ] Containerfile build will work once `go-toolset:1.25` is updated to include Go 1.25.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go language version to 1.25.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->