### PR TITLE
refactor(sql): remove TODO comments from PatchProvider function

### DIFF
--- a/internal/eval_hub/storage/sql/providers.go
+++ b/internal/eval_hub/storage/sql/providers.go
@@ -159,13 +159,6 @@ func (s *sqlStorage) updateProviderTransactional(txn *sql.Tx, providerID string,
 func (s *sqlStorage) PatchProvider(id string, patches *api.Patch) (*api.ProviderResource, error) {
 	var updated *api.ProviderResource
 	err := s.withTransaction("patch provider", id, func(txn *sql.Tx) error {
-		// TODO: verify the patches and return a validation error if they are on invalid fields
-		//for _, patch := range *patches {
-		//if isImmutablePatchPath(patch.Path) {
-		//	return se.NewServiceError(messages.InvalidJSONRequest, "Type", "provider", "Error", "Invalid patch path")
-		//}
-		//}
-
 		persisted, err := s.getUserProviderTransactional(txn, id)
 		if err != nil {
 			return err


### PR DESCRIPTION
## What and why

- Removed commented-out TODOs related to patch validation in the PatchProvider function to clean up the code and improve readability.

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually
