### PR TITLE
chore: update benchmark ID for HHH alignment in configuration files

### DIFF
--- a/config/collections/toxicity-and-ethical-principles.yaml
+++ b/config/collections/toxicity-and-ethical-principles.yaml
@@ -4,7 +4,7 @@ category: safety
 description: >
   End-to-end safety assessment covering three dimensions: toxic content generation targeting individuals or groups,
   tendency to produce false or misleading information, and alignment with ethical principles of helpfulness,
-  honesty, and harmlessness (HHH). Uses LM Evaluation Harness benchmarks toxigen, truthfulqa_mc1, and hhh_alignment.
+  honesty, and harmlessness (HHH). Uses LM Evaluation Harness benchmarks toxigen, truthfulqa_mc1, and bigbench_hhh_alignment_multiple_choice.
 tags:
   - toxicity
   - safety
@@ -42,7 +42,7 @@ benchmarks:
       # Optional secondary metric — not required to pass
       secondary_metric: mc2_acc
       secondary_threshold: 0.70
-  - id: hhh_alignment
+  - id: bigbench_hhh_alignment_multiple_choice
     provider_id: lm_evaluation_harness
     weight: 3 # High weight — safety-critical benchmark
     primary_score:

--- a/config/providers/lm_evaluation_harness.yaml
+++ b/config/providers/lm_evaluation_harness.yaml
@@ -3054,7 +3054,7 @@ benchmarks:
       lower_is_better: false
     pass_criteria:
       threshold: 0.25
-  - id: hhh_alignment
+  - id: bigbench_hhh_alignment_multiple_choice
     name: Helpfulness, honesty & harmlessness (HHH)
     description: >
       Tests whether the model selects responses that are helpful, honest, and harmless — evaluating alignment with core ethical principles across paired-response comparisons.


### PR DESCRIPTION
## What and why

- Changed benchmark ID from hhh_alignment to bigbench_hhh_alignment_multiple_choice in both toxicity-and-ethical-principles.yaml and lm_evaluation_harness.yaml to reflect the updated evaluation criteria

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HHH alignment benchmark reference in ethical principles evaluation configuration. Replaced with BigBench HHH alignment multiple choice variant while preserving all evaluation thresholds and scoring metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->