### PR TITLE
fix(docker): allow docs/openapi files through .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,6 +30,7 @@ coverage.xml
 
 # Documentation
 docs/
+!docs/openapi.*
 
 # CI/CD
 .github/


### PR DESCRIPTION
The Containerfile copies docs/openapi.* into the image, but .dockerignore excluded the entire docs/ directory, causing the Docker build to fail with "lstat /docs: no such file or directory".

## What and why

Fix the docker image build issue https://github.com/eval-hub/eval-hub/actions/runs/24874474285/job/72828579824 ; related to this change https://github.com/eval-hub/eval-hub/pull/469


Closes #

Assisted-by: Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually
Before fix
<img width="1249" height="210" alt="Screenshot 2026-04-24 at 11 54 59 AM" src="https://github.com/user-attachments/assets/9e071fc4-4318-4df3-a19f-b3b20e72f4d0" />

After fix
<img width="1239" height="169" alt="Screenshot 2026-04-24 at 11 56 41 AM" src="https://github.com/user-attachments/assets/adc11ed3-bd05-48b7-9488-46bb7195fa6d" />


## Breaking changes
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to ensure OpenAPI specification files are properly included in Docker images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->