### PR TITLE
test: add collection test scenarios for soft delete, weighted benchmarks, and OOB collections

### DIFF
--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -474,3 +474,121 @@ Feature: Collections Endpoint
     And the response should contain the value "Collection of benchmarks for FVT" at path "$.description"
     And the response should contain the value "0" at path "$.pass_criteria.threshold"
     And the array at path "$.benchmarks" in the response should have length 2
+
+  Scenario: Verify soft delete of collection
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
+    Then the response code should be 201
+    When I send a GET request to "/api/v1/evaluations/collections/{id}"
+    Then the response code should be 200
+    When I send a DELETE request to "/api/v1/evaluations/collections/{id}"
+    Then the response code should be 204
+    When I send a GET request to "/api/v1/evaluations/collections/{id}"
+    Then the response code should be 404
+    When I send a DELETE request to "/api/v1/evaluations/collections/{id}"
+    Then the response code should be 404
+  
+  Scenario: Create collection with weighted benchmarks
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/collections" with body:
+      """
+      {
+        "name": "test-multiple-benchmarks-collection",
+        "description": "Collection of benchmarks for FVT",
+        "category": "test",
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 10,
+              "num_fewshot": 3,
+              "limit": 5,
+              "tokenizer": "google/flan-t5-small",
+              "weight": 3
+            }
+          },
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small",
+              "weight": 2
+            }
+          }
+        ]
+      }
+      """
+    Then the response code should be 201
+    And the array at path "$.benchmarks" in the response should have length 2
+    And the response should contain the value "3" at path "$.benchmarks[0].parameters.weight"
+    And the response should contain the value "2" at path "$.benchmarks[1].parameters.weight"
+    When I send a GET request to "/api/v1/evaluations/collections/{id}"
+    Then the response code should be 200
+    And the response should contain the value "3" at path "$.benchmarks[0].parameters.weight"
+    And the response should contain the value "2" at path "$.benchmarks[1].parameters.weight"
+    When I send a DELETE request to "/api/v1/evaluations/collections/{id}?hard_delete=true"
+    Then the response code should be 204
+  
+  Scenario: List collections with scope=tenant
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
+    Then the response code should be 201
+    And the "resource.id" field in the response should be saved as "value:collection_id"
+    When I send a GET request to "/api/v1/evaluations/collections?scope=tenant"
+    Then the response code should be 200
+    And the response should contain the value "{{value:collection_id}}" at path "$.items[0].resource.id"
+    And the response should not contain the value "system" at path "$.items[0].resource.owner"
+    And the array at path "items" in the response should have length 1
+    When I send a GET request to "/api/v1/evaluations/collections?scope=system"
+    Then the response code should be 200
+    And the response should contain the value "system" at path "$.items[0].resource.owner"
+    And the array at path "items" in the response should have length at least 1
+    When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}?hard_delete=true"
+    Then the response code should be 204
+  
+  Scenario: Verify out of box collection retrieval by id
+    Given the service is running
+    When I send a GET request to "/api/v1/evaluations/collections/safety-and-fairness-v1"
+    Then the response code should be 200
+    And the response should contain "name" with value "Safety & Fairness"
+    And the response should contain "category" with value "safety"
+    And the response should contain "benchmarks"
+    And the array at path "benchmarks" in the response should have length 6
+    And the response should contain the value "0.758" at path "$.pass_criteria.threshold"
+    And the response should contain the value "truthfulqa_mc1" at path "$.benchmarks[0].id"
+    And the response should contain the value "toxigen" at path "$.benchmarks[1].id"
+    And the response should contain the value "winogender" at path "$.benchmarks[2].id"
+    And the response should contain the value "crows_pairs_english" at path "$.benchmarks[3].id"
+    And the response should contain the value "bbq" at path "$.benchmarks[4].id"
+    And the response should contain the value "ethics_cm" at path "$.benchmarks[5].id"
+    And the response should contain the value "2" at path "$.benchmarks[0].weight"
+    And the response should contain the value "1" at path "$.benchmarks[3].weight"
+    And the response should contain the value "3" at path "$.benchmarks[5].weight"
+ 
+  Scenario: Verify OOB Collections Are Immutable
+    Given the service is running
+    When I send a DELETE request to "/api/v1/evaluations/collections/leaderboard-v2?hard_delete=true"
+    Then the response code should be 400
+    And the response should contain the value "read_only_collection" at path "$.message_code"
+    And the response should contain the value "Collection 'leaderboard-v2' cannot be modified or deleted" at path "$.message"
+  
+  Scenario: Verify Evaluation Jobs Can Use OOB Collections
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+
+      """
+      {
+        "name": "test-evaluation-job-oob-collection",
+        "collection": {
+          "id": "toxicity-and-ethical-principles"
+        },
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the response should contain the value "toxicity-and-ethical-principles" at path "$.collection.id"

--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -565,19 +565,17 @@ Feature: Collections Endpoint
     And the response should contain the value "3" at path "$.benchmarks[0].weight"
     When I send a DELETE request to "/api/v1/evaluations/collections/{id}?hard_delete=true"
     Then the response code should be 204
-  
+
   Scenario: List collections with scope=tenant and check it returns only tenant collection
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
     Then the response code should be 201
     And the "resource.id" field in the response should be saved as "value:collection_id"
-    When I send a GET request to "/api/v1/evaluations/collections?scope=tenant"
+    When I send a GET request to "/api/v1/evaluations/collections?scope=tenant&name=test-benchmarks-collection"
     Then the response code should be 200
     And the response should contain the value "{{value:collection_id}}" at path "$.items[0].resource.id"
     And the response should not contain the value "system" at path "$.items[0].resource.owner"
     And the array at path "items" in the response should have length 1
-    When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}?hard_delete=true"
-    Then the response code should be 204
   
   Scenario: List collections with scope=system and check it returns only system collection
     Given the service is running
@@ -635,7 +633,6 @@ Feature: Collections Endpoint
   Scenario: Verify Evaluation Jobs Can Use OOB Collections
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
-
       """
       {
         "name": "test-evaluation-job-oob-collection",

--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -474,17 +474,29 @@ Feature: Collections Endpoint
     And the response should contain the value "Collection of benchmarks for FVT" at path "$.description"
     And the response should contain the value "0" at path "$.pass_criteria.threshold"
     And the array at path "$.benchmarks" in the response should have length 2
-
-  Scenario: Verify soft delete of collection
+  
+  Scenario: Verify soft delete of collection returns 204
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
     Then the response code should be 201
-    When I send a GET request to "/api/v1/evaluations/collections/{id}"
-    Then the response code should be 200
     When I send a DELETE request to "/api/v1/evaluations/collections/{id}"
     Then the response code should be 204
+  
+  Scenario: Verify soft deleted collection returns 404 on GET
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
+    Then the response code should be 201
+    When I send a DELETE request to "/api/v1/evaluations/collections/{id}"
+    Then the response code should be 204  
     When I send a GET request to "/api/v1/evaluations/collections/{id}"
     Then the response code should be 404
+  
+  Scenario: Verify DELETE on a deleted collection returns 404
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
+    Then the response code should be 201
+    When I send a DELETE request to "/api/v1/evaluations/collections/{id}"
+    Then the response code should be 204  
     When I send a DELETE request to "/api/v1/evaluations/collections/{id}"
     Then the response code should be 404
   
@@ -493,7 +505,7 @@ Feature: Collections Endpoint
     When I send a POST request to "/api/v1/evaluations/collections" with body:
       """
       {
-        "name": "test-multiple-benchmarks-collection",
+        "name": "test-multiple-weighted-collection",
         "description": "Collection of benchmarks for FVT",
         "category": "test",
         "benchmarks": [
@@ -524,14 +536,37 @@ Feature: Collections Endpoint
     And the array at path "$.benchmarks" in the response should have length 2
     And the response should contain the value "3" at path "$.benchmarks[0].weight"
     And the response should contain the value "2" at path "$.benchmarks[1].weight"
-    When I send a GET request to "/api/v1/evaluations/collections/{id}"
-    Then the response code should be 200
-    And the response should contain the value "3" at path "$.benchmarks[0].weight"
-    And the response should contain the value "2" at path "$.benchmarks[1].weight"
     When I send a DELETE request to "/api/v1/evaluations/collections/{id}?hard_delete=true"
     Then the response code should be 204
   
-  Scenario: List collections with scope=tenant
+  Scenario: Weighted benchmarks persist on GET
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/collections" with body:
+    """
+    {
+      "name": "test-weighted-collection",
+      "description": "Collection of benchmarks for FVT",
+      "category": "test",
+      "benchmarks": [
+      {
+        "id": "arc_easy",
+        "provider_id": "lm_evaluation_harness",
+        "weight": 3,
+        "parameters": {
+            "tokenizer": "google/flan-t5-small"
+          }
+        }
+       ]
+      }
+    """
+    Then the response code should be 201
+    When I send a GET request to "/api/v1/evaluations/collections/{id}"
+    Then the response code should be 200
+    And the response should contain the value "3" at path "$.benchmarks[0].weight"
+    When I send a DELETE request to "/api/v1/evaluations/collections/{id}?hard_delete=true"
+    Then the response code should be 204
+  
+  Scenario: List collections with scope=tenant and check it returns only tenant collection
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
     Then the response code should be 201
@@ -541,39 +576,62 @@ Feature: Collections Endpoint
     And the response should contain the value "{{value:collection_id}}" at path "$.items[0].resource.id"
     And the response should not contain the value "system" at path "$.items[0].resource.owner"
     And the array at path "items" in the response should have length 1
+    When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}?hard_delete=true"
+    Then the response code should be 204
+  
+  Scenario: List collections with scope=system and check it returns only system collection
+    Given the service is running
     When I send a GET request to "/api/v1/evaluations/collections?scope=system"
     Then the response code should be 200
     And the response should contain the value "system" at path "$.items[0].resource.owner"
     And the array at path "items" in the response should have length at least 1
-    When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}?hard_delete=true"
-    Then the response code should be 204
   
   Scenario: Verify out of box collection retrieval by id
     Given the service is running
     When I send a GET request to "/api/v1/evaluations/collections/safety-and-fairness-v1"
     Then the response code should be 200
+  
+  Scenario: Verify out of box collection retrieval - name and category
+    Given the service is running
+    When I send a GET request to "/api/v1/evaluations/collections/safety-and-fairness-v1"
+    Then the response code should be 200
     And the response should contain "name" with value "Safety & Fairness"
     And the response should contain "category" with value "safety"
+
+  Scenario: Verify out of box collection retrieval - threshold 
+    Given the service is running
+    When I send a GET request to "/api/v1/evaluations/collections/safety-and-fairness-v1"
+    Then the response code should be 200
+    And the response should contain the value "0.758" at path "$.pass_criteria.threshold"
+
+  Scenario: Verify out of box collection retrieval - benchmarks
+    Given the service is running
+    When I send a GET request to "/api/v1/evaluations/collections/safety-and-fairness-v1"
+    Then the response code should be 200
     And the response should contain "benchmarks"
     And the array at path "benchmarks" in the response should have length 6
-    And the response should contain the value "0.758" at path "$.pass_criteria.threshold"
     And the response should contain the value "truthfulqa_mc1" at path "$.benchmarks[0].id"
     And the response should contain the value "toxigen" at path "$.benchmarks[1].id"
     And the response should contain the value "winogender" at path "$.benchmarks[2].id"
     And the response should contain the value "crows_pairs_english" at path "$.benchmarks[3].id"
     And the response should contain the value "bbq" at path "$.benchmarks[4].id"
     And the response should contain the value "ethics_cm" at path "$.benchmarks[5].id"
+
+  Scenario: Verify out of box collection retrieval - weights 
+    Given the service is running
+    When I send a GET request to "/api/v1/evaluations/collections/safety-and-fairness-v1"
+    Then the response code should be 200
     And the response should contain the value "2" at path "$.benchmarks[0].weight"
     And the response should contain the value "1" at path "$.benchmarks[3].weight"
     And the response should contain the value "3" at path "$.benchmarks[5].weight"
- 
+
   Scenario: Verify OOB Collections Are Immutable
     Given the service is running
     When I send a DELETE request to "/api/v1/evaluations/collections/leaderboard-v2?hard_delete=true"
     Then the response code should be 400
     And the response should contain the value "read_only_collection" at path "$.message_code"
     And the response should contain the value "Collection 'leaderboard-v2' cannot be modified or deleted." at path "$.message"
-  
+
   Scenario: Verify Evaluation Jobs Can Use OOB Collections
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
@@ -592,4 +650,3 @@ Feature: Collections Endpoint
       """
     Then the response code should be 202
     And the response should contain the value "toxicity-and-ethical-principles" at path "$.collection.id"
-    

--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -500,21 +500,21 @@ Feature: Collections Endpoint
           {
             "id": "arc_easy",
             "provider_id": "lm_evaluation_harness",
+            "weight": 3,
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
               "limit": 5,
-              "tokenizer": "google/flan-t5-small",
-              "weight": 3
+              "tokenizer": "google/flan-t5-small"
             }
           },
           {
             "id": "arc_easy",
             "provider_id": "lm_evaluation_harness",
+            "weight": 2,
             "parameters": {
               "num_examples": 5,
-              "tokenizer": "google/flan-t5-small",
-              "weight": 2
+              "tokenizer": "google/flan-t5-small"
             }
           }
         ]
