### PR TITLE
docs: fix incorrect field names and types in MLFLOW.md payload examples

### DIFF
--- a/MLFLOW.md
+++ b/MLFLOW.md
@@ -34,9 +34,9 @@ env:
 {
   "experiment": {
     "name": "string",
-    "tags": {
-      "additionalProperties": "string"
-    }
+    "tags": [
+      {"key": "string", "value": "string"}
+    ]
   }
 }
 ```
@@ -49,26 +49,22 @@ env:
 ```json
 {
   "model": {
-    "server": "vllm",
-    "name": "meta-llama/llama-3.1-8b",
-    "configuration": {
-      "temperature": 0.1,
-      "max_tokens": 512
-    }
+    "url": "http://vllm:8000/v1",
+    "name": "meta-llama/llama-3.1-8b"
   },
   "benchmarks": [
     {
-      "benchmark_id": "arc_easy",
+      "id": "arc_easy",
       "provider_id": "lm_evaluation_harness",
-      "config": {"num_fewshot": 0}
+      "parameters": {"num_fewshot": 0}
     }
   ],
   "experiment": {
     "name": "arc-easy-evaluation",
-    "tags": {
-      "environment": "testing",
-      "model_family": "llama-3.1"
-    }
+    "tags": [
+      {"key": "environment", "value": "testing"},
+      {"key": "model_family", "value": "llama-3.1"}
+    ]
   }
 }
 ```
@@ -78,27 +74,27 @@ env:
 ```json
 {
   "model": {
-    "server": "vllm",
+    "url": "http://vllm:8000/v1",
     "name": "meta-llama/llama-3.1-8b"
   },
   "benchmarks": [
     {
-      "benchmark_id": "arc_easy",
+      "id": "arc_easy",
       "provider_id": "lm_evaluation_harness",
-      "config": {"num_fewshot": 0}
+      "parameters": {"num_fewshot": 0}
     },
     {
-      "benchmark_id": "faithfulness",
-      "provider_id": "ragas",
-      "config": {"dataset_path": "./data/test.jsonl"}
+      "id": "hellaswag",
+      "provider_id": "lighteval",
+      "parameters": {"num_fewshot": 0}
     }
   ],
   "experiment": {
     "name": "comprehensive-evaluation",
-    "tags": {
-      "evaluation_type": "comprehensive",
-      "model_version": "v1.0"
-    }
+    "tags": [
+      {"key": "evaluation_type", "value": "comprehensive"},
+      {"key": "model_version", "value": "v1.0"}
+    ]
   }
 }
 ```
@@ -108,16 +104,16 @@ env:
 ```json
 {
   "model": {
-    "server": "vllm",
+    "url": "http://vllm:8000/v1",
     "name": "meta-llama/llama-3.1-8b"
   },
   "experiment": {
     "name": "healthcare-certification",
-    "tags": {
-      "environment": "production",
-      "compliance": "healthcare",
-      "certification_level": "grade-a"
-    }
+    "tags": [
+      {"key": "environment", "value": "production"},
+      {"key": "compliance", "value": "healthcare"},
+      {"key": "certification_level", "value": "grade-a"}
+    ]
   }
 }
 ```
@@ -147,15 +143,15 @@ env:
 curl -X POST "http://eval-hub:8080/api/v1/evaluations/jobs" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": {"server": "vllm", "name": "my-model:v1.0"},
-    "benchmarks": [{"benchmark_id": "arc_easy", "provider_id": "lm_evaluation_harness"}],
+    "model": {"url": "http://vllm:8000/v1", "name": "my-model:v1.0"},
+    "benchmarks": [{"id": "arc_easy", "provider_id": "lm_evaluation_harness"}],
     "experiment": {
       "name": "ci-evaluation-'$BUILD_ID'",
-      "tags": {
-        "build_id": "'$BUILD_ID'",
-        "branch": "'$GIT_BRANCH'",
-        "commit": "'$GIT_COMMIT'"
-      }
+      "tags": [
+        {"key": "build_id", "value": "'$BUILD_ID'"},
+        {"key": "branch", "value": "'$GIT_BRANCH'"},
+        {"key": "commit", "value": "'$GIT_COMMIT'"}
+      ]
     }
   }'
 ```
@@ -165,12 +161,12 @@ curl -X POST "http://eval-hub:8080/api/v1/evaluations/jobs" \
 {
   "experiment": {
     "name": "production-monitoring-2025-01",
-    "tags": {
-      "environment": "production",
-      "monitoring": "true",
-      "alert_threshold": "0.85",
-      "team": "ml-ops"
-    }
+    "tags": [
+      {"key": "environment", "value": "production"},
+      {"key": "monitoring", "value": "true"},
+      {"key": "alert_threshold", "value": "0.85"},
+      {"key": "team", "value": "ml-ops"}
+    ]
   }
 }
 ```


### PR DESCRIPTION
All payload examples used outdated API field names that would cause 400 errors: model.server→model.url, benchmarks[].benchmark_id→benchmarks[].id, benchmarks[].config→benchmarks[].parameters. Removed non-existent model.configuration block, fixed experiment.tags from flat object to ExperimentTag array format, and replaced non-existent ragas provider reference with lighteval.

## What and why

Correct outdated MLFLOW.md documentation with the current codebase

Closes # https://redhat.atlassian.net/browse/RHOAIENG-59096

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [x] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually
Not required

## Breaking changes

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MLflow integration API documentation: experiment tags restructured to array-of-pairs format, model endpoints simplified with URL-based configuration, benchmark identifiers and parameters renamed for consistency, and all CI example requests updated to reflect these structural changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->