### PR TITLE
feat(tests): enhance response validation to support float comparisons

### DIFF
--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -494,7 +494,7 @@ Feature: Collections Endpoint
     And the response should contain the value "test-benchmarks-collection-threshold-zero" at path "$.name"
     And the response should contain the value "test" at path "$.category"
     And the response should contain the value "Collection of benchmarks for FVT" at path "$.description"
-    And the response should contain the value "0" at path "$.pass_criteria.threshold"
+    And the response should equal the value "0.0" at path "$.pass_criteria.threshold"
     And the array at path "$.benchmarks" in the response should have length 2
   
   Scenario: Verify soft delete of collection returns 204

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -1012,8 +1013,18 @@ func (tc *scenarioConfig) theResponseShouldContainAtJSONPathImpl(expectedValue s
 	for value := range values {
 		switch match {
 		case "==", "equals":
+			// first try an exact string match
 			if foundValue == strings.TrimSpace(value) {
 				return false, foundValue, nil
+			}
+			// then try a float match
+			if fv, err := strconv.ParseFloat(foundValue, 64); err == nil {
+				if ex, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil {
+					// compare the floats to 15 decimal places
+					if math.Abs(fv-ex) < 0.0000000000000001 {
+						return false, foundValue, nil
+					}
+				}
 			}
 		case "<=":
 			fv, err := strconv.ParseFloat(foundValue, 64)


### PR DESCRIPTION
## What and why

Updated the response validation logic in step_definitions_test.go to include float comparison checks. This enhancement allows for more precise validation of numeric values by comparing floats to 15 decimal places, improving the accuracy of test assertions.

Closes [RHOAIENG-60126](https://redhat.atlassian.net/browse/RHOAIENG-60126)

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually
