### PR TITLE
chore: remove SERVICE_URL env var dependency from runtimes

### DIFF
--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_test.go
@@ -54,7 +54,7 @@ func TestRunEvaluationJobCreatesResources(t *testing.T) {
 		t.Skip("set K8S_INTEGRATION_TEST=1 to run against a real cluster")
 	}
 	const apiTimeout = 15 * time.Second
-	t.Setenv("SERVICE_URL", "http://eval-hub")
+
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	helper, err := NewKubernetesHelper()
 	if err != nil {
@@ -188,7 +188,6 @@ func TestCreateBenchmarkResourcesDuplicateBenchmarkIDDoesNotCollide(t *testing.T
 	if os.Getenv("K8S_INTEGRATION_TEST") != "1" {
 		t.Skip("set K8S_INTEGRATION_TEST=1 to run against a real cluster")
 	}
-	t.Setenv("SERVICE_URL", "http://eval-hub")
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	helper, err := NewKubernetesHelper()
 	if err != nil {
@@ -273,7 +272,7 @@ func TestCreateBenchmarkResourcesSetsAnnotationsIntegration(t *testing.T) {
 	if os.Getenv("K8S_INTEGRATION_TEST") != "1" {
 		t.Skip("set K8S_INTEGRATION_TEST=1 to run against a real cluster")
 	}
-	t.Setenv("SERVICE_URL", "http://eval-hub")
+
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	helper, err := NewKubernetesHelper()
 	if err != nil {
@@ -369,7 +368,7 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnvIntegration(t *testing
 	if os.Getenv("K8S_INTEGRATION_TEST") != "1" {
 		t.Skip("set K8S_INTEGRATION_TEST=1 to run against a real cluster")
 	}
-	t.Setenv("SERVICE_URL", "http://eval-hub")
+
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	helper, err := NewKubernetesHelper()
 	if err != nil {
@@ -464,7 +463,7 @@ func TestCreateBenchmarkResourcesAddsInitContainerForS3TestDataIntegration(t *te
 	if os.Getenv("K8S_INTEGRATION_TEST") != "1" {
 		t.Skip("set K8S_INTEGRATION_TEST=1 to run against a real cluster")
 	}
-	t.Setenv("SERVICE_URL", "http://eval-hub")
+
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	helper, err := NewKubernetesHelper()
 	if err != nil {

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -167,7 +167,6 @@ func TestK8sRuntimeName(t *testing.T) {
 }
 
 func TestCreateBenchmarkResourcesSetsConfigMapOwner(t *testing.T) {
-	t.Setenv("SERVICE_URL", "http://service.example")
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)
 
@@ -213,7 +212,6 @@ func TestCreateBenchmarkResourcesSetsConfigMapOwner(t *testing.T) {
 }
 
 func TestCreateBenchmarkResourcesSetsAnnotations(t *testing.T) {
-	t.Setenv("SERVICE_URL", "http://service.example")
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)
 
@@ -275,7 +273,6 @@ func TestCreateBenchmarkResourcesSetsAnnotations(t *testing.T) {
 }
 
 func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
-	t.Setenv("SERVICE_URL", "http://service.example")
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)
 	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "model-auth-secret"}
@@ -346,8 +343,6 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
 }
 
 func TestCreateBenchmarkResourcesAddsInitContainerForS3TestData(t *testing.T) {
-
-	t.Setenv("SERVICE_URL", "http://service.example")
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)
 	evaluation.Benchmarks[0].TestDataRef = &api.TestDataRef{
@@ -445,7 +440,6 @@ func TestCreateBenchmarkResourcesAddsInitContainerForS3TestData(t *testing.T) {
 }
 
 func TestCreateBenchmarkResourcesDeletesConfigMapOnJobFailure(t *testing.T) {
-	t.Setenv("SERVICE_URL", "http://service.example")
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)
 
@@ -477,7 +471,6 @@ func TestCreateBenchmarkResourcesDeletesConfigMapOnJobFailure(t *testing.T) {
 }
 
 func TestRunEvaluationJobMarksBenchmarkFailedOnCreateError(t *testing.T) {
-	t.Setenv("SERVICE_URL", "http://service.example")
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)
 
@@ -531,7 +524,6 @@ func TestRunEvaluationJobMarksBenchmarkFailedOnCreateError(t *testing.T) {
 }
 
 func TestRunEvaluationJobHandlesUpdateFailure(t *testing.T) {
-	t.Setenv("SERVICE_URL", "http://service.example")
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)
 

--- a/internal/eval_hub/runtimes/local/local_runtime.go
+++ b/internal/eval_hub/runtimes/local/local_runtime.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/constants"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/runtimes/shared"
@@ -74,16 +75,19 @@ func (jr *pidTracker) isCancelled(jobID string) bool {
 }
 
 type LocalRuntime struct {
-	logger  *slog.Logger
-	ctx     context.Context
-	tracker jobTracker
+	logger      *slog.Logger
+	ctx         context.Context
+	tracker     jobTracker
+	callbackURL *string
 }
 
 func NewLocalRuntime(
 	logger *slog.Logger,
+	serviceConfig *config.Config,
 ) (abstractions.Runtime, error) {
 	return &LocalRuntime{
-		logger: logger,
+		logger:      logger,
+		callbackURL: buildCallbackURL(serviceConfig),
 		tracker: &pidTracker{
 			pids:      make(map[string][]int),
 			cancelled: make(map[string]bool),
@@ -91,19 +95,37 @@ func NewLocalRuntime(
 	}, nil
 }
 
+func buildCallbackURL(serviceConfig *config.Config) *string {
+	if serviceConfig == nil || serviceConfig.Service == nil || serviceConfig.Service.Port <= 0 {
+		return nil
+	}
+	host := serviceConfig.Service.Host
+	if host == "" {
+		host = "localhost"
+	}
+	scheme := "http"
+	if serviceConfig.Service.TLSEnabled() {
+		scheme = "https"
+	}
+	u := fmt.Sprintf("%s://%s:%d", scheme, host, serviceConfig.Service.Port)
+	return &u
+}
+
 func (r *LocalRuntime) WithLogger(logger *slog.Logger) abstractions.Runtime {
 	return &LocalRuntime{
-		logger:  logger,
-		ctx:     r.ctx,
-		tracker: r.tracker,
+		logger:      logger,
+		ctx:         r.ctx,
+		tracker:     r.tracker,
+		callbackURL: r.callbackURL,
 	}
 }
 
 func (r *LocalRuntime) WithContext(ctx context.Context) abstractions.Runtime {
 	return &LocalRuntime{
-		logger:  r.logger,
-		ctx:     ctx,
-		tracker: r.tracker,
+		logger:      r.logger,
+		ctx:         ctx,
+		tracker:     r.tracker,
+		callbackURL: r.callbackURL,
 	}
 }
 
@@ -127,14 +149,9 @@ func (r *LocalRuntime) RunEvaluationJob(
 
 	r.tracker.registerJob(jobID)
 
-	var callbackURL *string
-	if serviceURL := os.Getenv("SERVICE_URL"); serviceURL != "" {
-		callbackURL = &serviceURL
-	}
-
 	for i, bench := range benchmarks {
 		go func() {
-			if err := r.runBenchmark(jobID, bench, i, evaluation, callbackURL, storage); err != nil {
+			if err := r.runBenchmark(jobID, bench, i, evaluation, r.callbackURL, storage); err != nil {
 				r.logger.Error(
 					"local runtime benchmark launch failed",
 					"error", err,

--- a/internal/eval_hub/runtimes/local/local_runtime_test.go
+++ b/internal/eval_hub/runtimes/local/local_runtime_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/runtimes/shared"
 	"github.com/eval-hub/eval-hub/pkg/api"
@@ -216,8 +217,42 @@ func TestLocalRuntimeName(t *testing.T) {
 	}
 }
 
+func TestBuildCallbackURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *config.Config
+		want   *string
+	}{
+		{name: "nil config", config: nil, want: nil},
+		{name: "nil service", config: &config.Config{}, want: nil},
+		{name: "zero port", config: &config.Config{Service: &config.ServiceConfig{Port: 0}}, want: nil},
+		{name: "host and port", config: &config.Config{Service: &config.ServiceConfig{Host: "myhost", Port: 9090}}, want: strPtr("http://myhost:9090")},
+		{name: "empty host defaults to localhost", config: &config.Config{Service: &config.ServiceConfig{Port: 8080}}, want: strPtr("http://localhost:8080")},
+		{name: "tls enabled", config: &config.Config{Service: &config.ServiceConfig{Host: "myhost", Port: 443, TLSCertFile: "/cert", TLSKeyFile: "/key"}}, want: strPtr("https://myhost:443")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildCallbackURL(tc.config)
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil, got %q", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %q, got nil", *tc.want)
+			}
+			if *got != *tc.want {
+				t.Fatalf("expected %q, got %q", *tc.want, *got)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
 func TestNewLocalRuntime(t *testing.T) {
-	rt, err := NewLocalRuntime(discardLogger())
+	rt, err := NewLocalRuntime(discardLogger(), nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -736,15 +771,15 @@ func TestRunEvaluationJobCallbackURL(t *testing.T) {
 	providers := sampleLocalProviders(providerID, fmt.Sprintf("touch %s", sentinelPath))
 	cleanupDir(t, "job-1")
 
-	t.Setenv("SERVICE_URL", "http://localhost:8080")
-
 	tctx := testContext(t)
 	logger := discardLogger()
 
+	callbackURL := "http://localhost:8080"
 	rt := &LocalRuntime{
-		logger:  logger,
-		ctx:     tctx,
-		tracker: newTracker(),
+		logger:      logger,
+		ctx:         tctx,
+		tracker:     newTracker(),
+		callbackURL: &callbackURL,
 	}
 
 	storage := &fakeStorage{logger: logger, ctx: tctx, providerConfigs: providers}
@@ -786,9 +821,6 @@ func TestRunEvaluationJobCallbackURLNotSet(t *testing.T) {
 	sentinelPath := filepath.Join(dirName, "done")
 	providers := sampleLocalProviders(providerID, fmt.Sprintf("touch %s", sentinelPath))
 	cleanupDir(t, "job-1")
-
-	// Ensure SERVICE_URL is not set
-	t.Setenv("SERVICE_URL", "")
 
 	tctx := testContext(t)
 	logger := discardLogger()

--- a/internal/eval_hub/runtimes/runtime.go
+++ b/internal/eval_hub/runtimes/runtime.go
@@ -14,7 +14,7 @@ func NewRuntime(
 	serviceConfig *config.Config,
 ) (abstractions.Runtime, error) {
 	if serviceConfig.Service.LocalMode {
-		return local.NewLocalRuntime(logger)
+		return local.NewLocalRuntime(logger, serviceConfig)
 	}
 	return k8s.NewK8sRuntime(logger, serviceConfig)
 }


### PR DESCRIPTION
Derive the local runtime callback URL from service config (host, port, TLS) at construction time instead of reading the SERVICE_URL environment variable. Remove the no-op SERVICE_URL usage from k8s runtime tests where the production code never read it.

## What and why
SERVICE_URL is not consumed by k8s runtime.
SERVICE_URL was used by local runtime to populate callback_url of job.json; This could be populated from the service config itself, removing need for SERVICE_URL

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

```
make test
make test-all
```
Before if SERVICE_URL was not pass for local mode

<img width="975" height="438" alt="Screenshot 2026-04-21 at 2 46 11 PM" src="https://github.com/user-attachments/assets/1bee950e-a60f-4e8f-8dcf-e1cdae071361" />

AFter fix:
<img width="958" height="425" alt="Screenshot 2026-04-21 at 2 46 33 PM" src="https://github.com/user-attachments/assets/ade44d04-136f-4f26-a5b5-a72efc33062e" />

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed SERVICE_URL environment variable setup from multiple test suites to align with updated configuration handling.

* **Refactor**
  * Local runtime now precomputes callback URLs from service configuration instead of building them at runtime from environment variables.
  * Updated runtime initialization to pass service configuration to local runtime constructor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->