### PR TITLE
ci: add Docker build validation on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,29 @@ jobs:
         name: gosec-results
         path: gosec-results.sarif
 
+  docker-build-check:
+    runs-on: ubuntu-latest
+    needs: [quality-checks]
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+    - name: Build Docker image
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      with:
+        context: .
+        file: Containerfile
+        push: false
+        load: true
+        tags: evalhub:pr-check
+
+    - name: Dry-run Docker image
+      run: docker run --rm evalhub:pr-check /app/eval-hub --local --help
+
   docker-build-push:
     runs-on: ubuntu-latest
     needs: [quality-checks]


### PR DESCRIPTION
Catch Containerfile build issues before merge by running a build-only (no push) Docker check on PRs, with a binary dry-run smoke test.

## What and why

The existing ci `docker-build-push` runs only after merging PR
we need something that catch docker build issues prior to PR merge
Introduces : docker-build-check
- unlike the push job, this only build on ubuntu
- simple tagging logic (as this image will be discarded)
- does not push to quay.io

Closes # NA

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with automated Docker image validation checks on pull requests to ensure build integrity before code merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->