### PR TITLE
test: enhance collection response validation in feature tests

### DIFF
--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -597,8 +597,9 @@ Feature: Collections Endpoint
     And the "resource.id" field in the response should be saved as "value:collection_id"
     When I send a GET request to "/api/v1/evaluations/collections?scope=tenant&name=test-benchmarks-collection"
     Then the response code should be 200
-    And the response should contain the value "{{value:collection_id}}" at path "$.items[0].resource.id"
-    And the response should not contain the value "system" at path "$.items[0].resource.owner"
+    And the response should equal the value "{{value:collection_id}}" at path "$.items[0].resource.id"
+    # Not that a tenant owner can be 'system:serviceaccount:tenant:tenant-user' so we must check for equals and not contains
+    And the response should not equal the value "system" at path "$.items[0].resource.owner"
     And the array at path "items" in the response should have length 1
   
   Scenario: List collections with scope=system and check it returns only system collection
@@ -606,7 +607,7 @@ Feature: Collections Endpoint
     And there are system collections
     When I send a GET request to "/api/v1/evaluations/collections?scope=system"
     Then the response code should be 200
-    And the response should contain the value "system" at path "$.items[0].resource.owner"
+    And the response should equal the value "system" at path "$.items[0].resource.owner"
     And the array at path "items" in the response should have length at least 1
   
   Scenario: Verify out of box collection retrieval by id

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -1022,37 +1022,41 @@ func (tc *scenarioConfig) getJsonPathValue(jsonPath string) (interface{}, error)
 }
 
 func (tc *scenarioConfig) theResponseShouldContainAtJSONPath(expectedValue string, jsonPath string) error {
-	return tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "contains")
+	_, err := tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "contains")
+	return err
 }
 
 func (tc *scenarioConfig) theResponseShouldEqualAtJSONPath(expectedValue string, jsonPath string) error {
-	return tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "==")
+	_, err := tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "==")
+	return err
 }
 
 func (tc *scenarioConfig) theResponseShouldContainAtJSONPathAtLeast(expectedValue string, jsonPath string) error {
-	return tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, ">=")
+	_, err := tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, ">=")
+	return err
 }
 
