### PR TITLE
chore: bump up memory limit for lm_evaluation_harness

### DIFF
--- a/config/providers/lm_evaluation_harness.yaml
+++ b/config/providers/lm_evaluation_harness.yaml
@@ -13,7 +13,7 @@ runtime:
     cpu_request: 100m
     memory_request: 128Mi
     cpu_limit: 500m
-    memory_limit: 1Gi
+    memory_limit: 4Gi
     env:
       - name: VAR_NAME
         value: VALUE


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for job processing from 1GB to 4GB to improve performance and system stability during evaluation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->