### PR TITLE
feat(k8s): add GetPodLogs method and corresponding tests

### DIFF
--- a/internal/eval_hub/runtimes/k8s/k8s_helper.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper.go
@@ -4,6 +4,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"io"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,7 +44,6 @@ func NewKubernetesClient() (*kubernetes.Clientset, error) {
 // NewKubernetesHelper builds a Kubernetes client (in-cluster config, then default kubeconfig)
 // and returns a KubernetesHelper.
 func NewKubernetesHelper() (*KubernetesHelper, error) {
-
 	clientset, err := NewKubernetesClient()
 	if err != nil {
 		return nil, err
@@ -129,6 +129,20 @@ func (h *KubernetesHelper) ListConfigMaps(ctx context.Context, namespace, labelS
 		return nil, err
 	}
 	return list.Items, nil
+}
+
+// GetPodLogs reads the full log stream for a pod container, it is the responsibility of the caller to close the stream.
+// opts may be nil (equivalent to empty PodLogOptions); set Container on opts when the pod has multiple containers.
+func (h *KubernetesHelper) GetPodLogs(ctx context.Context, namespace, podName string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
+	if namespace == "" || podName == "" {
+		return nil, fmt.Errorf("namespace and pod name are required")
+	}
+	opt := opts
+	if opt == nil {
+		opt = &corev1.PodLogOptions{}
+	}
+	req := h.clientset.CoreV1().Pods(namespace).GetLogs(podName, opt)
+	return req.Stream(ctx)
 }
 
 // SetConfigMapOwner sets a single owner reference on the ConfigMap.

--- a/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
@@ -36,6 +36,24 @@ func TestDeleteConfigMapRequiresNamespaceAndName(t *testing.T) {
 	}
 }
 
+func TestGetPodLogsRequiresNamespaceAndPodName(t *testing.T) {
+	helper := &KubernetesHelper{}
+	stream, err := helper.GetPodLogs(context.Background(), "", "pod", nil)
+	if stream != nil {
+		defer stream.Close()
+	}
+	if err == nil {
+		t.Fatalf("expected error for missing namespace")
+	}
+	stream, err = helper.GetPodLogs(context.Background(), "default", "", nil)
+	if stream != nil {
+		defer stream.Close()
+	}
+	if err == nil {
+		t.Fatalf("expected error for missing pod name")
+	}
+}
+
 func TestSetConfigMapOwnerRequiresNamespaceAndName(t *testing.T) {
 	helper := &KubernetesHelper{}
 	if err := helper.SetConfigMapOwner(context.Background(), "", "name", emptyOwnerRef()); err == nil {

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -172,7 +172,7 @@ func (r *K8sRuntime) logPodLogs(evaluation *api.EvaluationJobResource, _ batchv1
 	// This is a hack to log pod logs on failure.
 	// TODO: This should be removed once we have a better way to save pod logs.
 	logPodLogs := "::log-pod-logs-on-failure::"
-	if evaluation.Status.State == api.OverallStateFailed || evaluation.Status.State == api.OverallStatePartiallyFailed {
+	if (evaluation.Status != nil) && ((evaluation.Status.State == api.OverallStateFailed) || (evaluation.Status.State == api.OverallStatePartiallyFailed)) {
 		return slices.Contains(evaluation.Tags, logPodLogs)
 	}
 	return false

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"slices"
+	"strings"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
@@ -13,6 +16,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
 	"github.com/eval-hub/eval-hub/pkg/api"
+	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -112,6 +116,30 @@ func (r *K8sRuntime) DeleteEvaluationJobResources(evaluation *api.EvaluationJobR
 
 	var deleteErr error
 	for _, job := range jobs {
+		if r.logPodLogs(evaluation, job) {
+			logs, err := r.helper.GetPodLogs(r.ctx, namespace, job.Name, nil)
+			if err == nil {
+				defer logs.Close()
+				buf := new(strings.Builder)
+				_, err = io.Copy(buf, logs)
+				if err == nil {
+					r.logger.Info("pod logs",
+						"job_id", evaluation.Resource.ID,
+						"job_name", job.Name,
+						"namespace", namespace,
+						"logs", buf.String(),
+					)
+				}
+			}
+			if err != nil {
+				r.logger.Info("failed to copy pod logs",
+					"job_id", evaluation.Resource.ID,
+					"job_name", job.Name,
+					"namespace", namespace,
+					"error", err,
+				)
+			}
+		}
 		r.logger.Info(
 			"deleting evaluation runtime job",
 			"job_id", evaluation.Resource.ID,
@@ -136,6 +164,16 @@ func (r *K8sRuntime) DeleteEvaluationJobResources(evaluation *api.EvaluationJobR
 		}
 	}
 	return deleteErr
+}
+
+func (r *K8sRuntime) logPodLogs(evaluation *api.EvaluationJobResource, _ batchv1.Job) bool {
+	// This is a hack to log pod logs on failure.
+	// TODO: This should be removed once we have a better way to save pod logs.
+	logPodLogs := "::log-pod-logs-on-failure::"
+	if evaluation.Status.State == api.OverallStateFailed || evaluation.Status.State == api.OverallStatePartiallyFailed {
+		return slices.Contains(evaluation.Tags, logPodLogs)
+	}
+	return false
 }
 
 func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -119,7 +119,6 @@ func (r *K8sRuntime) DeleteEvaluationJobResources(evaluation *api.EvaluationJobR
 		if r.logPodLogs(evaluation, job) {
 			logs, err := r.helper.GetPodLogs(r.ctx, namespace, job.Name, nil)
 			if err == nil {
-				defer logs.Close()
 				buf := new(strings.Builder)
 				_, err = io.Copy(buf, logs)
 				if err == nil {
@@ -130,6 +129,9 @@ func (r *K8sRuntime) DeleteEvaluationJobResources(evaluation *api.EvaluationJobR
 						"logs", buf.String(),
 					)
 				}
+			}
+			if logs != nil {
+				logs.Close()
 			}
 			if err != nil {
 				r.logger.Info("failed to copy pod logs",


### PR DESCRIPTION
## What and why

When jobs fail we need a way to be able to debug the failure. This PR adds a temporary fix to allow the job pod logs to be saved to the service logs if a certain tag is present for a failed job. This needs further discussion to decide how job pod logs should be handled and, if appropriate, how the saving of the logs should be triggered.

- Implemented GetPodLogs method in KubernetesHelper to retrieve logs for a specified pod, enforcing namespace and pod name requirements
- Added unit tests for GetPodLogs to ensure proper error handling for missing parameters

Assisted-by: Cursor

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually
