### PR TITLE
test: fail fast when evaluation job reaches terminal failure state

### DIFF
--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -548,8 +548,8 @@ func (tc *scenarioConfig) iWaitForEvaluationJobStatus(expectedStatus string) err
 			} else if status == expectedStatus {
 				return nil
 			} else {
-				// Check for terminal failure states and fail fast instead of continuing to poll
-				if status == "failed" || status == "cancelled" || status == "partially_failed" {
+				// Fail fast when the job has reached any terminal state other than the expected one.
+				if pkgapi.OverallState(status).IsTerminalState() {
 					// Get additional error context from the response for better diagnostics
 					message, _ := tc.getJsonPath("$.status.message.message")
 					if message != "" {

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -548,6 +548,15 @@ func (tc *scenarioConfig) iWaitForEvaluationJobStatus(expectedStatus string) err
 			} else if status == expectedStatus {
 				return nil
 			} else {
+				// Check for terminal failure states and fail fast instead of continuing to poll
+				if status == "failed" || status == "cancelled" || status == "partially_failed" {
+					// Get additional error context from the response for better diagnostics
+					message, _ := tc.getJsonPath("$.status.message.message")
+					if message != "" {
+						return tc.logError(fmt.Errorf("evaluation job reached terminal state %q (expected %q): %s", status, expectedStatus, message))
+					}
+					return tc.logError(fmt.Errorf("evaluation job reached terminal state %q (expected %q)", status, expectedStatus))
+				}
 				lastErr = fmt.Errorf("expected status %q but got %q", expectedStatus, status)
 			}
 		} else if tc.response != nil {


### PR DESCRIPTION
## What and why

* Fixed FVT test timeout issue where tests would run for 22+ minutes waiting for "completed" status on jobs that had already failed
* Added fast-fail logic to `iWaitForEvaluationJobStatus` to detect terminal failure states (failed, cancelled, partially_failed) and return immediately
* Enhanced error reporting by extracting the error message from the job status response for better diagnostics

## Root Cause

The `iWaitForEvaluationJobStatus` function in `step_definitions_test.go` would continue polling for up to 30 minutes (configured via `waitDeadline`) even when an evaluation job had reached a terminal failure state. This caused the test suite to hit the 22-minute test framework timeout.

Example from Jenkins build #34 logs:
- Job `a803da8a-7d54-4760-bf59-4af96d0cafdf` failed with "Evaluation failed: ConnectionError"
- Test continued polling for "completed" status instead of failing immediately
- Test suite killed after 22 minutes: `*** Test killed with quit: ran too long (22m0s).`

## Solution

Modified the wait loop to check if the job has reached any terminal failure state:
- `failed`
- `cancelled`  
- `partially_failed`

When detected, the test now fails immediately with a descriptive error message including the job's error details from `$.status.message.message`.

## Impact

- Tests fail fast (within seconds) when jobs fail, instead of timing out after 22+ minutes
- Better error diagnostics showing the actual failure reason from the job status
- No impact on successful test scenarios (jobs that reach "completed" state)

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Code review of terminal states matches API definition in `pkg/api/evaluations.go:165`
- [x] Logic verified against test logs from Jenkins build #34
- [ ] Manual testing pending (requires cluster environment with failing jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced job status evaluation to immediately detect terminal failure states (failed, cancelled, partially_failed) rather than continuing to poll until timeout, with detailed error messages extracted from response data when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->