### PR TITLE
fix(tests): update response validation in providers.feature to use 'not equal' for total_count checks

### DIFF
--- a/tests/features/providers.feature
+++ b/tests/features/providers.feature
@@ -170,7 +170,7 @@ Feature: Providers Endpoint
     And the response should contain the value "100" at path "$.limit"
     When I send a GET request to "/api/v1/evaluations/providers?benchmarks=false&limit=5"
     Then the response code should be 200
-    And the response should not contain the value "0" at path "$.total_count"
+    And the response should not equal the value "0" at path "$.total_count"
     And the response should contain the value "[]" at path "items[0].benchmarks"
     When I send a GET request to "/api/v1/evaluations/providers?tags=nonexistent-tag&limit=10"
     Then the response code should be 200
@@ -247,7 +247,7 @@ Feature: Providers Endpoint
     When I send a GET request to "/api/v1/evaluations/providers?benchmarks=false&limit=5"
     Then the response code should be 200
     And the array at path "items" in the response should have length at least 3
-    And the response should not contain the value "0" at path "$.total_count"
+    And the response should not equal the value "0" at path "$.total_count"
     And the response should contain the value "[]" at path "items[0].benchmarks"
     When I send a GET request to "/api/v1/evaluations/providers?benchmarks=true&limit=5"
     Then the response code should be 200
@@ -256,7 +256,7 @@ Feature: Providers Endpoint
     Then the response code should be 200
     And the response should contain the value "2" at path "$.limit"
     And the array at path "items" in the response should have length at least 1
-    And the response should not contain the value "0" at path "$.total_count"
+    And the response should not equal the value "0" at path "$.total_count"
     And the response should contain the value "[]" at path "items[0].benchmarks"
     And the response should contain the value "Test Provider" at path "$.items[0].name"
     When I send a DELETE request to "/api/v1/evaluations/providers/{{value:list_prov1_id}}"


### PR DESCRIPTION
## What and why

One of the tests was failing like this:
```shell
Error: expected $.total_count to not contain 0 but found 10
```
Modified the validation steps in providers.feature to replace "not contain" with "not equal" for the total_count checks. This change enhances clarity in the test assertions, ensuring that the expected behavior is accurately represented in the feature tests.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated provider-listing feature test assertions to use more precise validation logic for total count values across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->