### PR TITLE
refactor: remove unused timeout parameter from NewExecutionContext

### DIFF
--- a/internal/eval_hub/executioncontext/execution_context.go
+++ b/internal/eval_hub/executioncontext/execution_context.go
@@ -14,7 +14,7 @@ import (
 //
 // The ExecutionContext contains:
 //   - Logger: A request-scoped logger with enriched fields (request_id, method, uri, etc.)
-//   - Evaluation-specific state: model info, timeouts, retries, metadata
+//   - User and tenant from the request when present
 type ExecutionContext struct {
 	Ctx       context.Context
 	RequestID string
@@ -29,7 +29,6 @@ func NewExecutionContext(
 	ctx context.Context,
 	requestID string,
 	logger *slog.Logger,
-	timeout time.Duration,
 	user api.User,
 	tenant api.Tenant,
 ) *ExecutionContext {

--- a/internal/eval_hub/executioncontext/execution_context_test.go
+++ b/internal/eval_hub/executioncontext/execution_context_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
 	"github.com/eval-hub/eval-hub/pkg/api"
@@ -15,7 +14,7 @@ func TestNewExecutionContext(t *testing.T) {
 	logger := slog.Default()
 	user := api.User("u")
 	tenant := api.Tenant("t")
-	ec := executioncontext.NewExecutionContext(ctx, "req-1", logger, time.Minute, user, tenant)
+	ec := executioncontext.NewExecutionContext(ctx, "req-1", logger, user, tenant)
 	if ec.Ctx != ctx || ec.RequestID != "req-1" || ec.Logger != logger {
 		t.Fatalf("unexpected fields on ExecutionContext: %#v", ec)
 	}
@@ -32,7 +31,7 @@ func TestExecutionContext_WithContext(t *testing.T) {
 	next, cancel := context.WithCancel(base)
 	defer cancel()
 
-	ec := executioncontext.NewExecutionContext(base, "id", slog.Default(), 0, api.User(""), api.Tenant(""))
+	ec := executioncontext.NewExecutionContext(base, "id", slog.Default(), api.User(""), api.Tenant(""))
 	wrapped := ec.WithContext(next)
 	if wrapped.Ctx != next {
 		t.Error("WithContext should replace Ctx")

--- a/internal/eval_hub/handlers/collections_test.go
+++ b/internal/eval_hub/handlers/collections_test.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/constants"
@@ -227,7 +226,7 @@ func TestHandleListCollections(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListCollections(ctx, req, resp)
 
@@ -350,7 +349,7 @@ func TestHandleListCollections_ReturnsStoredBenchmarkURL(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListCollections(ctx, req, resp)
 
@@ -396,7 +395,7 @@ func TestHandleGetCollection_ReturnsStoredBenchmarkURL(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleGetCollection(ctx, req, resp)
 
@@ -431,7 +430,7 @@ func TestHandleListCollections_StorageError(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListCollections(ctx, req, resp)
 
@@ -476,7 +475,7 @@ func TestHandleCreateCollection(t *testing.T) {
 	req.SetBody([]byte(body))
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleCreateCollection(ctx, req, resp)
 
@@ -522,7 +521,7 @@ func TestHandleGetCollection(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleGetCollection(ctx, req, resp)
 
@@ -551,7 +550,7 @@ func TestHandleGetCollection_MissingPathParam(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleGetCollection(ctx, req, resp)
 
@@ -605,7 +604,7 @@ func TestHandleUpdateCollection(t *testing.T) {
 	req.SetBody([]byte(body))
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleUpdateCollection(ctx, req, resp)
 
@@ -696,7 +695,7 @@ func TestHandlePatchCollection_EnrichesFullBenchmarkElementBeforeStorage(t *test
 	req.SetBody([]byte(body))
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandlePatchCollection(ctx, req, resp)
 
@@ -758,7 +757,7 @@ func TestHandlePatchCollection_EnrichesFullBenchmarksArrayBeforeStorage(t *testi
 	req.SetBody([]byte(body))
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandlePatchCollection(ctx, req, resp)
 
@@ -806,7 +805,7 @@ func TestHandlePatchCollection(t *testing.T) {
 	req.SetBody([]byte(body))
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandlePatchCollection(ctx, req, resp)
 
@@ -827,7 +826,7 @@ func TestHandleDeleteCollection(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleDeleteCollection(ctx, req, resp)
 
@@ -946,7 +945,7 @@ func TestCollectionHandlers_PropagateTenantAndOwner(t *testing.T) {
 			}
 			recorder := httptest.NewRecorder()
 			resp := MockResponseWrapper{recorder: recorder}
-			ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "my-user", "my-tenant")
+			ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "my-user", "my-tenant")
 
 			tt.handler(h, ctx, req, resp)
 

--- a/internal/eval_hub/handlers/evaluations_test.go
+++ b/internal/eval_hub/handlers/evaluations_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
@@ -292,7 +291,7 @@ func TestHandleCreateEvaluationMarksFailedWhenRuntimeErrors(t *testing.T) {
 	validate := validation.NewValidator()
 
 	h := handlers.New(storage, validate, runtime, nil, nil)
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "")
 
 	req := &bodyRequest{
 		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs"),
@@ -336,7 +335,7 @@ func TestHandleCreateEvaluationSucceedsWhenRuntimeOk(t *testing.T) {
 	runtime := &fakeRuntime{}
 	validate := validation.NewValidator()
 	h := handlers.New(storage, validate, runtime, nil, nil)
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-2", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-2", logger, "test-user", "test-tenant")
 
 	req := &bodyRequest{
 		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs"),
@@ -371,7 +370,7 @@ func TestHandleCancelEvaluationWithSoftDeleteDoesNotCleanupResources(t *testing.
 	runtime := &fakeRuntime{}
 	validate := validation.NewValidator()
 	h := handlers.New(storage, validate, runtime, nil, nil)
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-3", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-3", logger, "test-user", "test-tenant")
 
 	req := &deleteRequest{
 		MockRequest: createMockRequest("DELETE", "/api/v1/evaluations/jobs/"+jobID),
@@ -413,7 +412,7 @@ func TestHandleDeleteEvaluationCleansUpResources(t *testing.T) {
 	runtime := &fakeRuntime{}
 	validate := validation.NewValidator()
 	h := handlers.New(storage, validate, runtime, nil, nil)
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-4", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-4", logger, "test-user", "test-tenant")
 
 	req := &deleteRequest{
 		MockRequest: createMockRequest("DELETE", "/api/v1/evaluations/jobs/"+jobID),
@@ -447,7 +446,7 @@ func TestHandleCreateEvaluationRejectsMissingBenchmarkID(t *testing.T) {
 		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs"),
 		body:        []byte(`{"name": "test-evaluation-job", "model":{"url":"http://test.com","name":"test"},"benchmarks":[{"provider_id":"garak"}]}`),
 	}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-3", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-3", logger, "test-user", "test-tenant")
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
 
@@ -480,7 +479,7 @@ func TestHandleCreateEvaluationRejectsMissingBenchmarks(t *testing.T) {
 			body:        []byte(body),
 		}
 
-		ctx := executioncontext.NewExecutionContext(context.Background(), fmt.Sprintf("invalid-request-body-%d", index), logger, time.Second, "test-user", "test-tenant")
+		ctx := executioncontext.NewExecutionContext(context.Background(), fmt.Sprintf("invalid-request-body-%d", index), logger, "test-user", "test-tenant")
 		index++
 		recorder := httptest.NewRecorder()
 		resp := MockResponseWrapper{recorder: recorder}
@@ -507,7 +506,7 @@ func TestHandleCreateEvaluationRejectsMissingProviderID(t *testing.T) {
 		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs"),
 		body:        []byte(`{"name": "test-evaluation-job", "model":{"url":"http://test.com","name":"test"},"benchmarks":[{"id":"bench-1"}]}`),
 	}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-4", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-4", logger, "test-user", "test-tenant")
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
 
@@ -537,7 +536,7 @@ func TestHandleCreateEvaluationRejectsInvalidProviderID(t *testing.T) {
 	runtime := &fakeRuntime{}
 	validate := validation.NewValidator()
 	h := handlers.New(storage, validate, runtime, nil, nil)
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-invalid-provider", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-invalid-provider", logger, "test-user", "test-tenant")
 
 	req := &bodyRequest{
 		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs"),
@@ -569,7 +568,7 @@ func TestHandleCreateEvaluationRejectsInvalidBenchmarkID(t *testing.T) {
 	runtime := &fakeRuntime{}
 	validate := validation.NewValidator()
 	h := handlers.New(storage, validate, runtime, nil, nil)
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-invalid-benchmark", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-invalid-benchmark", logger, "test-user", "test-tenant")
 
 	req := &bodyRequest{
 		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs"),
@@ -607,7 +606,7 @@ func TestHandleListEvaluations(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListEvaluations(ctx, req, resp)
 
@@ -647,7 +646,7 @@ func TestHandleGetEvaluation(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleGetEvaluation(ctx, req, resp)
 
@@ -675,7 +674,7 @@ func TestHandleGetEvaluation_MissingPathParam(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleGetEvaluation(ctx, req, resp)
 
@@ -718,7 +717,7 @@ func TestHandleUpdateEvaluation(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleUpdateEvaluation(ctx, reqWithPath, resp)
 
@@ -744,7 +743,7 @@ func TestHandleCreateEvaluationRejectsExperimentWhenMLflowDisabled(t *testing.T)
 	runtime := &fakeRuntime{}
 	validate := validation.NewValidator()
 	h := handlers.New(storage, validate, runtime, nil, nil)
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-mlflow-exp", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-mlflow-exp", logger, "test-user", "test-tenant")
 
 	req := &bodyRequest{
 		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs"),
@@ -783,7 +782,7 @@ func TestHandleCreateEvaluationRejectsEmptyExperimentName(t *testing.T) {
 	runtime := &fakeRuntime{}
 	validate := validation.NewValidator()
 	h := handlers.New(storage, validate, runtime, nil, nil)
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-empty-exp", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-empty-exp", logger, "test-user", "test-tenant")
 
 	req := &bodyRequest{
 		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs"),

--- a/internal/eval_hub/handlers/providers_test.go
+++ b/internal/eval_hub/handlers/providers_test.go
@@ -172,7 +172,7 @@ func TestHandleListProviders_ReturnsSystemProviders(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListProviders(ctx, req, resp)
 
@@ -222,7 +222,7 @@ func TestHandleListProviders_AppliesPaginationWhenLimitLessThanSystemProviders(t
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListProviders(ctx, req, resp)
 
@@ -311,7 +311,7 @@ func TestHandleListProviders_FilterSystemProvidersWithCommaAndPipe(t *testing.T)
 			}
 			recorder := httptest.NewRecorder()
 			resp := MockResponseWrapper{recorder: recorder}
-			ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+			ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 			h.HandleListProviders(ctx, req, resp)
 
@@ -359,7 +359,7 @@ func TestHandleListProviders_ExcludesSystemProvidersWhenParamFalse(t *testing.T)
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListProviders(ctx, req, resp)
 
@@ -398,7 +398,7 @@ func TestHandleListProviders_ExcludesBenchmarksWhenParamFalse(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListProviders(ctx, req, resp)
 
@@ -437,7 +437,7 @@ func TestHandleListProviders_ReturnsUserProvidersFromStorage(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListProviders(ctx, req, resp)
 
@@ -477,7 +477,7 @@ func TestHandleListProviders_ReturnsErrorWhenStorageFails(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListProviders(ctx, req, resp)
 
@@ -497,7 +497,7 @@ func TestHandleListProviders_Returns400WhenInvalidLimit(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleListProviders(ctx, req, resp)
 
@@ -526,7 +526,7 @@ func TestHandleListProvidersReturnsEmptyForInvalidProviderID(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleGetProvider(ctx, req, resp)
 
@@ -563,7 +563,7 @@ func TestHandleUpdateProvider(t *testing.T) {
 	req.SetBody([]byte(body))
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleUpdateProvider(ctx, req, resp)
 
@@ -601,7 +601,7 @@ func TestHandleUpdateProviderRejectsSystemProvider(t *testing.T) {
 	req.SetBody([]byte(body))
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleUpdateProvider(ctx, req, resp)
 
@@ -635,7 +635,7 @@ func TestHandlePatchProvider(t *testing.T) {
 	req.SetBody([]byte(body))
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandlePatchProvider(ctx, req, resp)
 
@@ -676,7 +676,7 @@ func TestHandlePatchProviderRejectsImmutablePaths(t *testing.T) {
 		req.SetBody([]byte(body))
 		recorder := httptest.NewRecorder()
 		resp := MockResponseWrapper{recorder: recorder}
-		ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+		ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 		h.HandlePatchProvider(ctx, req, resp)
 		if recorder.Code != 400 {
 			t.Errorf("path %q: expected 400, got %d body %s", path, recorder.Code, recorder.Body.String())
@@ -705,7 +705,7 @@ func TestHandlePatchProviderRejectsSystemProvider(t *testing.T) {
 	req.SetBody([]byte(body))
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandlePatchProvider(ctx, req, resp)
 
@@ -729,7 +729,7 @@ func TestHandleCreateProvider(t *testing.T) {
 	req.SetBody([]byte(body))
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleCreateProvider(ctx, req, resp)
 
@@ -760,7 +760,7 @@ func TestHandleDeleteProvider(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleDeleteProvider(ctx, req, resp)
 
@@ -781,7 +781,7 @@ func TestHandleDeleteProvider_MissingPathParam(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	resp := MockResponseWrapper{recorder: recorder}
-	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, time.Second, "test-user", "test-tenant")
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
 
 	h.HandleDeleteProvider(ctx, req, resp)
 

--- a/internal/eval_hub/server/execution_context.go
+++ b/internal/eval_hub/server/execution_context.go
@@ -24,10 +24,8 @@ const (
 // is called at the route level before invoking evaluation-related handlers to set up
 // request-scoped context.
 //
-// The function automatically:
-//   - Enhances the logger with request-specific fields via logging.LoggerWithRequest
-//   - Sets default timeout (60 minutes) and retry attempts (3)
-//   - Initializes an empty metadata map
+// The function automatically enhances the logger with request-specific fields via
+// logging.LoggerWithRequest.
 //
 // This enables automatic request ID tracking (from X-Global-Transaction-Id header or
 // auto-generated UUID) and structured logging with consistent request metadata.
@@ -60,7 +58,6 @@ func (s *Server) newExecutionContext(r *http.Request) *executioncontext.Executio
 		r.Context(),
 		requestID,
 		enhancedLogger,
-		3,
 		api.User(user),
 		api.Tenant(tenant))
 }


### PR DESCRIPTION
## Summary
`executioncontext.NewExecutionContext` accepted a `time.Duration` that was never stored or used to derive request deadlines. The server passed the untyped constant `3`, which Go converts to **3 nanoseconds**—a misleading API surface.

## Changes
- Remove the unused parameter from `NewExecutionContext` and update all call sites (including commented-out tests for consistency).
- Align `Server.newExecutionContext` documentation with actual behavior.
- Trim `ExecutionContext` package docs to match the struct fields.

## Testing
- `make fmt && make vet`
- `go test ./auth/... ./internal/... ./cmd/...`

Made with [Cursor](https://cursor.com)
Assisted-by; Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the internal request context initialization by removing unnecessary timeout configuration, reducing constructor complexity while maintaining all request tracking capabilities (context, request ID, logging, user and tenant information).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->