### PR TITLE
fix: set Job backoffLimit to 0 (no pod retries)

### DIFF
--- a/internal/eval_hub/runtimes/k8s/examples/eval-job.yaml
+++ b/internal/eval_hub/runtimes/k8s/examples/eval-job.yaml
@@ -17,7 +17,7 @@ metadata:
     eval-hub.github.io/provider_id: "lm_evaluation_harness"
     eval-hub.github.io/benchmark_id: "mmlu"
 spec:
-  backoffLimit: 3
+  backoffLimit: 0
   ttlSecondsAfterFinished: 3600
   template:
     metadata:

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -21,7 +21,7 @@ const (
 	maxK8sNameLength       = 63
 	maxK8sLabelValueLength = 63
 	defaultJobTTLSeconds   = int32(3600)
-	defaultJobBackoffLimit = int32(3)
+	defaultJobBackoffLimit = int32(0)
 	adapterContainerName   = "adapter"
 	sidecarContainerName   = "sidecar"
 	defaultSidecarPort     = int32(8080)


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes #
https://redhat.atlassian.net/browse/RHOAIENG-58361: [EvalHub] status.state reports only the first run status
https://redhat.atlassian.net/browse/RHOAIENG-58362: [EvalHub] provide a way to control the retry logic

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified evaluation job retry configuration. Jobs will no longer automatically retry on failure; all failures will be reported immediately without recovery attempts. This changes the job behavior from allowing up to three retries to zero retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->