### PR TITLE
feat(http): add configurable timeouts and configurable max request body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,17 @@ make grant-permissions  # Grant permissions to user
 make clean              # Remove build artifacts and coverage files
 ```
 
+## Git commits
+
+Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, etc., with an optional scope (e.g. `feat(http): …`).
+
+When a change is assisted by Cursor, add these lines to the **end** of the commit message body (after the subject and any description), as Git trailers:
+
+```
+Assisted-by: Cursor
+Made-with: Cursor
+```
+
 ## Architecture Overview
 
 ### Project Structure
@@ -172,7 +183,7 @@ Example (matches `setupEvaluationJobsRoutes`):
 s.handleFunc(router, "/api/v1/evaluations/jobs", func(w http.ResponseWriter, r *http.Request) {
     ctx := s.newExecutionContext(r)
     resp := NewRespWrapper(w, ctx)
-    req := NewRequestWrapper(r)
+    req := s.newRequestWrapper(w, r)
     switch r.Method {
     case http.MethodPost:
         h.HandleCreateEvaluation(ctx, req, resp)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,6 +9,7 @@ service:
   # write_timeout: 15s      # http.Server WriteTimeout; omit or 0 for default (15s)
   # idle_timeout: 60s       # http.Server IdleTimeout; omit or 0 for default (60s)
   # read_header_timeout: 15s   # HTTP server ReadHeaderTimeout; omit or 0 for default (15s)
+  # max_header_bytes: 1048576    # http.Server MaxHeaderBytes; omit or 0 for default (1 MiB, net/http default)
   # max_request_body_bytes: 10485760  # default 10 MiB when omitted or 0; use -1 to disable the limit
 # These are here so that the config can be loaded from the secrets directory when needed
 secrets:
@@ -23,6 +24,7 @@ env_mappings:
   WRITE_TIMEOUT: service.write_timeout
   IDLE_TIMEOUT: service.idle_timeout
   READ_HEADER_TIMEOUT: service.read_header_timeout
+  MAX_HEADER_BYTES: service.max_header_bytes
   MAX_REQUEST_BODY_BYTES: service.max_request_body_bytes
   TLS_CERT_FILE: service.tls_cert_file
   TLS_KEY_FILE: service.tls_key_file

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,6 +5,8 @@ service:
   ready_file: "/tmp/repo-ready"
   termination_file: "/tmp/termination-log"
   disable_auth: false
+  # read_header_timeout: 15s   # HTTP server ReadHeaderTimeout; omit or 0 for default (15s)
+  # max_request_body_bytes: 10485760  # default 10 MiB when omitted or 0; use -1 to disable the limit
 # These are here so that the config can be loaded from the secrets directory when needed
 secrets:
   dir: /tmp
@@ -14,6 +16,8 @@ secrets:
 env_mappings:
   PORT: service.port
   API_HOST: service.host
+  READ_HEADER_TIMEOUT: service.read_header_timeout
+  MAX_REQUEST_BODY_BYTES: service.max_request_body_bytes
   TLS_CERT_FILE: service.tls_cert_file
   TLS_KEY_FILE: service.tls_key_file
   DB_URL: database.url

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,6 +5,9 @@ service:
   ready_file: "/tmp/repo-ready"
   termination_file: "/tmp/termination-log"
   disable_auth: false
+  # read_timeout: 15s       # http.Server ReadTimeout; omit or 0 for default (15s)
+  # write_timeout: 15s      # http.Server WriteTimeout; omit or 0 for default (15s)
+  # idle_timeout: 60s       # http.Server IdleTimeout; omit or 0 for default (60s)
   # read_header_timeout: 15s   # HTTP server ReadHeaderTimeout; omit or 0 for default (15s)
   # max_request_body_bytes: 10485760  # default 10 MiB when omitted or 0; use -1 to disable the limit
 # These are here so that the config can be loaded from the secrets directory when needed
@@ -16,6 +19,9 @@ secrets:
 env_mappings:
   PORT: service.port
   API_HOST: service.host
+  READ_TIMEOUT: service.read_timeout
+  WRITE_TIMEOUT: service.write_timeout
+  IDLE_TIMEOUT: service.idle_timeout
   READ_HEADER_TIMEOUT: service.read_header_timeout
   MAX_REQUEST_BODY_BYTES: service.max_request_body_bytes
   TLS_CERT_FILE: service.tls_cert_file

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,12 +20,6 @@ secrets:
 env_mappings:
   PORT: service.port
   API_HOST: service.host
-  READ_TIMEOUT: service.read_timeout
-  WRITE_TIMEOUT: service.write_timeout
-  IDLE_TIMEOUT: service.idle_timeout
-  READ_HEADER_TIMEOUT: service.read_header_timeout
-  MAX_HEADER_BYTES: service.max_header_bytes
-  MAX_REQUEST_BODY_BYTES: service.max_request_body_bytes
   TLS_CERT_FILE: service.tls_cert_file
   TLS_KEY_FILE: service.tls_key_file
   DB_URL: database.url

--- a/internal/eval_hub/config/config_test.go
+++ b/internal/eval_hub/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -200,6 +201,18 @@ func TestServiceConfig_HTTP(t *testing.T) {
 			t.Errorf("got read=%v write=%v idle=%v", c.EffectiveReadTimeout(), c.EffectiveWriteTimeout(), c.EffectiveIdleTimeout())
 		}
 	})
+	t.Run("EffectiveMaxHeaderBytes", func(t *testing.T) {
+		var c *config.ServiceConfig
+		if got := c.EffectiveMaxHeaderBytes(); got != http.DefaultMaxHeaderBytes {
+			t.Errorf("nil: got %d want %d", got, http.DefaultMaxHeaderBytes)
+		}
+		if got := (&config.ServiceConfig{}).EffectiveMaxHeaderBytes(); got != http.DefaultMaxHeaderBytes {
+			t.Errorf("empty: got %d want %d", got, http.DefaultMaxHeaderBytes)
+		}
+		if got := (&config.ServiceConfig{MaxHeaderBytes: 8192}).EffectiveMaxHeaderBytes(); got != 8192 {
+			t.Errorf("explicit: got %d", got)
+		}
+	})
 	t.Run("EffectiveMaxRequestBodyBytes", func(t *testing.T) {
 		var c *config.ServiceConfig
 		if got := c.EffectiveMaxRequestBodyBytes(); got != config.DefaultMaxRequestBodyBytes {
@@ -230,6 +243,9 @@ func TestServiceConfig_HTTP(t *testing.T) {
 		}
 		if err := (&config.ServiceConfig{ReadHeaderTimeout: -1}).ValidateHTTPConfig(); err == nil {
 			t.Error("negative readheader: want error")
+		}
+		if err := (&config.ServiceConfig{MaxHeaderBytes: -1}).ValidateHTTPConfig(); err == nil {
+			t.Error("negative max_header_bytes: want error")
 		}
 		if err := (&config.ServiceConfig{MaxRequestBodyBytes: -2}).ValidateHTTPConfig(); err == nil {
 			t.Error("max body < -1: want error")

--- a/internal/eval_hub/config/config_test.go
+++ b/internal/eval_hub/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 )
@@ -147,6 +148,50 @@ func TestServiceConfig_TLS(t *testing.T) {
 		}
 		if err := (&config.ServiceConfig{TLSKeyFile: "/k"}).ValidateTLSConfig(); err == nil {
 			t.Error("key only: want error")
+		}
+	})
+}
+
+func TestServiceConfig_HTTP(t *testing.T) {
+	t.Run("EffectiveReadHeaderTimeout default", func(t *testing.T) {
+		var c *config.ServiceConfig
+		if got := c.EffectiveReadHeaderTimeout(); got != 15*time.Second {
+			t.Errorf("nil ServiceConfig: got %v", got)
+		}
+		if got := (&config.ServiceConfig{}).EffectiveReadHeaderTimeout(); got != 15*time.Second {
+			t.Errorf("empty: got %v", got)
+		}
+	})
+	t.Run("EffectiveReadHeaderTimeout explicit", func(t *testing.T) {
+		c := &config.ServiceConfig{ReadHeaderTimeout: 3 * time.Second}
+		if got := c.EffectiveReadHeaderTimeout(); got != 3*time.Second {
+			t.Errorf("got %v", got)
+		}
+	})
+	t.Run("EffectiveMaxRequestBodyBytes", func(t *testing.T) {
+		var c *config.ServiceConfig
+		if got := c.EffectiveMaxRequestBodyBytes(); got != config.DefaultMaxRequestBodyBytes {
+			t.Errorf("nil: got %d", got)
+		}
+		if got := (&config.ServiceConfig{}).EffectiveMaxRequestBodyBytes(); got != config.DefaultMaxRequestBodyBytes {
+			t.Errorf("zero: got %d", got)
+		}
+		if got := (&config.ServiceConfig{MaxRequestBodyBytes: -1}).EffectiveMaxRequestBodyBytes(); got != -1 {
+			t.Errorf("unlimited: got %d", got)
+		}
+		if got := (&config.ServiceConfig{MaxRequestBodyBytes: 1024}).EffectiveMaxRequestBodyBytes(); got != 1024 {
+			t.Errorf("explicit: got %d", got)
+		}
+	})
+	t.Run("ValidateHTTPConfig", func(t *testing.T) {
+		if err := (&config.ServiceConfig{}).ValidateHTTPConfig(); err != nil {
+			t.Errorf("empty: %v", err)
+		}
+		if err := (&config.ServiceConfig{ReadHeaderTimeout: -1}).ValidateHTTPConfig(); err == nil {
+			t.Error("negative readheader: want error")
+		}
+		if err := (&config.ServiceConfig{MaxRequestBodyBytes: -2}).ValidateHTTPConfig(); err == nil {
+			t.Error("max body < -1: want error")
 		}
 	})
 }

--- a/internal/eval_hub/config/config_test.go
+++ b/internal/eval_hub/config/config_test.go
@@ -168,6 +168,38 @@ func TestServiceConfig_HTTP(t *testing.T) {
 			t.Errorf("got %v", got)
 		}
 	})
+	t.Run("EffectiveReadWriteIdleTimeout defaults", func(t *testing.T) {
+		var c *config.ServiceConfig
+		if got := c.EffectiveReadTimeout(); got != 15*time.Second {
+			t.Errorf("ReadTimeout nil: got %v", got)
+		}
+		if got := c.EffectiveWriteTimeout(); got != 15*time.Second {
+			t.Errorf("WriteTimeout nil: got %v", got)
+		}
+		if got := c.EffectiveIdleTimeout(); got != 60*time.Second {
+			t.Errorf("IdleTimeout nil: got %v", got)
+		}
+		empty := &config.ServiceConfig{}
+		if got := empty.EffectiveReadTimeout(); got != 15*time.Second {
+			t.Errorf("ReadTimeout empty: got %v", got)
+		}
+		if got := empty.EffectiveWriteTimeout(); got != 15*time.Second {
+			t.Errorf("WriteTimeout empty: got %v", got)
+		}
+		if got := empty.EffectiveIdleTimeout(); got != 60*time.Second {
+			t.Errorf("IdleTimeout empty: got %v", got)
+		}
+	})
+	t.Run("EffectiveReadWriteIdleTimeout explicit", func(t *testing.T) {
+		c := &config.ServiceConfig{
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 45 * time.Second,
+			IdleTimeout:  120 * time.Second,
+		}
+		if c.EffectiveReadTimeout() != 30*time.Second || c.EffectiveWriteTimeout() != 45*time.Second || c.EffectiveIdleTimeout() != 120*time.Second {
+			t.Errorf("got read=%v write=%v idle=%v", c.EffectiveReadTimeout(), c.EffectiveWriteTimeout(), c.EffectiveIdleTimeout())
+		}
+	})
 	t.Run("EffectiveMaxRequestBodyBytes", func(t *testing.T) {
 		var c *config.ServiceConfig
 		if got := c.EffectiveMaxRequestBodyBytes(); got != config.DefaultMaxRequestBodyBytes {
@@ -186,6 +218,15 @@ func TestServiceConfig_HTTP(t *testing.T) {
 	t.Run("ValidateHTTPConfig", func(t *testing.T) {
 		if err := (&config.ServiceConfig{}).ValidateHTTPConfig(); err != nil {
 			t.Errorf("empty: %v", err)
+		}
+		if err := (&config.ServiceConfig{ReadTimeout: -1}).ValidateHTTPConfig(); err == nil {
+			t.Error("negative read_timeout: want error")
+		}
+		if err := (&config.ServiceConfig{WriteTimeout: -1}).ValidateHTTPConfig(); err == nil {
+			t.Error("negative write_timeout: want error")
+		}
+		if err := (&config.ServiceConfig{IdleTimeout: -1}).ValidateHTTPConfig(); err == nil {
+			t.Error("negative idle_timeout: want error")
 		}
 		if err := (&config.ServiceConfig{ReadHeaderTimeout: -1}).ValidateHTTPConfig(); err == nil {
 			t.Error("negative readheader: want error")

--- a/internal/eval_hub/config/service_config.go
+++ b/internal/eval_hub/config/service_config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -30,6 +31,9 @@ type ServiceConfig struct {
 	// ReadHeaderTimeout is the HTTP server ReadHeaderTimeout (time to read request headers).
 	// Zero means use the default (15s), matching the server read timeout.
 	ReadHeaderTimeout time.Duration `mapstructure:"read_header_timeout,omitempty"`
+	// MaxHeaderBytes is http.Server MaxHeaderBytes (bytes allowed for request headers). Zero uses
+	// [http.DefaultMaxHeaderBytes] (1 MiB), matching the net/http default when unset.
+	MaxHeaderBytes int `mapstructure:"max_header_bytes,omitempty"`
 	// MaxRequestBodyBytes limits incoming request bodies via http.MaxBytesReader.
 	// Zero or unset uses DefaultMaxRequestBodyBytes. -1 disables the limit.
 	MaxRequestBodyBytes int64 `mapstructure:"max_request_body_bytes,omitempty"`
@@ -89,6 +93,15 @@ func (c *ServiceConfig) EffectiveReadHeaderTimeout() time.Duration {
 	return c.ReadHeaderTimeout
 }
 
+// EffectiveMaxHeaderBytes returns http.Server MaxHeaderBytes. When unset or non-positive, returns
+// [http.DefaultMaxHeaderBytes] (1 MiB).
+func (c *ServiceConfig) EffectiveMaxHeaderBytes() int {
+	if c == nil || c.MaxHeaderBytes <= 0 {
+		return http.DefaultMaxHeaderBytes
+	}
+	return c.MaxHeaderBytes
+}
+
 // EffectiveMaxRequestBodyBytes returns the limit for http.MaxBytesReader; -1 means no limit.
 func (c *ServiceConfig) EffectiveMaxRequestBodyBytes() int64 {
 	if c == nil {
@@ -119,6 +132,9 @@ func (c *ServiceConfig) ValidateHTTPConfig() error {
 	}
 	if c.ReadHeaderTimeout < 0 {
 		return fmt.Errorf("service.read_header_timeout must not be negative")
+	}
+	if c.MaxHeaderBytes < 0 {
+		return fmt.Errorf("service.max_header_bytes must not be negative")
 	}
 	if c.MaxRequestBodyBytes < -1 {
 		return fmt.Errorf("service.max_request_body_bytes must be -1 (unlimited) or >= 0")

--- a/internal/eval_hub/config/service_config.go
+++ b/internal/eval_hub/config/service_config.go
@@ -21,6 +21,12 @@ type ServiceConfig struct {
 	DisableAuth     bool   `mapstructure:"disable_auth,omitempty"`
 	TLSCertFile     string `mapstructure:"tls_cert_file,omitempty"`
 	TLSKeyFile      string `mapstructure:"tls_key_file,omitempty"`
+	// ReadTimeout is http.Server ReadTimeout (entire request read). Zero uses default (15s).
+	ReadTimeout time.Duration `mapstructure:"read_timeout,omitempty"`
+	// WriteTimeout is http.Server WriteTimeout. Zero uses default (15s).
+	WriteTimeout time.Duration `mapstructure:"write_timeout,omitempty"`
+	// IdleTimeout is http.Server IdleTimeout. Zero uses default (60s).
+	IdleTimeout time.Duration `mapstructure:"idle_timeout,omitempty"`
 	// ReadHeaderTimeout is the HTTP server ReadHeaderTimeout (time to read request headers).
 	// Zero means use the default (15s), matching the server read timeout.
 	ReadHeaderTimeout time.Duration `mapstructure:"read_header_timeout,omitempty"`
@@ -43,7 +49,36 @@ func (c *ServiceConfig) ValidateTLSConfig() error {
 	return nil
 }
 
-const defaultReadHeaderTimeout = 15 * time.Second
+const (
+	defaultReadTimeout       = 15 * time.Second
+	defaultWriteTimeout      = 15 * time.Second
+	defaultIdleTimeout       = 60 * time.Second
+	defaultReadHeaderTimeout = 15 * time.Second
+)
+
+// EffectiveReadTimeout returns http.Server ReadTimeout. When unset or non-positive, returns 15s.
+func (c *ServiceConfig) EffectiveReadTimeout() time.Duration {
+	if c == nil || c.ReadTimeout <= 0 {
+		return defaultReadTimeout
+	}
+	return c.ReadTimeout
+}
+
+// EffectiveWriteTimeout returns http.Server WriteTimeout. When unset or non-positive, returns 15s.
+func (c *ServiceConfig) EffectiveWriteTimeout() time.Duration {
+	if c == nil || c.WriteTimeout <= 0 {
+		return defaultWriteTimeout
+	}
+	return c.WriteTimeout
+}
+
+// EffectiveIdleTimeout returns http.Server IdleTimeout. When unset or non-positive, returns 60s.
+func (c *ServiceConfig) EffectiveIdleTimeout() time.Duration {
+	if c == nil || c.IdleTimeout <= 0 {
+		return defaultIdleTimeout
+	}
+	return c.IdleTimeout
+}
 
 // EffectiveReadHeaderTimeout returns the HTTP server ReadHeaderTimeout. When unset or
 // non-positive, it matches the default read timeout used by the server (15s).
@@ -72,6 +107,15 @@ func (c *ServiceConfig) EffectiveMaxRequestBodyBytes() int64 {
 func (c *ServiceConfig) ValidateHTTPConfig() error {
 	if c == nil {
 		return nil
+	}
+	if c.ReadTimeout < 0 {
+		return fmt.Errorf("service.read_timeout must not be negative")
+	}
+	if c.WriteTimeout < 0 {
+		return fmt.Errorf("service.write_timeout must not be negative")
+	}
+	if c.IdleTimeout < 0 {
+		return fmt.Errorf("service.idle_timeout must not be negative")
 	}
 	if c.ReadHeaderTimeout < 0 {
 		return fmt.Errorf("service.read_header_timeout must not be negative")

--- a/internal/eval_hub/config/service_config.go
+++ b/internal/eval_hub/config/service_config.go
@@ -1,6 +1,12 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
+
+// DefaultMaxRequestBodyBytes is applied when service.max_request_body_bytes is omitted or zero.
+const DefaultMaxRequestBodyBytes int64 = 10 << 20 // 10 MiB
 
 type ServiceConfig struct {
 	Version         string `mapstructure:"version,omitempty"`
@@ -15,6 +21,12 @@ type ServiceConfig struct {
 	DisableAuth     bool   `mapstructure:"disable_auth,omitempty"`
 	TLSCertFile     string `mapstructure:"tls_cert_file,omitempty"`
 	TLSKeyFile      string `mapstructure:"tls_key_file,omitempty"`
+	// ReadHeaderTimeout is the HTTP server ReadHeaderTimeout (time to read request headers).
+	// Zero means use the default (15s), matching the server read timeout.
+	ReadHeaderTimeout time.Duration `mapstructure:"read_header_timeout,omitempty"`
+	// MaxRequestBodyBytes limits incoming request bodies via http.MaxBytesReader.
+	// Zero or unset uses DefaultMaxRequestBodyBytes. -1 disables the limit.
+	MaxRequestBodyBytes int64 `mapstructure:"max_request_body_bytes,omitempty"`
 }
 
 // TLSEnabled returns true when both TLS cert and key paths are configured.
@@ -27,6 +39,45 @@ func (c *ServiceConfig) TLSEnabled() bool {
 func (c *ServiceConfig) ValidateTLSConfig() error {
 	if (c.TLSCertFile != "") != (c.TLSKeyFile != "") {
 		return fmt.Errorf("partial TLS config: both TLSCertFile and TLSKeyFile must be provided")
+	}
+	return nil
+}
+
+const defaultReadHeaderTimeout = 15 * time.Second
+
+// EffectiveReadHeaderTimeout returns the HTTP server ReadHeaderTimeout. When unset or
+// non-positive, it matches the default read timeout used by the server (15s).
+func (c *ServiceConfig) EffectiveReadHeaderTimeout() time.Duration {
+	if c == nil || c.ReadHeaderTimeout <= 0 {
+		return defaultReadHeaderTimeout
+	}
+	return c.ReadHeaderTimeout
+}
+
+// EffectiveMaxRequestBodyBytes returns the limit for http.MaxBytesReader; -1 means no limit.
+func (c *ServiceConfig) EffectiveMaxRequestBodyBytes() int64 {
+	if c == nil {
+		return DefaultMaxRequestBodyBytes
+	}
+	if c.MaxRequestBodyBytes == -1 {
+		return -1
+	}
+	if c.MaxRequestBodyBytes == 0 {
+		return DefaultMaxRequestBodyBytes
+	}
+	return c.MaxRequestBodyBytes
+}
+
+// ValidateHTTPConfig returns an error when HTTP-related settings are invalid.
+func (c *ServiceConfig) ValidateHTTPConfig() error {
+	if c == nil {
+		return nil
+	}
+	if c.ReadHeaderTimeout < 0 {
+		return fmt.Errorf("service.read_header_timeout must not be negative")
+	}
+	if c.MaxRequestBodyBytes < -1 {
+		return fmt.Errorf("service.max_request_body_bytes must be -1 (unlimited) or >= 0")
 	}
 	return nil
 }

--- a/internal/eval_hub/constants/http_codes.go
+++ b/internal/eval_hub/constants/http_codes.go
@@ -11,6 +11,7 @@ const (
 	HTTPCodeNotFound            = 404
 	HTTPCodeMethodNotAllowed    = 405
 	HTTPCodeConflict            = 409
+	HTTPCodePayloadTooLarge     = 413
 	HTTPCodeInternalServerError = 500
 	HTTPCodeNotImplemented      = 501
 )

--- a/internal/eval_hub/messages/messages.go
+++ b/internal/eval_hub/messages/messages.go
@@ -65,6 +65,13 @@ var (
 		"job_can_not_be_updated",
 	)
 
+	// RequestBodyTooLarge The request body exceeds the maximum allowed size of {{.Limit}} bytes.
+	RequestBodyTooLarge = createMessage(
+		constants.HTTPCodePayloadTooLarge,
+		"The request body exceeds the maximum allowed size of {{.Limit}} bytes.",
+		"request_body_too_large",
+	)
+
 	// InvalidJSONRequest The request JSON is invalid: '{{.Error}}'. Please check the request and try again.
 	InvalidJSONRequest = createMessage(
 		constants.HTTPCodeBadRequest,

--- a/internal/eval_hub/server/execution_context.go
+++ b/internal/eval_hub/server/execution_context.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/http_wrappers"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
 	"github.com/eval-hub/eval-hub/internal/logging"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
@@ -70,7 +72,12 @@ type ReqWrapper struct {
 	Request *http.Request
 }
 
-func NewRequestWrapper(req *http.Request) http_wrappers.RequestWrapper {
+// NewRequestWrapper wraps the request. When maxBodyBytes is >= 0, the body is limited with
+// [http.MaxBytesReader]. Pass -1 for maxBodyBytes to disable the limit.
+func NewRequestWrapper(w http.ResponseWriter, req *http.Request, maxBodyBytes int64) http_wrappers.RequestWrapper {
+	if maxBodyBytes >= 0 {
+		req.Body = http.MaxBytesReader(w, req.Body, maxBodyBytes)
+	}
 	return &ReqWrapper{
 		Request: req,
 	}
@@ -103,6 +110,10 @@ func (r *ReqWrapper) Header(key string) string {
 func (r *ReqWrapper) BodyAsBytes() ([]byte, error) {
 	bodyBytes, err := io.ReadAll(r.Request.Body)
 	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			return nil, serviceerrors.NewServiceError(messages.RequestBodyTooLarge, "Limit", maxErr.Limit)
+		}
 		return nil, err
 	}
 

--- a/internal/eval_hub/server/execution_context_test.go
+++ b/internal/eval_hub/server/execution_context_test.go
@@ -1,17 +1,21 @@
 package server_test
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/server"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
 )
 
 func TestRequestWrapper(t *testing.T) {
 	httpRequest := httptest.NewRequest(http.MethodGet, "/api/v1/evaluations/jobs?tags=test-tag-2&tags=test-tag-3", nil)
-	requestWrapper := server.NewRequestWrapper(httpRequest)
+	rec := httptest.NewRecorder()
+	requestWrapper := server.NewRequestWrapper(rec, httpRequest, -1)
 
 	if requestWrapper.Method() != http.MethodGet {
 		t.Errorf("Expected method %s, got %s", http.MethodGet, requestWrapper.Method())
@@ -31,5 +35,25 @@ func TestRequestWrapper(t *testing.T) {
 	}
 	if !slices.Contains(tags, "test-tag-3") {
 		t.Errorf("Expected query %s, got %s", []string{"test-tag-2", "test-tag-3"}, tags)
+	}
+}
+
+func TestRequestWrapper_BodyExceedsMaxBytes(t *testing.T) {
+	body := strings.NewReader(`{"x":"` + strings.Repeat("a", 64) + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/evaluations/jobs", body)
+	rec := httptest.NewRecorder()
+	const maxBytes int64 = 32
+	rw := server.NewRequestWrapper(rec, req, maxBytes)
+
+	_, err := rw.BodyAsBytes()
+	if err == nil {
+		t.Fatal("expected error for oversized body")
+	}
+	var se *serviceerrors.ServiceError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected ServiceError, got %v", err)
+	}
+	if se.MessageCode().GetStatusCode() != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected status 413, got %d", se.MessageCode().GetStatusCode())
 	}
 }