-func (tc *scenarioConfig) theResponseShouldContainAtJSONPathImpl(expectedValue string, jsonPath string, match string) error {
+func (tc *scenarioConfig) theResponseShouldContainAtJSONPathImpl(expectedValue string, jsonPath string, match string) (bool, error) {
 	expanded, err := tc.substituteValues(expectedValue)
 	if err != nil {
-		return err
+		return false, err
 	}
 	expectedValue = expanded
 
 	foundValue, err := tc.getJsonPath(jsonPath)
 	if err != nil {
-		return tc.logError(err)
+		// true because the path is not found
+		return true, tc.logError(err)
 	}
 
 	if rawExpr, ok := strings.CutPrefix(expectedValue, regexpPrefix); ok {
 		expr, err := regexp.Compile(rawExpr)
 		if err != nil {
-			return tc.logError(fmt.Errorf("invalid regex %q: %w", rawExpr, err))
+			return false, tc.logError(fmt.Errorf("invalid regex %q: %w", rawExpr, err))
 		}
 		if expr.MatchString(foundValue) {
 			tc.logDebug("Value %s matches regex %s in path %s", foundValue, rawExpr, jsonPath)
-			return nil
+			return false, nil
 		}
 	}
 
@@ -1061,51 +1065,59 @@ func (tc *scenarioConfig) theResponseShouldContainAtJSONPathImpl(expectedValue s
 		switch match {
 		case "==", "equals":
 			if foundValue == strings.TrimSpace(value) {
-				return nil
+				return false, nil
 			}
 		case "<=":
 			fv, err := strconv.ParseFloat(foundValue, 64)
 			if err != nil {
-				return tc.logError(fmt.Errorf("failed to parse found value %s as float: %w", foundValue, err))
+				return false, tc.logError(fmt.Errorf("failed to parse found value %s as float: %w", foundValue, err))
 			}
 			ex, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
 			if err != nil {
-				return tc.logError(fmt.Errorf("failed to parse expected value %s as float: %w", value, err))
+				return false, tc.logError(fmt.Errorf("failed to parse expected value %s as float: %w", value, err))
 			}
 			if fv <= ex {
-				return nil
+				return false, nil
 			}
 		case ">=":
 			fv, err := strconv.ParseFloat(foundValue, 64)
 			if err != nil {
-				return tc.logError(fmt.Errorf("failed to parse found value %s as float: %w", foundValue, err))
+				return false, tc.logError(fmt.Errorf("failed to parse found value %s as float: %w", foundValue, err))
 			}
 			ex, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
 			if err != nil {
-				return tc.logError(fmt.Errorf("failed to parse expected value %s as float: %w", value, err))
+				return false, tc.logError(fmt.Errorf("failed to parse expected value %s as float: %w", value, err))
 			}
 			if fv >= ex {
-				return nil
+				return false, nil
 			}
 		case "contains":
 			if strings.Contains(foundValue, strings.TrimSpace(value)) {
-				return nil
+				return false, nil
 			}
 		}
 	}
 
-	return tc.logError(fmt.Errorf("expected %s to be %s but was %s in %s", jsonPath, expectedValue, foundValue, asPrettyJson(string(tc.body))))
+	return true, tc.logError(fmt.Errorf("expected %s to be %s but was %s in %s", jsonPath, expectedValue, foundValue, asPrettyJson(string(tc.body))))
 }
 
 func (tc *scenarioConfig) theResponseShouldNotContainAtJSONPath(expectedValue string, jsonPath string) error {
-	if tc.theResponseShouldContainAtJSONPath(expectedValue, jsonPath) == nil {
+	notFound, err := tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "contains")
+	if !notFound {
+		if err != nil {
+			return err
+		}
 		return tc.logError(fmt.Errorf("expected %s to not contain %s but it did in %s", jsonPath, expectedValue, asPrettyJson(string(tc.body))))
 	}
 	return nil
 }
 
 func (tc *scenarioConfig) theResponseShouldNotEqualAtJSONPath(expectedValue string, jsonPath string) error {
-	if tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "==") == nil {
+	notFound, err := tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "==")
+	if !notFound {
+		if err != nil {
+			return err
+		}
 		return tc.logError(fmt.Errorf("expected %s to not equal %s but it did in %s", jsonPath, expectedValue, asPrettyJson(string(tc.body))))
 	}
 	return nil

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -1025,6 +1025,10 @@ func (tc *scenarioConfig) theResponseShouldContainAtJSONPath(expectedValue strin
 	return tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "contains")
 }
 
+func (tc *scenarioConfig) theResponseShouldEqualAtJSONPath(expectedValue string, jsonPath string) error {
+	return tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "==")
+}
+
 func (tc *scenarioConfig) theResponseShouldContainAtJSONPathAtLeast(expectedValue string, jsonPath string) error {
 	return tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, ">=")
 }
@@ -1055,7 +1059,7 @@ func (tc *scenarioConfig) theResponseShouldContainAtJSONPathImpl(expectedValue s
 	values := strings.SplitSeq(expectedValue, "|")
 	for value := range values {
 		switch match {
-		case "==":
+		case "==", "equals":
 			if foundValue == strings.TrimSpace(value) {
 				return nil
 			}
@@ -1102,7 +1106,21 @@ func (tc *scenarioConfig) theResponseShouldNotContainAtJSONPath(expectedValue st
 		expectedValue = expanded
 	}
 	if tc.theResponseShouldContainAtJSONPath(expectedValue, jsonPath) == nil {
-		return tc.logError(fmt.Errorf("expected %s to not contain %s but it did", jsonPath, expectedValue))
+		return tc.logError(fmt.Errorf("expected %s to not contain %s but it did in %s", jsonPath, expectedValue, asPrettyJson(string(tc.body))))
+	}
+	return nil
+}
+
+func (tc *scenarioConfig) theResponseShouldNotEqualAtJSONPath(expectedValue string, jsonPath string) error {
+	if strings.Contains(expectedValue, "{{") {
+		expanded, err := tc.substituteValues(expectedValue)
+		if err != nil {
+			return err
+		}
+		expectedValue = expanded
+	}
+	if tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "==") == nil {
+		return tc.logError(fmt.Errorf("expected %s to not equal %s but it did in %s", jsonPath, expectedValue, asPrettyJson(string(tc.body))))
 	}
 	return nil
 }
@@ -1405,8 +1423,10 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the response should have schema as:$`, tc.theResponseShouldHaveSchemaAs)
 	ctx.Step(`^the "([^"]*)" field in the response should be saved as "([^"]*)"$`, tc.theFieldShouldBeSaved)
 	ctx.Step(`^the response should contain the value "([^"]*)" at path "([^"]*)"$`, tc.theResponseShouldContainAtJSONPath)
+	ctx.Step(`^the response should equal the value "([^"]*)" at path "([^"]*)"$`, tc.theResponseShouldEqualAtJSONPath)
 	ctx.Step(`^the response should contain at least the value "([^"]*)" at path "([^"]*)"$`, tc.theResponseShouldContainAtJSONPathAtLeast)
 	ctx.Step(`^the response should not contain the value "([^"]*)" at path "([^"]*)"$`, tc.theResponseShouldNotContainAtJSONPath)
+	ctx.Step(`^the response should not equal the value "([^"]*)" at path "([^"]*)"$`, tc.theResponseShouldNotEqualAtJSONPath)
 	ctx.Step(`^the array at path "([^"]*)" in the response should have length (\d+)$`, tc.theArrayAtPathInResponseShouldHaveLength)
 	ctx.Step(`^the array at path "([^"]*)" in the response should have length "([^"]*)"$`, tc.theArrayAtPathInResponseShouldHaveLength)
 	ctx.Step(`^the array at path "([^"]*)" in the response should have length at least (\d+)$`, tc.theArrayAtPathInResponseShouldHaveLengthAtLeast)

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -1098,13 +1098,6 @@ func (tc *scenarioConfig) theResponseShouldContainAtJSONPathImpl(expectedValue s
 }
 
 func (tc *scenarioConfig) theResponseShouldNotContainAtJSONPath(expectedValue string, jsonPath string) error {
-	if strings.Contains(expectedValue, "{{") {
-		expanded, err := tc.substituteValues(expectedValue)
-		if err != nil {
-			return err
-		}
-		expectedValue = expanded
-	}
 	if tc.theResponseShouldContainAtJSONPath(expectedValue, jsonPath) == nil {
 		return tc.logError(fmt.Errorf("expected %s to not contain %s but it did in %s", jsonPath, expectedValue, asPrettyJson(string(tc.body))))
 	}
@@ -1112,13 +1105,6 @@ func (tc *scenarioConfig) theResponseShouldNotContainAtJSONPath(expectedValue st
 }
 
 func (tc *scenarioConfig) theResponseShouldNotEqualAtJSONPath(expectedValue string, jsonPath string) error {
-	if strings.Contains(expectedValue, "{{") {
-		expanded, err := tc.substituteValues(expectedValue)
-		if err != nil {
-			return err
-		}
-		expectedValue = expanded
-	}
 	if tc.theResponseShouldContainAtJSONPathImpl(expectedValue, jsonPath, "==") == nil {
 		return tc.logError(fmt.Errorf("expected %s to not equal %s but it did in %s", jsonPath, expectedValue, asPrettyJson(string(tc.body))))
 	}


### PR DESCRIPTION
## What and why

- Updated the collections.feature file to replace `contain` assertions with `equal` assertions for more precise response validation.
- Added comments to clarify the reasoning behind these changes.
- Introduced new step definitions in step_definitions_test.go to support equality checks, ensuring that the tests accurately verify the expected values in the API responses.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened collection assertions to use strict equality for IDs and owners.
  * Added new JSON-path equality/inequality assertion helpers and accepted "equals" as an equality alias.
  * Improved failure diagnostics for JSON-path checks by including a pretty-printed response body and clearer non-match handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->