### PR TITLE
test: add @local tag to evaluation job scenarios in evaluations.feature

### DIFF
--- a/tests/features/evaluations.feature
+++ b/tests/features/evaluations.feature
@@ -408,6 +408,7 @@ Feature: Evaluations Endpoint
       }
     """
 
+  @local
   Scenario: Update evaluation job status with running status
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
@@ -437,6 +438,7 @@ Feature: Evaluations Endpoint
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
 
+  @local
   Scenario: Pass criteria - job and aggregate results after benchmark events
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_for_pass_criteria_test.json"
@@ -458,6 +460,7 @@ Feature: Evaluations Endpoint
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
 
+  @local
   Scenario: Pass criteria from provider - test results from provider benchmarks
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/providers" with body "file:/provider_pass_criteria_test.json"
@@ -502,6 +505,7 @@ Feature: Evaluations Endpoint
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
 
+  @local
   Scenario: Aggregate pass criteria uses collection threshold when job omits pass_criteria
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/providers" with body "file:/provider_pass_criteria_test.json"
@@ -524,6 +528,7 @@ Feature: Evaluations Endpoint
     And the response should contain the value "false" at path "$.results.test.pass"
     And the response should contain the value "0.84|0.85|0.86" at path "$.results.test.score"
 
+  @local
   Scenario: Cancel running evaluation job (soft delete)
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
@@ -568,6 +573,7 @@ Feature: Evaluations Endpoint
     When I send a POST request to "/api/v1/evaluations/jobs/unknown-id/events" with body "file:/evaluation_job_status_event_running.json"
     Then the response code should be 404
 
+  @local
   Scenario: List evaluation jobs filtered by status
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
@@ -607,6 +613,7 @@ Feature: Evaluations Endpoint
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
 
+  @local
   Scenario: Partially failed job - one benchmark completed and one failed
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_for_pass_criteria_test.json"
@@ -631,6 +638,7 @@ Feature: Evaluations Endpoint
     Then the response code should be 200
     And the response should contain the value "0" at path "$.total_count"
 
+  @local
   Scenario: List evaluation jobs with all search filters
     Given the service is running
     And there are no evaluation jobs


### PR DESCRIPTION
## What and why

This commit adds the `@local` tag to multiple scenarios in the evaluations.feature file, indicating that these tests are intended to run in a local environment. These tests call the events API and so can not be used on a running cluster.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test organization and categorization for evaluation endpoint scenarios.

---

**Note:** This release contains only internal testing infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->