@@ -522,12 +522,12 @@ Feature: Collections Endpoint
       """
     Then the response code should be 201
     And the array at path "$.benchmarks" in the response should have length 2
-    And the response should contain the value "3" at path "$.benchmarks[0].parameters.weight"
-    And the response should contain the value "2" at path "$.benchmarks[1].parameters.weight"
+    And the response should contain the value "3" at path "$.benchmarks[0].weight"
+    And the response should contain the value "2" at path "$.benchmarks[1].weight"
     When I send a GET request to "/api/v1/evaluations/collections/{id}"
     Then the response code should be 200
-    And the response should contain the value "3" at path "$.benchmarks[0].parameters.weight"
-    And the response should contain the value "2" at path "$.benchmarks[1].parameters.weight"
+    And the response should contain the value "3" at path "$.benchmarks[0].weight"
+    And the response should contain the value "2" at path "$.benchmarks[1].weight"
     When I send a DELETE request to "/api/v1/evaluations/collections/{id}?hard_delete=true"
     Then the response code should be 204
   
@@ -572,7 +572,7 @@ Feature: Collections Endpoint
     When I send a DELETE request to "/api/v1/evaluations/collections/leaderboard-v2?hard_delete=true"
     Then the response code should be 400
     And the response should contain the value "read_only_collection" at path "$.message_code"
-    And the response should contain the value "Collection 'leaderboard-v2' cannot be modified or deleted" at path "$.message"
+    And the response should contain the value "Collection 'leaderboard-v2' cannot be modified or deleted." at path "$.message"
   
   Scenario: Verify Evaluation Jobs Can Use OOB Collections
     Given the service is running
@@ -592,3 +592,4 @@ Feature: Collections Endpoint
       """
     Then the response code should be 202
     And the response should contain the value "toxicity-and-ethical-principles" at path "$.collection.id"
+    


### PR DESCRIPTION

## What and why

Created more scenarios for better coverage of collections endpoint

<!-- What does this PR do and why? Link to related issues. -->

Closes #

Assisted-by: <!-- Cursor, Claude etc -->
Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x ] test / ci

## Testing

- [ x] Tests added or updated
- [ x] Tested manually
[test-20-04-2026-30.log](https://github.com/user-attachments/files/26936122/test-20-04-2026-30.log)


## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end Collections scenarios covering soft-delete (DELETE → 204, subsequent GET → 404, repeated DELETE → 404), per-benchmark weight creation and persistence with hard-delete option, list filtering by scope (tenant vs system), out-of-box collection retrieval and immutability (detailed metadata/threshold/weights, hard-delete rejected), and evaluation job creation referencing OOB collections (202 with echoed id).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->