### PR TITLE
fix(deps): update dompurify to 3.4.0 to fix GHSA-39q2-94rc-95cp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "eval-hub",
       "devDependencies": {
         "@redocly/cli": "^2.26.0",
         "cucumber-html-reporter": "^7.2.0"
@@ -1391,9 +1392,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {


### PR DESCRIPTION
## Summary

- Updates `dompurify` from 3.3.3 to 3.4.0 to fix [GHSA-39q2-94rc-95cp](https://github.com/advisories/GHSA-39q2-94rc-95cp) (moderate severity: ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit evaluation)
- `dompurify` is a transitive devDependency via `cucumber-html-reporter`
- Verified `make documentation` still builds successfully with no file changes

### Additional CVE findings (not fixable at this time)

**Go standard library (4 vulnerabilities, all need Go 1.25.9):**
- GO-2026-4947: Unexpected work during chain building in `crypto/x509`
- GO-2026-4946: Inefficient policy validation in `crypto/x509`
- GO-2026-4870: TLS 1.3 KeyUpdate DoS in `crypto/tls`
- GO-2026-4865: JsBraceDepth XSS in `html/template`

> **Go 1.25.9 is not yet available in `registry.access.redhat.com/ubi9/go-toolset`.** The latest go-toolset tag is `1.25.8`. Per project policy, go.mod must not be updated until the version exists in go-toolset.

**Go module dependency:**
- GO-2026-4771 (CVE-2026-33815) in `github.com/jackc/pgx/v5@v5.9.1` — **no fix available** (v5.9.1 is the latest release)

## Test plan

- [x] `npm audit` reports 0 vulnerabilities
- [x] `make documentation` builds successfully with no changes to docs output

🤖 Generated with [Claude Code](https://claude.com/claude-code)