### PR TITLE
chore: update .dockerignore and Makefile for local Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,7 +29,10 @@ coverage.xml
 .hypothesis
 
 # Documentation
+# we need to copy the final swagger files to the container
 docs/
+!docs/openapi.yaml
+!docs/openapi.json
 
 # CI/CD
 .github/
@@ -57,6 +60,7 @@ tests/
 # Build
 build/
 dist/
+bin/
 *.egg-info/
 
 # Development
@@ -78,3 +82,9 @@ containers
 
 # Documentation
 examples
+
+scripts/
+node_modules/
+package*.json
+package.json
+redocly.yaml

--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,8 @@ update-redocly-cli:
 # Local image build (same Containerfile and BUILD_DATE arg as .github/workflows/ci.yml docker-build-push; CI also sets multi-arch push and registry tags).
 DOCKER_IMAGE_LOCAL ?= eval-hub:local
 DOCKER_BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-DOCKER ?= podman # or docker
+# Container build tool: podman or docker
+DOCKER ?= podman
 
 docker-image-local: ## Build the eval-hub Docker image locally from Containerfile
 	$(DOCKER) build -f Containerfile --build-arg "BUILD_DATE=$(DOCKER_BUILD_DATE)" -t "$(DOCKER_IMAGE_LOCAL)" .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-all-platforms start-service stop-service start-sidecar stop-sidecar lint test test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet update-deps generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components fvt-report
+.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-all-platforms start-service stop-service start-sidecar stop-sidecar lint test test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet update-deps generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components fvt-report docker-image-local
 
 GOPATH := $(shell go env GOPATH)
 GOBIN := $(shell go env GOPATH)/bin
@@ -383,3 +383,11 @@ documentation: check-unused-components generate-public-docs verify-api-docs
 update-redocly-cli:
 	rm -f package-lock.json
 	npm install @redocly/cli@latest
+
+# Local image build (same Containerfile and BUILD_DATE arg as .github/workflows/ci.yml docker-build-push; CI also sets multi-arch push and registry tags).
+DOCKER_IMAGE_LOCAL ?= eval-hub:local
+DOCKER_BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+DOCKER ?= podman # or docker
+
+docker-image-local: ## Build the eval-hub Docker image locally from Containerfile
+	$(DOCKER) build -f Containerfile --build-arg "BUILD_DATE=$(DOCKER_BUILD_DATE)" -t "$(DOCKER_IMAGE_LOCAL)" .


### PR DESCRIPTION
## What and why

- Added exclusions for specific documentation files in .dockerignore to ensure final swagger files are included in the container.
- Updated Makefile to include a new target for building the Docker image locally, specifying build arguments and the use of podman or docker.

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build configuration with improved build artifact handling and cleaner build context.
  * Added configurable local Docker image building with customizable settings including build timestamp and container tool selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->