### PR TITLE
test: add @cluster tag to evaluation job scenarios in collections and evaluations features

### DIFF
--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -630,6 +630,7 @@ Feature: Collections Endpoint
     And the response should contain the value "read_only_collection" at path "$.message_code"
     And the response should contain the value "Collection 'leaderboard-v2' cannot be modified or deleted." at path "$.message"
 
+  @cluster
   Scenario: Verify Evaluation Jobs Can Use OOB Collections
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:

--- a/tests/features/evaluations.feature
+++ b/tests/features/evaluations.feature
@@ -7,6 +7,7 @@ Feature: Evaluations Endpoint
   Background:
     Given I set the header "X-Tenant" to "{{env:X_TENANT|test-tenant}}"
 
+  @cluster
   Scenario: Create an evaluation job
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"


### PR DESCRIPTION
## What and why

This commit introduces the @cluster tag to the scenarios in both collections.feature and evaluations.feature, indicating that these tests are intended to run in a clustered environment. This enhancement improves the organization and execution of tests related to evaluation jobs and collections.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite organization and tagging for evaluation and collection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->