### PR TITLE
ci: run @gha-wheel-sanity FVT tests during wheel validation

### DIFF
--- a/.github/workflows/publish-python-server.yml
+++ b/.github/workflows/publish-python-server.yml
@@ -171,10 +171,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Checkout VERSION file
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          sparse-checkout: VERSION
+          go-version-file: "go.mod"
 
       - name: Set up uv python
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -193,19 +196,16 @@ jobs:
           uv venv .venv
           uv pip install --python .venv dist/*.whl
 
-      - name: Validate --version
+      - name: Wheel sanity test
         shell: bash
         run: |
-          if [ -f .venv/bin/eval-hub-server ]; then
-            EVAL_HUB=.venv/bin/eval-hub-server
+          if [ -f .venv/bin/activate ]; then
+            source .venv/bin/activate
           else
-            EVAL_HUB=.venv/Scripts/eval-hub-server
+            source .venv/Scripts/activate
           fi
-          EXPECTED=$(tr -d '\r\n' < VERSION)
-          ACTUAL=$($EVAL_HUB --version | tr -d '\r')
-          echo "Expected: eval-hub-server ${EXPECTED}"
-          echo "Actual:   ${ACTUAL}"
-          echo "${ACTUAL}" | grep -qF "${EXPECTED}"
+          chmod +x scripts/gha_wheel_sanity_test.sh
+          ./scripts/gha_wheel_sanity_test.sh
 
   publish:
     name: Publish to PyPI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,14 @@ BDD-style tests using godog in `tests/features/`:
 - Tests run against actual HTTP server
 - Suite setup in `suite_test.go`
 
+##### FVT Tags
+
+- `@cluster` — tests that require a Kubernetes cluster
+- `@local` — tests that only run locally (excluded from CI)
+- `@mlflow` — tests requiring MLflow integration
+- `@negative` — negative/error-path tests
+- `@gha-wheel-sanity` — subset run during GHA wheel validation (`scripts/gha_wheel_sanity_test.sh`); the script starts the wheel-installed binary, waits for health, then runs `make test-fvt` with this tag
+
 ### Server Lifecycle
 
 Main function (`cmd/eval_hub/main.go`) implements graceful shutdown:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,7 @@ func (h *Handlers) HandleCreateEvaluation(
 ### Test Categories
 
 - **Unit Tests**: Test individual functions and packages (in `internal/`)
-- **FVT (Functional Verification Tests)**: BDD-style tests using godog (in `tests/features/`)
+- **FVT (Functional Verification Tests)**: BDD-style tests using godog (in `tests/features/`). Scenarios are tagged (`@local`, `@cluster`, `@mlflow`, `@negative`, `@gha-wheel-sanity`) to control which run in each context. The `@gha-wheel-sanity` tag marks scenarios executed during GHA wheel validation via `scripts/gha_wheel_sanity_test.sh`.
 - **Integration Tests**: Test component interactions
 
 ### Running Tests

--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,11 @@ SERVICE_LOG ?= $(BIN_DIR)/service.log
 
 start-service: test-setup ${SERVER_PID_FILE} build-service ## Run the application in background
 	@echo "Running $(BINARY_NAME) on port $(PORT)..."
-	@. $(VENV_DIR)/bin/activate && ./scripts/start_server.sh "${SERVER_PID_FILE}" "${BIN_DIR}/$(BINARY_NAME)" "${SERVICE_LOG}" ${PORT} ""
+	@if [ -f $(VENV_DIR)/bin/activate ]; then . $(VENV_DIR)/bin/activate; else . $(VENV_DIR)/Scripts/activate; fi && ./scripts/start_server.sh "${SERVER_PID_FILE}" "${BIN_DIR}/$(BINARY_NAME)" "${SERVICE_LOG}" ${PORT} ""
 
 start-service-coverage: test-setup ${SERVER_PID_FILE} build-coverage ## Run the application in background
 	@echo "Running $(BINARY_NAME)-cov on port $(PORT)..."
-	@. $(VENV_DIR)/bin/activate && ./scripts/start_server.sh "${SERVER_PID_FILE}" "${BIN_DIR}/$(BINARY_NAME)-cov" "${SERVICE_LOG}" ${PORT} "${BIN_DIR}"
+	@if [ -f $(VENV_DIR)/bin/activate ]; then . $(VENV_DIR)/bin/activate; else . $(VENV_DIR)/Scripts/activate; fi && ./scripts/start_server.sh "${SERVER_PID_FILE}" "${BIN_DIR}/$(BINARY_NAME)-cov" "${SERVICE_LOG}" ${PORT} "${BIN_DIR}"
 
 stop-service:
 	-./scripts/stop_server.sh "${SERVER_PID_FILE}"
@@ -165,7 +165,7 @@ test-setup: venv ## Set up Python test environment (venv + eval-hub-sdk adapter)
 
 test-fvt: $(BIN_DIR) test-setup ## Run FVT (Functional Verification Tests) using godog
 	@echo "Running FVT tests..."
-	@. $(VENV_DIR)/bin/activate && bash -c 'set -o pipefail; go test ${FVT_TESTS} ${FVT_OUTPUT} ${FVT_TAGS} -v -race | ${PWD}/scripts/grcat ${PWD}/.conf.go-integration-test'
+	@if [ -f $(VENV_DIR)/bin/activate ]; then . $(VENV_DIR)/bin/activate; else . $(VENV_DIR)/Scripts/activate; fi && bash -c 'set -o pipefail; go test ${FVT_TESTS} ${FVT_OUTPUT} ${FVT_TAGS} -v -race | ${PWD}/scripts/grcat ${PWD}/.conf.go-integration-test'
 
 test-fvt-server: start-service ## Run FVT tests using godog against a running server
 	@SERVER_URL="${SERVER_URL}" make test-fvt; status=$$?; make stop-service; exit $$status

--- a/python-server/DEVELOPMENT.md
+++ b/python-server/DEVELOPMENT.md
@@ -38,11 +38,14 @@ When a release is published in the eval-hub repository:
   - Downloads the appropriate binary for each platform
   - Packages the binary into the wheel
   - Renames wheels with correct platform tags (e.g., `manylinux_2_17_x86_64`)
-3. **Publish to TestPyPI** (`publish-test-pypi` job) — on `main` pushes or manual dispatch
+3. **Validate Wheels** (`validate-wheels` job)
+  - Installs each wheel on its native platform (Linux x64/arm64, macOS arm64, Windows x64)
+  - Runs `scripts/gha_wheel_sanity_test.sh` which starts the server, verifies health, then runs `@gha-wheel-sanity`-tagged FVT tests against it
+4. **Publish to TestPyPI** (`publish-test-pypi` job) — on `main` pushes or manual dispatch
   - Builds wheels with `.devN` version suffix (e.g., `0.2.0.dev42`)
   - Uses GitHub OIDC trusted publishing against the `testpypi` environment
   - Publishes all 5 wheels to [TestPyPI](https://test.pypi.org/p/eval-hub-server)
-4. **Publish to PyPI** (`publish` job) — on tag pushes only
+5. **Publish to PyPI** (`publish` job) — on tag pushes only
   - Uses GitHub OIDC trusted publishing (no API tokens)
   - Publishes all 5 wheels to PyPI with the clean version from `VERSION`
 

--- a/scripts/gha_wheel_sanity_test.sh
+++ b/scripts/gha_wheel_sanity_test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+BINARY="eval-hub-server"
+CONFIG_DIR="./config"
+PORT="${1:-8080}"
+FVT_TAGS="${2:---godog.tags=@gha-wheel-sanity}"
+
+LOGFILE=$(mktemp)
+
+cleanup() {
+    if [ -n "${SERVER_PID:-}" ]; then
+        kill -15 "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -f "$LOGFILE"
+}
+trap cleanup EXIT
+
+# Windows GHA runners lack /tmp; the Go binary resolves it to \tmp on the
+# current drive (e.g. D:\tmp) which differs from Git Bash's MSYS2 /tmp
+if [[ "$OSTYPE" == msys* ]]; then
+    echo "Windows detected (OSTYPE=${OSTYPE}): creating \\tmp via cmd"
+    cmd //c "mkdir \\tmp 2>nul" || true
+else
+    echo "Unix detected (OSTYPE=${OSTYPE}): ensuring /tmp exists"
+    mkdir -p /tmp
+fi
+
+echo "Starting: ${BINARY} -configdir ${CONFIG_DIR} -local"
+"${BINARY}" -configdir "${CONFIG_DIR}" -local > "${LOGFILE}" 2>&1 &
+SERVER_PID=$!
+
+SERVER_URL="http://localhost:${PORT}"
+HEALTH_URL="${SERVER_URL}/api/v1/health"
+MAX_ATTEMPTS=20
+
+echo "Waiting for health at ${HEALTH_URL} ..."
+for i in $(seq 1 "$MAX_ATTEMPTS"); do
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "Server process died (PID ${SERVER_PID})"
+        echo "--- server log ---"
+        cat "$LOGFILE"
+        echo "--- end ---"
+        exit 1
+    fi
+    RESPONSE=$(curl -s -k --max-time 5 "$HEALTH_URL" 2>/dev/null || true)
+    if echo "${RESPONSE}" | grep -qF '"status":"healthy"'; then
+        echo "Server is healthy: ${RESPONSE}"
+        break
+    fi
+    if [ "$i" -eq "$MAX_ATTEMPTS" ]; then
+        echo "Server failed to become healthy after ${MAX_ATTEMPTS} attempts"
+        echo "--- server log ---"
+        cat "$LOGFILE"
+        echo "--- end ---"
+        exit 1
+    fi
+    echo "  attempt ${i}/${MAX_ATTEMPTS} ..."
+    sleep 2
+done
+
+echo "Running FVT tests with tags: ${FVT_TAGS}"
+SERVER_URL="${SERVER_URL}" FVT_TAGS="${FVT_TAGS}" make test-fvt

--- a/scripts/gha_wheel_sanity_test.sh
+++ b/scripts/gha_wheel_sanity_test.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 BINARY="eval-hub-server"
 CONFIG_DIR="./config"
-PORT="${1:-8080}"
-FVT_TAGS="${2:---godog.tags=@gha-wheel-sanity}"
+PORT=8080
+FVT_TAGS="${1:---godog.tags=@gha-wheel-sanity}"
 
 LOGFILE=$(mktemp)
 

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -477,6 +477,7 @@ Feature: Evaluation Jobs
     When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}"
     Then the response code should be 204
 
+  @gha-wheel-sanity
   Scenario: Create an evaluation job and wait for completion
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"


### PR DESCRIPTION
Extend gha_wheel_validation.sh to run tagged FVT tests against the wheel-installed binary after the health check. Update the GHA workflow to full checkout with Go setup so go test can run. Fix venv activation across all Makefile targets to support Windows (Scripts/activate fallback). Handle /tmp creation on Windows GHA runners.

## What and why

sanity run in GHA ci for all platforms for wheel installation

Change notes:
- scripts/gha_wheel_sanity_test.sh (new): starts the wheel-installed binary, waits for     
  health, then runs @gha-wheel-sanity-tagged FVT tests via make test-fvt                     
- Makefile: platform-aware venv activation (bin/activate vs Scripts/activate) in           
start-service, start-service-coverage, and test-fvt targets                                
- .github/workflows/publish-python-server.yml: full checkout + Go setup in validate-wheels 
job; renamed step to "Wheel sanity test"; updated script reference                         
- tests/features/evaluation_jobs.feature: tagged "Create an evaluation job and wait for    
completion" scenario with @gha-wheel-sanity                                                
- *.md doc updates


Closes https://redhat.atlassian.net/browse/RHOAIENG-52869

Assisted-by:  Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually
```
make clean test-all
make clean test-all-coverage
```

## Breaking changes
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced development and contribution guides with comprehensive documentation of the FVT test framework, including test categorization by environment requirements and test scope.

* **Chores**
  * Strengthened the wheel validation process in CI/CD pipeline with automated sanity testing before publication.
  * Updated build configuration for improved handling of virtual environments across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->