### PR TITLE
chore: update Containerfile and swagger doc and dependencies

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -48,7 +48,7 @@ FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:late
 # Create user and app directory
 RUN groupadd -g 1000 evalhub && \
     useradd -u 1000 -g evalhub -s /bin/bash -m evalhub && \
-    mkdir -p /app/config && \
+    mkdir -p /app/docs && \
     chown -R evalhub:evalhub /app
 
 # Copy both binaries from builder
@@ -56,11 +56,8 @@ COPY --from=builder --chown=evalhub:evalhub /build/eval-hub /app/eval-hub
 COPY --from=builder --chown=evalhub:evalhub /build/eval-runtime-sidecar /app/eval-runtime-sidecar
 COPY --from=builder --chown=evalhub:evalhub /build/eval-runtime-init /app/eval-runtime-init
 
-
-# The config file should not really be part of the image.
-COPY --chown=evalhub:evalhub config/config.yaml /app/config/config.yaml
-COPY --chown=evalhub:evalhub config/providers /app/config/providers
-COPY --chown=evalhub:evalhub config/collections /app/config/collections
+# The swagger source files required for the openapi.yaml and docs
+COPY --chown=evalhub:evalhub docs/openapi.* /app/docs/
 
 # Set working directory
 WORKDIR /app
@@ -88,6 +85,7 @@ LABEL org.opencontainers.image.title="eval-hub" \
       org.opencontainers.image.vendor="eval-hub"
 
 # Health check removed - wget not available without package installation
+HEALTHCHECK NONE
 
 # Run the binary
 CMD ["/app/eval-hub"]

--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ generate-public-docs: ${REDOCLY_CLI}
 
 verify-api-docs: ${REDOCLY_CLI}
 	${REDOCLY_CLI} lint
-	@echo "Tip: open docs/openapi.yaml in Swagger Editor (such as https://editor.swagger.io/) to automatically inspect the rendered spec."
+	@echo "Tip: open docs/openapi.yaml in Swagger Editor (such as https://editor.swagger.io/) to automatically inspect the rendered spec or open the file docs/index.html."
 
 generate-ignore-file: ${REDOCLY_CLI}
 	${REDOCLY_CLI} lint --generate-ignore-file ./docs/src/openapi.yaml

--- a/internal/eval_hub/handlers/handlers_test.go
+++ b/internal/eval_hub/handlers/handlers_test.go
@@ -39,6 +39,7 @@ func createMockRequest(method string, uri string) *MockRequest {
 type MockRequest struct {
 	TestMethod string
 	TestURI    string
+	TestPath   string
 	headers    map[string]string
 }
 
@@ -51,6 +52,9 @@ func (r *MockRequest) URI() string {
 }
 
 func (r *MockRequest) Path() string {
+	if r.TestPath != "" {
+		return r.TestPath
+	}
 	return ""
 }
 

--- a/internal/eval_hub/handlers/openapi.go
+++ b/internal/eval_hub/handlers/openapi.go
@@ -19,64 +19,62 @@ var (
 	}
 )
 
-func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper) {
+func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper, dirs ...string) {
+	found := func(contents []byte, contentType string) {
+		w.SetHeader("Content-Type", contentType)
+		for key, value := range noCacheHeaders {
+			w.SetHeader(key, value)
+		}
+		w.Write(contents)
+	}
+
 	// Determine content type based on Accept header
 	file := "openapi.yaml"
 	contentType := "application/yaml"
-
 	if strings.Contains(r.Header("Accept"), "application/json") {
 		file = "openapi.json"
 		contentType = "application/json"
 	}
 
-	// Find the OpenAPI spec file relative to the working directory
-	// Try multiple possible locations
-	possiblePaths := []string{
-		filepath.Join("docs", file),
-		filepath.Join("..", "docs", file),
-		filepath.Join("..", "..", "docs", file),
-		filepath.Join("..", "..", "..", "docs", file),
+	// start by trying to find it relative to the executable (when running in a cluster)
+	exePath, _ := os.Executable()
+	if exePath != "" {
+		exeDir := filepath.Dir(exePath)
+		specPath := filepath.Join(exeDir, "docs", file)
+		contents, err := os.ReadFile(specPath)
+		if err == nil {
+			found(contents, contentType)
+			return
+		}
 	}
 
+	if len(dirs) == 0 {
+		dirs = []string{
+			filepath.Join("docs"),
+			filepath.Join("..", "docs"),
+			filepath.Join("..", "..", "docs"),
+			filepath.Join("..", "..", "..", "docs"),
+		}
+	}
+
+	// Find the OpenAPI spec file relative to the working directory
 	var paths []string
-	var spec []byte
-	var err error
-	for _, path := range possiblePaths {
-		absPath, aerr := filepath.Abs(path)
+	for _, dir := range dirs {
+		absPath, aerr := filepath.Abs(filepath.Join(dir, file))
 		if aerr != nil {
-			ctx.Logger.Error("Failed to get absolute path for OpenAPI spec", "path", path, "error", aerr.Error())
+			ctx.Logger.Error("Failed to get absolute path for OpenAPI spec", "path", absPath, "error", aerr.Error())
 			continue
 		}
 		paths = append(paths, absPath)
-		spec, err = os.ReadFile(absPath)
+		contents, err := os.ReadFile(absPath)
 		if err == nil {
-			break
+			found(contents, contentType)
+			return
 		}
 	}
 
-	if err != nil {
-		// If file not found, try to find it relative to the executable
-		exePath, _ := os.Executable()
-		if exePath != "" {
-			exeDir := filepath.Dir(exePath)
-			specPath := filepath.Join(exeDir, "docs", file)
-			paths = append(paths, specPath)
-			spec, err = os.ReadFile(specPath)
-		}
-	}
-
-	if err != nil {
-		ctx.Logger.Error("Failed to read OpenAPI spec", "paths", paths, "error", err.Error())
-		w.ErrorWithMessageCode(ctx.RequestID, messages.InternalServerError, "Error", err.Error())
-		return
-	}
-
-	w.SetHeader("Content-Type", contentType)
-	for key, value := range noCacheHeaders {
-		w.SetHeader(key, value)
-	}
-
-	w.Write(spec)
+	ctx.Logger.Error("Failed to read OpenAPI spec", "paths", strings.Join(paths, ", "))
+	w.ErrorWithMessageCode(ctx.RequestID, messages.InternalServerError, "Error", "Failed to read OpenAPI spec")
 }
 
 func (h *Handlers) HandleDocs(ctx *executioncontext.ExecutionContext, r http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper) {

--- a/internal/eval_hub/handlers/openapi.go
+++ b/internal/eval_hub/handlers/openapi.go
@@ -10,13 +10,22 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 )
 
-func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper) {
+var (
+	noCacheHeaders = map[string]string{
+		"Cache-Control": "no-cache, no-store, must-revalidate",
+		"Pragma":        "no-cache",
+		"Expires":       "0",
+	}
+)
 
+func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper) {
 	// Determine content type based on Accept header
+	file := "openapi.yaml"
 	accept := r.Header("Accept")
 	contentType := "application/yaml"
 	if strings.Contains(accept, "application/json") {
 		contentType = "application/json"
+		file = "openapi.json"
 	}
 
 	w.SetHeader("Content-Type", contentType)
@@ -24,10 +33,10 @@ func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_
 	// Find the OpenAPI spec file relative to the working directory
 	// Try multiple possible locations
 	possiblePaths := []string{
-		filepath.Join("docs", "openapi.yaml"),
-		filepath.Join("..", "docs", "openapi.yaml"),
-		filepath.Join("..", "..", "docs", "openapi.yaml"),
-		filepath.Join("..", "..", "..", "docs", "openapi.yaml"),
+		filepath.Join("docs", file),
+		filepath.Join("..", "docs", file),
+		filepath.Join("..", "..", "docs", file),
+		filepath.Join("..", "..", "..", "docs", file),
 	}
 
 	var paths []string
@@ -51,7 +60,7 @@ func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_
 		exePath, _ := os.Executable()
 		if exePath != "" {
 			exeDir := filepath.Dir(exePath)
-			specPath := filepath.Join(exeDir, "docs", "openapi.yaml")
+			specPath := filepath.Join(exeDir, "docs", file)
 			paths = append(paths, specPath)
 			spec, err = os.ReadFile(specPath)
 		}
@@ -67,15 +76,19 @@ func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_
 }
 
 func (h *Handlers) HandleDocs(ctx *executioncontext.ExecutionContext, r http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper) {
+	// Get the base URL for the OpenAPI spec (so without the "/docs" path)
+	baseURL := strings.TrimSuffix(r.URI(), r.Path())
 
-	// Get the base URL for the OpenAPI spec
-	baseURL := r.URI()
+	swaggerVersion := "5.32.4"
+	if r.Header("SWAGGER_VERSION") != "" {
+		swaggerVersion = r.Header("SWAGGER_VERSION")
+	}
 
 	html := `<!DOCTYPE html>
 <html>
 <head>
-  <title>Eval Hub Backend Service API Documentation</title>
-  <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui.css" />
+  <title>Eval Hub API Documentation</title>
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@` + swaggerVersion + `/swagger-ui.css" />
   <style>
     html {
       box-sizing: border-box;
@@ -93,8 +106,8 @@ func (h *Handlers) HandleDocs(ctx *executioncontext.ExecutionContext, r http_wra
 </head>
 <body>
   <div id="swagger-ui"></div>
-  <script src="https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui-bundle.js"></script>
-  <script src="https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui-standalone-preset.js"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@` + swaggerVersion + `/swagger-ui-bundle.js"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@` + swaggerVersion + `/swagger-ui-standalone-preset.js"></script>
   <script>
     window.onload = function() {
       const ui = SwaggerUIBundle({
@@ -115,6 +128,9 @@ func (h *Handlers) HandleDocs(ctx *executioncontext.ExecutionContext, r http_wra
 </body>
 </html>`
 
+	for key, value := range noCacheHeaders {
+		w.SetHeader(key, value)
+	}
 	w.SetHeader("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(html))
 }

--- a/internal/eval_hub/handlers/openapi.go
+++ b/internal/eval_hub/handlers/openapi.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"html/template"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,6 +84,7 @@ func (h *Handlers) HandleDocs(ctx *executioncontext.ExecutionContext, r http_wra
 	if r.Header("SWAGGER_VERSION") != "" {
 		swaggerVersion = r.Header("SWAGGER_VERSION")
 	}
+	swaggerVersion = template.HTMLEscapeString(swaggerVersion)
 
 	html := `<!DOCTYPE html>
 <html>

--- a/internal/eval_hub/handlers/openapi.go
+++ b/internal/eval_hub/handlers/openapi.go
@@ -22,14 +22,12 @@ var (
 func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper) {
 	// Determine content type based on Accept header
 	file := "openapi.yaml"
-	accept := r.Header("Accept")
 	contentType := "application/yaml"
-	if strings.Contains(accept, "application/json") {
-		contentType = "application/json"
-		file = "openapi.json"
-	}
 
-	w.SetHeader("Content-Type", contentType)
+	if strings.Contains(r.Header("Accept"), "application/json") {
+		file = "openapi.json"
+		contentType = "application/json"
+	}
 
 	// Find the OpenAPI spec file relative to the working directory
 	// Try multiple possible locations
@@ -71,6 +69,11 @@ func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_
 		ctx.Logger.Error("Failed to read OpenAPI spec", "paths", paths, "error", err.Error())
 		w.ErrorWithMessageCode(ctx.RequestID, messages.InternalServerError, "Error", err.Error())
 		return
+	}
+
+	w.SetHeader("Content-Type", contentType)
+	for key, value := range noCacheHeaders {
+		w.SetHeader(key, value)
 	}
 
 	w.Write(spec)

--- a/internal/eval_hub/handlers/openapi_test.go
+++ b/internal/eval_hub/handlers/openapi_test.go
@@ -1,27 +1,22 @@
 package handlers_test
 
 import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
 )
 
 func TestHandleOpenAPI(t *testing.T) {
 	h := handlers.New(nil, nil, nil, nil, nil)
-
-	// Ensure the OpenAPI file exists for testing
-	apiPath := filepath.Join("..", "..", "docs", "openapi.yaml")
-	if _, err := os.Stat(apiPath); os.IsNotExist(err) {
-		// Try alternative path
-		apiPath = "docs/openapi.yaml"
-		if _, err := os.Stat(apiPath); os.IsNotExist(err) {
-			t.Skip("OpenAPI spec file not found, skipping test")
-		}
-	}
 
 	t.Run("GET request returns OpenAPI spec", func(t *testing.T) {
 		ctx := createExecutionContext()
@@ -64,6 +59,38 @@ func TestHandleOpenAPI(t *testing.T) {
 	})
 }
 
+func TestHandleOpenAPI_SpecNotFound(t *testing.T) {
+	h := handlers.New(nil, nil, nil, nil, nil)
+
+	base := t.TempDir()
+	deep := filepath.Join(base, "a", "b", "c", "d")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	if err := os.Chdir(deep); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &executioncontext.ExecutionContext{
+		Ctx:    context.Background(),
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	w := httptest.NewRecorder()
+	h.HandleOpenAPI(ctx, createMockRequest("GET", "/openapi.yaml"), &MockResponseWrapper{w})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json error body, got Content-Type %q", ct)
+	}
+}
+
 func TestHandleDocs(t *testing.T) {
 	h := handlers.New(nil, nil, nil, nil, nil)
 
@@ -90,6 +117,48 @@ func TestHandleDocs(t *testing.T) {
 		if !strings.Contains(body, "openapi.yaml") {
 			t.Error("Response does not reference openapi.yaml")
 		}
+
+		for _, key := range []string{"Cache-Control", "Pragma", "Expires"} {
+			if w.Header().Get(key) == "" {
+				t.Errorf("expected cache-disabling header %q to be set", key)
+			}
+		}
 	})
 
+	t.Run("SWAGGER_VERSION header selects Swagger UI asset version", func(t *testing.T) {
+		ctx := createExecutionContext()
+		req := createMockRequest("GET", "/docs")
+		req.SetHeader("SWAGGER_VERSION", "9.8.7")
+		w := httptest.NewRecorder()
+
+		h.HandleDocs(ctx, req, &MockResponseWrapper{w})
+
+		body := w.Body.String()
+		if !strings.Contains(body, "swagger-ui-dist@9.8.7") {
+			snippet := body
+			if len(snippet) > 200 {
+				snippet = snippet[:200]
+			}
+			t.Fatalf("expected custom Swagger UI version in HTML, got body snippet: %s", snippet)
+		}
+	})
+
+	t.Run("base URL strips request path for spec URL", func(t *testing.T) {
+		ctx := createExecutionContext()
+		req := &MockRequest{
+			TestMethod: "GET",
+			TestURI:    "/api/v1/docs",
+			TestPath:   "/docs",
+			headers:    map[string]string{},
+		}
+		w := httptest.NewRecorder()
+
+		h.HandleDocs(ctx, req, &MockResponseWrapper{w})
+
+		body := w.Body.String()
+		want := `url: "/api/v1/openapi.yaml"`
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in HTML, got: %s", want, body)
+		}
+	})
 }

--- a/internal/eval_hub/handlers/openapi_test.go
+++ b/internal/eval_hub/handlers/openapi_test.go
@@ -143,6 +143,25 @@ func TestHandleDocs(t *testing.T) {
 		}
 	})
 
+	t.Run("SWAGGER_VERSION header can not insert malicious code", func(t *testing.T) {
+		badScript := `<script>alert("Hello, world!");</script>`
+		ctx := createExecutionContext()
+		req := createMockRequest("GET", "/docs")
+		req.SetHeader("SWAGGER_VERSION", badScript)
+		w := httptest.NewRecorder()
+
+		h.HandleDocs(ctx, req, &MockResponseWrapper{w})
+
+		body := w.Body.String()
+		if !strings.Contains(body, "swagger-ui-dist@&lt;script&gt;") {
+			snippet := body
+			if len(snippet) > 200 {
+				snippet = snippet[:200]
+			}
+			t.Fatalf("expected custom Swagger UI version in HTML, got body snippet: %s", snippet)
+		}
+	})
+
 	t.Run("base URL strips request path for spec URL", func(t *testing.T) {
 		ctx := createExecutionContext()
 		req := &MockRequest{

--- a/internal/eval_hub/handlers/openapi_test.go
+++ b/internal/eval_hub/handlers/openapi_test.go
@@ -67,21 +67,16 @@ func TestHandleOpenAPI_SpecNotFound(t *testing.T) {
 	if err := os.MkdirAll(deep, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldWd) })
-	if err := os.Chdir(deep); err != nil {
-		t.Fatal(err)
-	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(base)
+	})
 
 	ctx := &executioncontext.ExecutionContext{
 		Ctx:    context.Background(),
 		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	w := httptest.NewRecorder()
-	h.HandleOpenAPI(ctx, createMockRequest("GET", "/openapi.yaml"), &MockResponseWrapper{w})
+	h.HandleOpenAPI(ctx, createMockRequest("GET", "/openapi.yaml"), &MockResponseWrapper{w}, deep)
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, w.Code)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@redocly/cli": "^2.28.0",
+        "@redocly/cli": "^2.28.1",
         "cucumber-html-reporter": "^7.2.0"
       }
     },
@@ -711,9 +711,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.28.0.tgz",
-      "integrity": "sha512-hAHtMjo4fLdLqZXtZwQqlwGnAiOzEAh7EPbE01rs9j7cewj2btOXrGQW8v6Eg3gDh+i77/DOxxazRWvZ/zAa7w==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.28.1.tgz",
+      "integrity": "sha512-gDi0+vC905YHrtGD3WCP86gW44JdXQb0fu4128tVFpgfh5T65tFZkhs2xoPqLJn7RCtkndQ+rSwyXcALKoao0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -722,8 +722,8 @@
         "@opentelemetry/sdk-trace-node": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
         "@redocly/cli-otel": "0.1.2",
-        "@redocly/openapi-core": "2.28.0",
-        "@redocly/respect-core": "2.28.0",
+        "@redocly/openapi-core": "2.28.1",
+        "@redocly/respect-core": "2.28.1",
         "abort-controller": "^3.0.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
@@ -787,9 +787,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.28.0.tgz",
-      "integrity": "sha512-Htpp4PsjKMgEuMT9iJu4iuFFzWCDe8FylvpGaQEA5D7jZXWv+8XvnqhpGCKN2cM/n/Uri2QfqNdw0JlKIC59sg==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.28.1.tgz",
+      "integrity": "sha512-PXulQY+lUJzeLWfhtJ8UPBFaMvlPDvW/dkozDhUAlYDotEYNMOaKFbJxKcrPCtRYtZ0TJsh5MohdcDLCBAJbFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -810,16 +810,16 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.28.0.tgz",
-      "integrity": "sha512-svjCRzXsj/EyN7chfB9pTVYvWT1+hlOqMkZVlkrH6PqFKXAHYeP47YRW9+3omUSDBd1Ph4A4J4NBUW1PRph5+g==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.28.1.tgz",
+      "integrity": "sha512-r8sf7damvSviJwVif4hZVP/Qw7ciLgwLvHVy9AsUWxWh6JQtTZpV2/lJB681bqjn+GM9EMzhcNL1rBUo4K6Uyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.0",
-        "@redocly/openapi-core": "2.28.0",
+        "@redocly/openapi-core": "2.28.1",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",
@@ -1391,9 +1391,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -2638,9 +2638,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@redocly/cli": "^2.28.0",
+    "@redocly/cli": "^2.28.1",
     "cucumber-html-reporter": "^7.2.0"
   },
   "overrides": {


### PR DESCRIPTION
## What and why

- Updated the Containerfile to create a new /app/docs directory and copy OpenAPI source files into it.
- Removed the previous configuration file copying.
- Modified Makefile to include a tip for opening the generated index.html for documentation.
- Bumped @redocly/cli and related dependencies to version 2.28.1 in package.json and package-lock.json.
- Adjusted OpenAPI handler to support both YAML and JSON responses, and added no-cache headers for documentation responses.

Assisted-by: Cursor

## Type

- [ ] feat
- [x] fix
- [x] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API spec served as YAML or JSON based on client Accept header
  * Swagger UI version selectable via request header; docs responses include no-cache headers

* **Documentation**
  * Makefile message updated to suggest opening rendered docs/index.html

* **Tests**
  * Added tests for missing spec handling, docs rendering, versioning, escaping, and prefixed paths

* **Chores**
  * Container image build adjusted; static config removed and docs assets relocated; health check disabled
* **Chores**
  * Development dependency version bump
<!-- end of auto-generated comment: release notes by coderabbit.ai -->