### PR TITLE
refactor(config): update loadProvider and loadCollection functions to return config file used

### DIFF
--- a/internal/eval_hub/config/loader.go
+++ b/internal/eval_hub/config/loader.go
@@ -83,7 +83,7 @@ func readConfig(logger *slog.Logger, name string, ext string, dirs ...string) (*
 	return configValues, err
 }
 
-func loadProvider(logger *slog.Logger, validate *validator.Validate, file string, dirs ...string) (*api.ProviderResource, error) {
+func loadProvider(logger *slog.Logger, validate *validator.Validate, file string, dirs ...string) (*api.ProviderResource, string, error) {
 	type providerConfigInternal struct {
 		ID                 string `mapstructure:"id" yaml:"id" json:"id"`
 		api.ProviderConfig `mapstructure:",squash"`
@@ -91,11 +91,11 @@ func loadProvider(logger *slog.Logger, validate *validator.Validate, file string
 	providerConfig := providerConfigInternal{}
 	configValues, err := readConfig(logger, file, "yaml", dirs...)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if err := configValues.Unmarshal(&providerConfig); err != nil {
-		return nil, err
+		return nil, configValues.ConfigFileUsed(), err
 	}
 	res := &api.ProviderResource{
 		Resource: api.Resource{
@@ -107,13 +107,13 @@ func loadProvider(logger *slog.Logger, validate *validator.Validate, file string
 
 	// validate the provider
 	if err := validate.Struct(res); err != nil {
-		return nil, err
+		return nil, configValues.ConfigFileUsed(), err
 	}
 
-	return res, nil
+	return res, configValues.ConfigFileUsed(), nil
 }
 
-func loadCollection(logger *slog.Logger, validate *validator.Validate, file string, dirs ...string) (*api.CollectionResource, error) {
+func loadCollection(logger *slog.Logger, validate *validator.Validate, file string, dirs ...string) (*api.CollectionResource, string, error) {
 	type collectionConfigInternal struct {
 		ID                   string `mapstructure:"id"`
 		api.CollectionConfig `mapstructure:",squash"`
@@ -121,11 +121,11 @@ func loadCollection(logger *slog.Logger, validate *validator.Validate, file stri
 	collectionConfig := collectionConfigInternal{}
 	configValues, err := readConfig(logger, file, "yaml", dirs...)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if err := configValues.Unmarshal(&collectionConfig); err != nil {
-		return nil, err
+		return nil, configValues.ConfigFileUsed(), err
 	}
 	res := &api.CollectionResource{
 		Resource: api.Resource{
@@ -137,10 +137,10 @@ func loadCollection(logger *slog.Logger, validate *validator.Validate, file stri
 
 	// validate the collection
 	if err := validate.Struct(res); err != nil {
-		return nil, err
+		return nil, configValues.ConfigFileUsed(), err
 	}
 
-	return res, nil
+	return res, configValues.ConfigFileUsed(), nil
 }
 
 func scanFolders(logger *slog.Logger, dirs ...string) ([]os.DirEntry, string, error) {
@@ -187,18 +187,22 @@ func LoadProviderConfigs(logger *slog.Logger, validate *validator.Validate, dirs
 			continue
 		}
 		name := strings.TrimSuffix(file.Name(), ".yaml")
-		providerConfig, err := loadProvider(logger, validate, name, dir)
+		providerConfig, fileUsed, err := loadProvider(logger, validate, name, dir)
 		if err != nil {
 			return nil, err
 		}
 
+		fileName := fileUsed
+		if fileName == "" {
+			fileName = file.Name()
+		}
 		if providerConfig.Resource.ID == "" {
-			logger.Warn("Provider config missing id, skipping", "file", file.Name())
+			logger.Warn("Provider config missing id, skipping", "file", fileName)
 			continue
 		}
 
 		providerConfigs[providerConfig.Resource.ID] = *providerConfig
-		logger.Info("Provider loaded", "provider_id", providerConfig.Resource.ID)
+		logger.Info("Provider loaded", "provider_id", providerConfig.Resource.ID, "file", fileName)
 	}
 
 	return providerConfigs, nil
@@ -225,18 +229,21 @@ func LoadCollectionConfigs(logger *slog.Logger, validate *validator.Validate, di
 			continue
 		}
 		name := strings.TrimSuffix(file.Name(), ".yaml")
-		collectionConfig, err := loadCollection(logger, validate, name, dir)
+		collectionConfig, fileUsed, err := loadCollection(logger, validate, name, dir)
 		if err != nil {
 			return nil, err
 		}
-
+		fileName := fileUsed
+		if fileName == "" {
+			fileName = file.Name()
+		}
 		if collectionConfig.Resource.ID == "" {
-			logger.Warn("Collection config missing id, skipping", "file", file.Name())
+			logger.Warn("Collection config missing id, skipping", "file", fileName)
 			continue
 		}
 
 		collectionConfigs[collectionConfig.Resource.ID] = *collectionConfig
-		logger.Info("Collection loaded", "collection_id", collectionConfig.Resource.ID)
+		logger.Info("Collection loaded", "collection_id", collectionConfig.Resource.ID, "file", fileName)
 	}
 
 	return collectionConfigs, nil

--- a/internal/eval_hub/server/authentication.go
+++ b/internal/eval_hub/server/authentication.go
@@ -23,7 +23,7 @@ func WithAuthentication(next http.Handler, logger *slog.Logger, client *kubernet
 		logger.Info("Authenticating request", "path", r.URL.Path, "method", r.Method)
 		rules := auth.FindRules(r, config)
 		if len(rules) == 0 {
-			logger.Info("No rules found for request", "path", r.URL.Path, "method", r.Method)
+			logger.Debug("No rules found for request", "path", r.URL.Path, "method", r.Method)
 			// If the endpoint and method is not mentioned in the authorization config,
 			// we skip authentication as well. Authorization will get no user info.
 			next.ServeHTTP(w, r)


### PR DESCRIPTION
## What and why

- Modified loadProvider and loadCollection functions to return the name of the configuration file used in addition to the resource and error.
- Updated related logging to include the configuration file name for better traceability.
- Changed log level from Info to Debug for cases where no rules are found in authentication to reduce log verbosity.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually
