### PR TITLE
fix(test): remove redundant cancellation step from evaluation scenario

### DIFF
--- a/tests/features/evaluations.feature
+++ b/tests/features/evaluations.feature
@@ -602,11 +602,6 @@ Feature: Evaluations Endpoint
         "required": ["limit", "first", "total_count", "items"]
       }
     """
-    When I send a POST request to "/api/v1/evaluations/jobs/{id}/events" with body "file:/evaluation_job_status_event_cancelled.json"
-    Then the response code should be 204
-    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
-    Then the response code should be 200
-    And the response should contain the value "cancelled" at path "$.status.state"
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
 


### PR DESCRIPTION
The cancel-before-delete step is unnecessary since hard_delete works regardless of job state.

## What and why
Prior to this fix: Consider two sequence of steps:
1. The job_id was updated to cancelled state with `events` endpoint
2. For local mode (as well as k8s), `DeleteEvaluationJobResources` is only called for Cancel job if the state is not already cancel, and it was already cancelled.

This left the `/tmp/evalhub-jobs/<job-id>` uncleaned as the state was already put in cancelled state.

This does not address if cancelled event update should be allowed or not. It address the part for the test case , so not no leftover files-dirs are present after test run

Assisted-by: Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually
`make test-fvt`

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test coverage for job cancellation event handling in evaluation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->