### PR TITLE
fix(deps): update protobufjs to 7.5.5 to fix GHSA-xq3m-2v4x-88gg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2638,9 +2638,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "cucumber-html-reporter": "^7.2.0"
   },
   "overrides": {
-    "semver": "^7.5.2"
+    "semver": "^7.5.2",
+    "protobufjs": "^7.5.5"
   },
   "scripts": {
     "lint-openapi": "redocly lint docs/src/openapi.yaml",


### PR DESCRIPTION
## Summary

- Adds npm override for `protobufjs` to `^7.5.5` to fix [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) (critical severity: arbitrary code execution)
- `protobufjs` is a transitive dependency via `@redocly/cli` → `@opentelemetry/exporter-trace-otlp-http` → `@opentelemetry/otlp-transformer` → `protobufjs`
- Verified `make documentation` still builds successfully

### Additional CVE notes

**Go stdlib vulnerabilities (GO-2026-4947, GO-2026-4946, GO-2026-4870, GO-2026-4865):** 4 vulnerabilities in `crypto/x509`, `crypto/tls`, and `html/template` are fixed in Go 1.25.9, but Go 1.25.9 is **not yet available** in `registry.access.redhat.com/ubi9/go-toolset`. The latest available go-toolset version is 1.25.8. The Go version update should be applied once go-toolset supports 1.25.9.

**npm dompurify (GHSA-39q2-94rc-95cp):** Already addressed by PR #459.

## Test plan

- [x] Verified `npm audit` no longer reports protobufjs vulnerability
- [x] Verified `make documentation` builds successfully
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints in package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->