--- a/internal/eval_hub/server/server.go
+++ b/internal/eval_hub/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/constants"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/http_wrappers"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/runtimes/k8s"
 	"github.com/eval-hub/eval-hub/internal/platform"
@@ -180,6 +181,10 @@ func (s *Server) loggerWithRequest(r *http.Request) (string, *slog.Logger) {
 	return requestID, enhancedLogger
 }
 
+func (s *Server) newRequestWrapper(w http.ResponseWriter, r *http.Request) http_wrappers.RequestWrapper {
+	return NewRequestWrapper(w, r, s.serviceConfig.Service.EffectiveMaxRequestBodyBytes())
+}
+
 func (s *Server) handleFunc(router *http.ServeMux, pattern string, handler func(http.ResponseWriter, *http.Request)) {
 	s.handle(router, pattern, http.HandlerFunc(handler))
 }
@@ -201,7 +206,7 @@ func (s *Server) setupHealthRoutes(h *handlers.Handlers, router *http.ServeMux) 
 	s.handleFunc(router, "/api/v1/health", func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
-		req := NewRequestWrapper(r)
+		req := s.newRequestWrapper(w, r)
 		switch req.Method() {
 		case http.MethodGet:
 			h.HandleHealth(ctx, req, resp, s.serviceConfig.Service.Build, s.serviceConfig.Service.BuildDate)
@@ -215,7 +220,7 @@ func (s *Server) setupEvaluationJobsRoutes(h *handlers.Handlers, router *http.Se
 	s.handleFunc(router, "/api/v1/evaluations/jobs", func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
-		req := NewRequestWrapper(r)
+		req := s.newRequestWrapper(w, r)
 		switch r.Method {
 		case http.MethodPost:
 			h.HandleCreateEvaluation(ctx, req, resp)
@@ -231,7 +236,7 @@ func (s *Server) setupEvaluationJobEventsRoutes(h *handlers.Handlers, router *ht
 	s.handleFunc(router, fmt.Sprintf("/api/v1/evaluations/jobs/{%s}/events", constants.PATH_PARAMETER_JOB_ID), func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
-		req := NewRequestWrapper(r)
+		req := s.newRequestWrapper(w, r)
 		switch r.Method {
 		case http.MethodPost:
 			h.HandleUpdateEvaluation(ctx, req, resp)
@@ -245,7 +250,7 @@ func (s *Server) setupEvaluationJobRoutes(h *handlers.Handlers, router *http.Ser
 	s.handleFunc(router, fmt.Sprintf("/api/v1/evaluations/jobs/{%s}", constants.PATH_PARAMETER_JOB_ID), func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
-		req := NewRequestWrapper(r)
+		req := s.newRequestWrapper(w, r)
 		switch r.Method {
 		case http.MethodGet:
 			h.HandleGetEvaluation(ctx, req, resp)
@@ -261,7 +266,7 @@ func (s *Server) setupCollectionsRoutes(h *handlers.Handlers, router *http.Serve
 	s.handleFunc(router, "/api/v1/evaluations/collections", func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
-		req := NewRequestWrapper(r)
+		req := s.newRequestWrapper(w, r)
 		switch r.Method {
 		case http.MethodPost:
 			h.HandleCreateCollection(ctx, req, resp)
@@ -277,7 +282,7 @@ func (s *Server) setupCollectionRoutes(h *handlers.Handlers, router *http.ServeM
 	s.handleFunc(router, fmt.Sprintf("/api/v1/evaluations/collections/{%s}", constants.PATH_PARAMETER_COLLECTION_ID), func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
-		req := NewRequestWrapper(r)
+		req := s.newRequestWrapper(w, r)
 		switch r.Method {
 		case http.MethodGet:
 			h.HandleGetCollection(ctx, req, resp)
@@ -297,7 +302,7 @@ func (s *Server) setupProvidersRoutes(h *handlers.Handlers, router *http.ServeMu
 	s.handleFunc(router, "/api/v1/evaluations/providers", func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
-		req := NewRequestWrapper(r)
+		req := s.newRequestWrapper(w, r)
 		switch r.Method {
 		case http.MethodGet:
 			h.HandleListProviders(ctx, req, resp)
@@ -313,7 +318,7 @@ func (s *Server) setupProviderRoutes(h *handlers.Handlers, router *http.ServeMux
 	s.handleFunc(router, fmt.Sprintf("/api/v1/evaluations/providers/{%s}", constants.PATH_PARAMETER_PROVIDER_ID), func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
-		req := NewRequestWrapper(r)
+		req := s.newRequestWrapper(w, r)
 		switch r.Method {
 		case http.MethodGet:
 			h.HandleGetProvider(ctx, req, resp)
@@ -333,7 +338,7 @@ func (s *Server) setupOpenAPIRoutes(h *handlers.Handlers, router *http.ServeMux)
 	s.handleFunc(router, "/openapi.yaml", func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
-		req := NewRequestWrapper(r)
+		req := s.newRequestWrapper(w, r)
 		switch r.Method {
 		case http.MethodGet:
 			h.HandleOpenAPI(ctx, req, resp)
@@ -347,7 +352,7 @@ func (s *Server) setupDocsRoutes(h *handlers.Handlers, router *http.ServeMux) {
 	s.handleFunc(router, "/docs", func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
-		req := NewRequestWrapper(r)
+		req := s.newRequestWrapper(w, r)
 		switch r.Method {
 		case http.MethodGet:
 			h.HandleDocs(ctx, req, resp)
@@ -431,6 +436,9 @@ func (s *Server) SetupRoutes() (http.Handler, error) {
 }
 
 func (s *Server) Start() error {
+	if err := s.serviceConfig.Service.ValidateHTTPConfig(); err != nil {
+		return err
+	}
 	if err := s.serviceConfig.Service.ValidateTLSConfig(); err != nil {
 		return err
 	}
@@ -445,11 +453,12 @@ func (s *Server) Start() error {
 	}
 	addr := net.JoinHostPort(host, strconv.Itoa(s.port))
 	s.httpServer = &http.Server{
-		Addr:         addr,
-		Handler:      handler,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		Addr:              addr,
+		Handler:           handler,
+		ReadTimeout:       15 * time.Second,
+		ReadHeaderTimeout: s.serviceConfig.Service.EffectiveReadHeaderTimeout(),
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 			MaxVersion: tls.VersionTLS13,

--- a/internal/eval_hub/server/server.go
+++ b/internal/eval_hub/server/server.go
@@ -458,6 +458,7 @@ func (s *Server) Start() error {
 		ReadHeaderTimeout: s.serviceConfig.Service.EffectiveReadHeaderTimeout(),
 		WriteTimeout:      s.serviceConfig.Service.EffectiveWriteTimeout(),
 		IdleTimeout:       s.serviceConfig.Service.EffectiveIdleTimeout(),
+		MaxHeaderBytes:    s.serviceConfig.Service.EffectiveMaxHeaderBytes(),
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 			MaxVersion: tls.VersionTLS13,

--- a/internal/eval_hub/server/server.go
+++ b/internal/eval_hub/server/server.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/eval-hub/eval-hub/auth"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
@@ -455,10 +454,10 @@ func (s *Server) Start() error {
 	s.httpServer = &http.Server{
 		Addr:              addr,
 		Handler:           handler,
-		ReadTimeout:       15 * time.Second,
+		ReadTimeout:       s.serviceConfig.Service.EffectiveReadTimeout(),
 		ReadHeaderTimeout: s.serviceConfig.Service.EffectiveReadHeaderTimeout(),
-		WriteTimeout:      15 * time.Second,
-		IdleTimeout:       60 * time.Second,
+		WriteTimeout:      s.serviceConfig.Service.EffectiveWriteTimeout(),
+		IdleTimeout:       s.serviceConfig.Service.EffectiveIdleTimeout(),
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 			MaxVersion: tls.VersionTLS13,


### PR DESCRIPTION
## What and why

- Set http.Server ReadHeaderTimeout from service.read_header_timeout (default 15s).
- Wrap request bodies with http.MaxBytesReader using service.max_request_body_bytes (default 10 MiB; -1 disables the limit). Map oversized reads to HTTP 413 with request_body_too_large.
- Add service.read_timeout, write_timeout, and idle_timeout with defaults matching previous hardcoded values (15s, 15s, 60s). Wire http.Server from Effective* helpers; validate non-negative durations.
- Add service.max_header_bytes; omit or 0 uses http.DefaultMaxHeaderBytes (1 MiB).
- Document Conventional Commits and Cursor trailers in CLAUDE.md.

Assisted-by: Cursor
Made-with: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP server configuration options for read/write timeouts, idle timeout, header limits, and maximum request body size.
  * Implemented request body size validation with descriptive error messages when limits are exceeded.

* **Tests**
  * Added comprehensive test coverage for HTTP configuration validation.

* **Documentation**
  * Updated Git commit conventions documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->