### PR TITLE
fix: enable OCI proxy based on job spec

### DIFF
--- a/internal/eval_hub/config/sidecar_config.go
+++ b/internal/eval_hub/config/sidecar_config.go
@@ -14,7 +14,9 @@ type SidecarConfig struct {
 	SidecarContainer *SidecarContainerConfig `mapstructure:"sidecar_container,omitempty" json:"sidecar_container,omitempty"`
 }
 
-// SidecarOCIConfig holds sidecar OCI/registry proxy settings (host from configmap).
+// SidecarOCIConfig holds optional TLS/timeout overrides for the OCI registry HTTP client.
+// Whether the OCI reverse proxy runs is determined from the job spec (exports.oci), not from
+// the presence of this block; when nil, the sidecar uses defaults for registry TLS.
 type SidecarOCIConfig struct {
 	CACertPath         string        `mapstructure:"ca_cert_path,omitempty" json:"ca_cert_path,omitempty"`                 // optional PEM CA for registry TLS
 	InsecureSkipVerify bool          `mapstructure:"insecure_skip_verify,omitempty" json:"insecure_skip_verify,omitempty"` // skip TLS verify for registry (e.g. self-signed)

--- a/internal/eval_runtime_sidecar/handlers/handlers.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers.go
@@ -115,7 +115,7 @@ func newEvalhubProxy(config *config.Config, logger *slog.Logger) (*httputil.Reve
 }
 
 func newOciProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, *proxy.OCITokenProducer, string, error) {
-	if config == nil || config.Sidecar == nil || config.Sidecar.OCI == nil {
+	if config == nil || config.Sidecar == nil {
 		return nil, nil, "", nil
 	}
 	jobSpecPath := os.Getenv("JOB_SPEC_PATH")
@@ -124,13 +124,16 @@ func newOciProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseP
 	}
 	host, repository, err := proxy.GetOCICoordinatesFromJobSpec(jobSpecPath)
 	if err != nil {
-		logger.Debug("OCI disabled: could not read job spec for OCI coordinates", "path", jobSpecPath, "error", err)
+		logger.Debug("OCI proxy disabled: could not read job spec for OCI coordinates", "path", jobSpecPath, "error", err)
 		return nil, nil, "", nil
 	}
 	if host == "" {
-		logger.Debug("OCI disabled: job spec has no OCI exports or oci_host", "path", jobSpecPath)
+		logger.Debug("OCI proxy disabled: job spec has no exports.oci with registry host", "path", jobSpecPath)
 		return nil, nil, "", nil
 	}
+	// OCI reverse proxy is enabled from job spec (exports.oci + coordinates), not from eval-hub
+	// service YAML sidecar.oci. sidecar_config.json "oci" is optional: TLS/timeout overrides only
+	// (see NewOCIHTTPClient).
 	ociHTTPClient, err := proxy.NewOCIHTTPClient(config, config.IsOTELEnabled(), logger)
 	if err != nil {
 		logger.Error("failed to create OCI HTTP client", "error", err)
@@ -156,6 +159,11 @@ func newOciProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseP
 		proxy.ModifyOCIRegistryResponse(resp, logger, tokenProducer)
 		return nil
 	})
+	logger.Info("OCI registry proxy enabled",
+		"registry_host", host,
+		"oci_repository", repository,
+		"job_spec", jobSpecPath,
+	)
 	return rp, tokenProducer, repository, nil
 }
 
@@ -271,8 +279,7 @@ func (h *Handlers) parseProxyCall(r *http.Request) (*httputil.ReverseProxy, *pro
 		return nil, nil, fmt.Errorf("mlflow proxy is not configured")
 
 	case h.ociRouteMatch(r.RequestURI):
-		ociConfig := h.serviceConfig.Sidecar.OCI
-		if ociConfig != nil && h.ociProxy != nil {
+		if h.ociProxy != nil {
 			// Reuse the TokenProducer created at startup; token cache and refresh in resolveOCIAuthToken.
 			return h.ociProxy, &proxy.AuthTokenInput{
 				TargetEndpoint:   "oci",

--- a/internal/eval_runtime_sidecar/handlers/handlers_test.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers_test.go
@@ -177,7 +177,7 @@ func TestHandlers_HandleProxyCall(t *testing.T) {
 	})
 
 	t.Run("registry path with nil OCI returns 400", func(t *testing.T) {
-		// h has no Sidecar.OCI, so ociRepository is empty; path without repository name does not match OCI -> unknown proxy call
+		// h has no ociRepository (as when job spec has no OCI); path without repository name does not match OCI -> unknown proxy call
 		req := httptest.NewRequest(http.MethodGet, "/registry/v2/", nil)
 		rw := httptest.NewRecorder()
 		h.HandleProxyCall(rw, req)

--- a/internal/eval_runtime_sidecar/proxy/http_client.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client.go
@@ -128,8 +128,10 @@ func NewMLFlowHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logge
 }
 
 // NewOCIHTTPClient creates an HTTP client for the OCI registry from config (TLS, timeout).
-// Registry host comes from the job spec, not sidecar.oci.host; Host may be empty.
-// Returns (nil, nil) only when Sidecar.OCI is nil.
+// Registry host comes from the job spec, not this config. When Sidecar.OCI is nil, defaults
+// are used; non-nil sidecar.oci in sidecar_config.json supplies optional CA, insecure, and
+// http_timeout overrides.
+// Returns (nil, nil) only when Sidecar is nil.
 func NewOCIHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger *slog.Logger) (*http.Client, error) {
 	if serviceConfig == nil || serviceConfig.Sidecar == nil {
 		return nil, nil


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes # https://redhat.atlassian.net/browse/RHOAIENG-59731

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Refined OCI registry proxy initialization and request routing logic for improved reliability
  * Enhanced logging to provide clearer visibility into OCI registry operations and diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->