### PR TITLE
fix(deps): bump protobufjs from 7.5.4 to 7.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "eval-hub",
       "devDependencies": {
         "@redocly/cli": "^2.28.1",
         "cucumber-html-reporter": "^7.2.0"
@@ -2652,9 +2653,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- Bumps `protobufjs` from 7.5.4 to 7.5.5 to fix **critical** CVE [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) (arbitrary code execution in protobufjs < 7.5.5)
- Verified documentation build (`make documentation`) passes with no content changes

## Additional CVEs noted

### Go standard library (go1.25.8 → go1.25.9)
The following 4 active Go standard library CVEs require upgrading to **go1.25.9**, which is **not yet available** in `registry.access.redhat.com/ubi9/go-toolset` (latest available is 1.25.8). These will need to be addressed once go-toolset publishes 1.25.9:

| CVE ID | Package | Severity | Description |
|--------|---------|----------|-------------|
| [GO-2026-4947](https://pkg.go.dev/vuln/GO-2026-4947) | crypto/x509 | — | Unexpected work during chain building |
| [GO-2026-4946](https://pkg.go.dev/vuln/GO-2026-4946) | crypto/x509 | — | Inefficient policy validation |
| [GO-2026-4870](https://pkg.go.dev/vuln/GO-2026-4870) | crypto/tls | — | TLS 1.3 KeyUpdate DoS |
| [GO-2026-4865](https://pkg.go.dev/vuln/GO-2026-4865) | html/template | — | JsBraceDepth XSS |

### npm uuid (moderate)
6 moderate `uuid` vulnerabilities ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)) exist in the `cucumber-html-reporter` dependency chain. Fixing these requires downgrading `cucumber-html-reporter` from 7.x to 5.x (breaking change), so they are deferred.

## Test plan
- [x] Ran `npm audit` — critical protobufjs CVE resolved
- [x] Ran `make documentation` — builds successfully with no content changes to docs/

🤖 Generated with [Claude Code](https://claude.ai/claude-code)