### PR TITLE
fix(storage): retry UpdateEvaluationJob on database lock contention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   # Ruff linting and formatting (replaces black)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -33,7 +33,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.13.9
+    rev: v4.13.10
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,6 +38,8 @@ env_mappings:
 database:
   driver: sqlite
   url: file::eval_hub:?mode=memory&cache=shared
+  tx_retry_max: 3
+  tx_retry_interval: 50ms
   # driver: pgx
   # url: postgres://user@localhost:5432/eval_hub
 # MLFlow configuration

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,8 +38,6 @@ env_mappings:
 database:
   driver: sqlite
   url: file::eval_hub:?mode=memory&cache=shared
-  tx_retry_max: 3
-  tx_retry_interval: 50ms
   # driver: pgx
   # url: postgres://user@localhost:5432/eval_hub
 # MLFlow configuration

--- a/internal/eval_hub/storage/sql/evaluations.go
+++ b/internal/eval_hub/storage/sql/evaluations.go
@@ -376,11 +376,6 @@ func (s *sqlStorage) updateBenchmarkResults(job *api.EvaluationJobResource, runS
 //
 //	SQLITE_BUSY  (5) → "database is locked (5) (SQLITE_BUSY)"
 //	SQLITE_LOCKED(6) → "database table is locked: database is deadlocked (6)"
-//
-// PostgreSQL error strings come from pgx/v5 pgconn.PgError.Error():
-//
-//	serialization_failure → "ERROR: could not serialize access ... (SQLSTATE 40001)"
-//	deadlock_detected     → "ERROR: deadlock detected (SQLSTATE 40P01)"
 func isRetryableDBError(err error) bool {
 	if err == nil {
 		return false
@@ -388,9 +383,7 @@ func isRetryableDBError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "database is locked") ||
 		strings.Contains(msg, "database is deadlocked") ||
-		strings.Contains(msg, "database table is locked") ||
-		strings.Contains(msg, "SQLSTATE 40001") ||
-		strings.Contains(msg, "SQLSTATE 40P01")
+		strings.Contains(msg, "database table is locked")
 }
 
 // UpdateEvaluationJobWithRunStatus runs in a transaction: fetches the job, merges RunStatusInternal into the entity, and persists.

--- a/internal/eval_hub/storage/sql/evaluations.go
+++ b/internal/eval_hub/storage/sql/evaluations.go
@@ -373,11 +373,14 @@ func (s *sqlStorage) updateBenchmarkResults(job *api.EvaluationJobResource, runS
 // String-matched because ServiceError does not preserve the original driver error.
 // SQLite error strings come from the C library via modernc.org/sqlite conn.errstr()
 // (sqlite3_errstr + sqlite3_errmsg), not from the ErrorCodeString map in error.go:
-//   SQLITE_BUSY  (5) → "database is locked (5) (SQLITE_BUSY)"
-//   SQLITE_LOCKED(6) → "database table is locked: database is deadlocked (6)"
+//
+//	SQLITE_BUSY  (5) → "database is locked (5) (SQLITE_BUSY)"
+//	SQLITE_LOCKED(6) → "database table is locked: database is deadlocked (6)"
+//
 // PostgreSQL error strings come from pgx/v5 pgconn.PgError.Error():
-//   serialization_failure → "ERROR: could not serialize access ... (SQLSTATE 40001)"
-//   deadlock_detected     → "ERROR: deadlock detected (SQLSTATE 40P01)"
+//
+//	serialization_failure → "ERROR: could not serialize access ... (SQLSTATE 40001)"
+//	deadlock_detected     → "ERROR: deadlock detected (SQLSTATE 40P01)"
 func isRetryableDBError(err error) bool {
 	if err == nil {
 		return false

--- a/internal/eval_hub/storage/sql/evaluations.go
+++ b/internal/eval_hub/storage/sql/evaluations.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
+	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/constants"
@@ -368,90 +370,122 @@ func (s *sqlStorage) updateBenchmarkResults(job *api.EvaluationJobResource, runS
 	return nil
 }
 
+// String-matched because ServiceError does not preserve the original driver error.
+// SQLite error strings come from the C library via modernc.org/sqlite conn.errstr()
+// (sqlite3_errstr + sqlite3_errmsg), not from the ErrorCodeString map in error.go:
+//   SQLITE_BUSY  (5) → "database is locked (5) (SQLITE_BUSY)"
+//   SQLITE_LOCKED(6) → "database table is locked: database is deadlocked (6)"
+// PostgreSQL error strings come from pgx/v5 pgconn.PgError.Error():
+//   serialization_failure → "ERROR: could not serialize access ... (SQLSTATE 40001)"
+//   deadlock_detected     → "ERROR: deadlock detected (SQLSTATE 40P01)"
+func isRetryableDBError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "database is deadlocked") ||
+		strings.Contains(msg, "database table is locked") ||
+		strings.Contains(msg, "SQLSTATE 40001") ||
+		strings.Contains(msg, "SQLSTATE 40P01")
+}
+
 // UpdateEvaluationJobWithRunStatus runs in a transaction: fetches the job, merges RunStatusInternal into the entity, and persists.
+// Concurrent benchmark status events for the same job can cause lock contention;
+// the transaction is retried on retryable database errors.
 func (s *sqlStorage) UpdateEvaluationJob(id string, runStatus *api.StatusEvent) error {
-	err := s.withTransaction("update evaluation job", id, func(txn *sql.Tx) error {
-		s.logger.Info("Updating evaluation job", "id", id, "status", runStatus.BenchmarkStatusEvent.Status, "runStatus", runStatus)
-
-		job, err := s.getEvaluationJobTransactional(txn, id)
-		if err != nil {
-			return err
+	const maxRetries = 3
+	var err error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			s.logger.Info("Retrying evaluation job update after lock contention", "id", id, "attempt", attempt)
+			time.Sleep(time.Duration(attempt) * 50 * time.Millisecond)
 		}
+		err = s.withTransaction("update evaluation job", id, func(txn *sql.Tx) error {
+			s.logger.Info("Updating evaluation job", "id", id, "status", runStatus.BenchmarkStatusEvent.Status, "runStatus", runStatus)
 
-		// Guard: reject benchmark updates if job is already in a terminal state.
-		// We pass OverallStateRunning as the target to leverage checkEvaluationJobState's terminal-state check.
-		if _, err := s.checkEvaluationJobState(job.Resource.ID, job.Status.State, api.OverallStateRunning); err != nil {
-			return err
-		}
-
-		var collection *api.CollectionResource
-		if job.Collection != nil && job.Collection.ID != "" {
-			collection, err = s.GetCollection(job.Collection.ID)
+			job, err := s.getEvaluationJobTransactional(txn, id)
 			if err != nil {
 				return err
 			}
-		}
-		err = s.validateBenchmarkExists(job, runStatus, collection)
-		if err != nil {
-			return err
-		}
 
-		// first we store the benchmark status
-		benchmark := api.BenchmarkStatus{
-			ProviderID:     runStatus.BenchmarkStatusEvent.ProviderID,
-			ID:             runStatus.BenchmarkStatusEvent.ID,
-			Status:         runStatus.BenchmarkStatusEvent.Status,
-			ErrorMessage:   runStatus.BenchmarkStatusEvent.ErrorMessage,
-			StartedAt:      runStatus.BenchmarkStatusEvent.StartedAt,
-			CompletedAt:    runStatus.BenchmarkStatusEvent.CompletedAt,
-			BenchmarkIndex: runStatus.BenchmarkStatusEvent.BenchmarkIndex,
-		}
-		s.updateBenchmarkStatus(job, runStatus, &benchmark)
+			// Guard: reject benchmark updates if job is already in a terminal state.
+			// We pass OverallStateRunning as the target to leverage checkEvaluationJobState's terminal-state check.
+			if _, err := s.checkEvaluationJobState(job.Resource.ID, job.Status.State, api.OverallStateRunning); err != nil {
+				return err
+			}
 
-		outcome := s.computeBenchmarkTestResult(job, runStatus.BenchmarkStatusEvent, collection)
+			var collection *api.CollectionResource
+			if job.Collection != nil && job.Collection.ID != "" {
+				collection, err = s.GetCollection(job.Collection.ID)
+				if err != nil {
+					return err
+				}
+			}
+			err = s.validateBenchmarkExists(job, runStatus, collection)
+			if err != nil {
+				return err
+			}
 
-		// if the run status is terminal, we need to update the results
-		if api.IsBenchmarkTerminalState(runStatus.BenchmarkStatusEvent.Status) {
-			result := api.BenchmarkResult{
-				ID:             runStatus.BenchmarkStatusEvent.ID,
+			// first we store the benchmark status
+			benchmark := api.BenchmarkStatus{
 				ProviderID:     runStatus.BenchmarkStatusEvent.ProviderID,
-				Metrics:        runStatus.BenchmarkStatusEvent.Metrics,
-				Artifacts:      runStatus.BenchmarkStatusEvent.Artifacts,
-				MLFlowRunID:    runStatus.BenchmarkStatusEvent.MLFlowRunID,
-				LogsPath:       runStatus.BenchmarkStatusEvent.LogsPath,
+				ID:             runStatus.BenchmarkStatusEvent.ID,
+				Status:         runStatus.BenchmarkStatusEvent.Status,
+				ErrorMessage:   runStatus.BenchmarkStatusEvent.ErrorMessage,
+				StartedAt:      runStatus.BenchmarkStatusEvent.StartedAt,
+				CompletedAt:    runStatus.BenchmarkStatusEvent.CompletedAt,
 				BenchmarkIndex: runStatus.BenchmarkStatusEvent.BenchmarkIndex,
-				Test:           outcome,
 			}
-			err := s.updateBenchmarkResults(job, runStatus, &result)
+			s.updateBenchmarkStatus(job, runStatus, &benchmark)
+
+			outcome := s.computeBenchmarkTestResult(job, runStatus.BenchmarkStatusEvent, collection)
+
+			// if the run status is terminal, we need to update the results
+			if api.IsBenchmarkTerminalState(runStatus.BenchmarkStatusEvent.Status) {
+				result := api.BenchmarkResult{
+					ID:             runStatus.BenchmarkStatusEvent.ID,
+					ProviderID:     runStatus.BenchmarkStatusEvent.ProviderID,
+					Metrics:        runStatus.BenchmarkStatusEvent.Metrics,
+					Artifacts:      runStatus.BenchmarkStatusEvent.Artifacts,
+					MLFlowRunID:    runStatus.BenchmarkStatusEvent.MLFlowRunID,
+					LogsPath:       runStatus.BenchmarkStatusEvent.LogsPath,
+					BenchmarkIndex: runStatus.BenchmarkStatusEvent.BenchmarkIndex,
+					Test:           outcome,
+				}
+				err := s.updateBenchmarkResults(job, runStatus, &result)
+				if err != nil {
+					return err
+				}
+			}
+
+			// get the overall job status
+			overallState, message, err := s.getOverallJobStatus(job)
 			if err != nil {
 				return err
 			}
-		}
+			job.Status.State = overallState
+			job.Status.Message = message
 
-		// get the overall job status
-		overallState, message, err := s.getOverallJobStatus(job)
-		if err != nil {
+			s.logger.Info("Calculated overall job status", "id", id, "overall_state", overallState, "status", runStatus.BenchmarkStatusEvent.Status)
+
+			// compute the job test result only if the job is completed
+			if overallState == api.OverallStateCompleted {
+				s.computeJobTestResult(job, collection)
+			}
+
+			entity := EvaluationJobEntity{
+				Config:  &job.EvaluationJobConfig,
+				Status:  job.Status,
+				Results: job.Results,
+			}
+
+			return s.updateEvaluationJobTxn(txn, id, overallState, &entity)
+		})
+		if err == nil || !isRetryableDBError(err) {
 			return err
 		}
-		job.Status.State = overallState
-		job.Status.Message = message
-
-		s.logger.Info("Calculated overall job status", "id", id, "overall_state", overallState, "status", runStatus.BenchmarkStatusEvent.Status)
-
-		// compute the job test result only if the job is completed
-		if overallState == api.OverallStateCompleted {
-			s.computeJobTestResult(job, collection)
-		}
-
-		entity := EvaluationJobEntity{
-			Config:  &job.EvaluationJobConfig,
-			Status:  job.Status,
-			Results: job.Results,
-		}
-
-		return s.updateEvaluationJobTxn(txn, id, overallState, &entity)
-	})
-
+	}
 	return err
 }
 

--- a/internal/eval_hub/storage/sql/evaluations.go
+++ b/internal/eval_hub/storage/sql/evaluations.go
@@ -390,12 +390,13 @@ func isRetryableDBError(err error) bool {
 // Concurrent benchmark status events for the same job can cause lock contention;
 // the transaction is retried on retryable database errors.
 func (s *sqlStorage) UpdateEvaluationJob(id string, runStatus *api.StatusEvent) error {
-	const maxRetries = 3
+	maxRetries := s.sqlConfig.GetTxRetryMax()
+	retryInterval := s.sqlConfig.GetTxRetryInterval()
 	var err error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
 			s.logger.Info("Retrying evaluation job update after lock contention", "id", id, "attempt", attempt)
-			time.Sleep(time.Duration(attempt) * 50 * time.Millisecond)
+			time.Sleep(time.Duration(attempt) * retryInterval)
 		}
 		err = s.withTransaction("update evaluation job", id, func(txn *sql.Tx) error {
 			s.logger.Info("Updating evaluation job", "id", id, "status", runStatus.BenchmarkStatusEvent.Status, "runStatus", runStatus)

--- a/internal/eval_hub/storage/sql/shared/database_config.go
+++ b/internal/eval_hub/storage/sql/shared/database_config.go
@@ -19,8 +19,29 @@ type SQLDatabaseConfig struct {
 	MaxIdleConns    *int           `mapstructure:"max_idle_conns,omitempty"`
 	MaxOpenConns    *int           `mapstructure:"max_open_conns,omitempty"`
 	Fallback        bool           `mapstructure:"fallback,omitempty"`
+	TxRetryMax      int            `mapstructure:"tx_retry_max,omitempty"`
+	TxRetryInterval time.Duration  `mapstructure:"tx_retry_interval,omitempty"`
 
 	// Other map[string]any `mapstructure:",remain"`
+}
+
+const (
+	DefaultTxRetryMax      = 3
+	DefaultTxRetryInterval = 50 * time.Millisecond
+)
+
+func (s *SQLDatabaseConfig) GetTxRetryMax() int {
+	if s.TxRetryMax <= 0 {
+		return DefaultTxRetryMax
+	}
+	return s.TxRetryMax
+}
+
+func (s *SQLDatabaseConfig) GetTxRetryInterval() time.Duration {
+	if s.TxRetryInterval <= 0 {
+		return DefaultTxRetryInterval
+	}
+	return s.TxRetryInterval
 }
 
 func (s *SQLDatabaseConfig) GetDriverName() string {

--- a/internal/eval_hub/storage/sql/sql.go
+++ b/internal/eval_hub/storage/sql/sql.go
@@ -56,8 +56,14 @@ func NewStorage(
 	logger *slog.Logger,
 ) (abstractions.Storage, error) {
 	var sqlConfig shared.SQLDatabaseConfig
-	merr := mapstructure.Decode(config, &sqlConfig)
+	decoder, merr := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
+		Result:     &sqlConfig,
+	})
 	if merr != nil {
+		return nil, merr
+	}
+	if merr = decoder.Decode(config); merr != nil {
 		return nil, merr
 	}
 

--- a/internal/eval_hub/storage/sql/sql_test.go
+++ b/internal/eval_hub/storage/sql/sql_test.go
@@ -4,16 +4,69 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/storage"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/storage/sql/shared"
 	"github.com/eval-hub/eval-hub/internal/logging"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 var (
 	dbIndex = atomic.Int32{}
 )
+
+func TestTxRetryConfig(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		cfg := shared.SQLDatabaseConfig{}
+		if cfg.GetTxRetryMax() != shared.DefaultTxRetryMax {
+			t.Errorf("want %d, got %d", shared.DefaultTxRetryMax, cfg.GetTxRetryMax())
+		}
+		if cfg.GetTxRetryInterval() != shared.DefaultTxRetryInterval {
+			t.Errorf("want %v, got %v", shared.DefaultTxRetryInterval, cfg.GetTxRetryInterval())
+		}
+	})
+
+	t.Run("custom values", func(t *testing.T) {
+		cfg := shared.SQLDatabaseConfig{
+			TxRetryMax:      5,
+			TxRetryInterval: 200 * time.Millisecond,
+		}
+		if cfg.GetTxRetryMax() != 5 {
+			t.Errorf("want 5, got %d", cfg.GetTxRetryMax())
+		}
+		if cfg.GetTxRetryInterval() != 200*time.Millisecond {
+			t.Errorf("want 200ms, got %v", cfg.GetTxRetryInterval())
+		}
+	})
+
+	t.Run("mapstructure decodes duration strings", func(t *testing.T) {
+		config := map[string]any{
+			"driver":            "sqlite",
+			"url":               "file::test:?mode=memory&cache=shared",
+			"tx_retry_max":      7,
+			"tx_retry_interval": "5s",
+		}
+		var sqlConfig shared.SQLDatabaseConfig
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
+			Result:     &sqlConfig,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err = decoder.Decode(config); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sqlConfig.GetTxRetryMax() != 7 {
+			t.Errorf("want 7, got %d", sqlConfig.GetTxRetryMax())
+		}
+		if sqlConfig.GetTxRetryInterval() != 5*time.Second {
+			t.Errorf("want 5s, got %v", sqlConfig.GetTxRetryInterval())
+		}
+	})
+}
 
 func TestSQLStorage(t *testing.T) {
 	t.Run("Check database name is extracted correctly", func(t *testing.T) {


### PR DESCRIPTION
Concurrent benchmark status events for the same evaluation job cause SQLite deadlocks (SQLITE_LOCKED) and PostgreSQL serialization failures when two transactions read-modify-write the same row simultaneously.

Retry the transaction up to 3 times with linear backoff on retryable database errors. Each retry re-reads the job from the database, so it picks up any committed updates from the other transaction.

## What and why

This issue is encountered on mock runtime running locally. **Due to the nature of the mock runtime**, sometimes the benchmark jobs callback can end in deadlock during `callback.report_results()` . One of the benchmark update will pass and the other benchmark update fails leaving the Job in `running` state.

The same window is applicable for postgresql also, but is not likely to be encountered in production or test .

Closes # https://redhat.atlassian.net/browse/RHOAIENG-60140

Assisted-by: Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation job updates now automatically retry on transient DB errors, reducing failures under contention.

* **New Features**
  * Retry behavior is configurable (max attempts and interval) and supports duration strings.

* **Tests**
  * Added tests validating retry defaults, overrides, and duration decoding.

* **Chores**
  * Updated pre-commit tool version pins for linting and commit tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->