### PR TITLE
fix: add /api/3.0/mlflow to MLflow reverse proxy routes

### DIFF
--- a/internal/eval_runtime_sidecar/handlers/handlers.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers.go
@@ -24,11 +24,14 @@ const OCIAuthConfigPathDefault = "/etc/evalhub/.docker/config.json"
 // internal/runtimes/k8s/job_builders.go jobSpecMountPath + subPath jobSpecFileName.
 const JobSpecPathDefault = "/meta/job.json"
 
-// mlflowAPIPathPrefix is the path prefix routed to the MLflow tracking proxy (any suffix allowed).
-const mlflowAPIPathPrefix = "/api/2.0/mlflow"
+// /api/2.0|3.0/mlflow/* proxied to mlflow.tracking_uri.
+const (
+	mlflowAPIv2PathPrefix = "/api/2.0/mlflow"
+	mlflowAPIv3PathPrefix = "/api/3.0/mlflow"
+)
 
 func isMLflowProxyPath(path string) bool {
-	return strings.HasPrefix(path, mlflowAPIPathPrefix)
+	return strings.HasPrefix(path, mlflowAPIv2PathPrefix) || strings.HasPrefix(path, mlflowAPIv3PathPrefix)
 }
 
 // Handlers holds service state for HTTP handlers.

--- a/internal/eval_runtime_sidecar/handlers/handlers_test.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers_test.go
@@ -133,6 +133,9 @@ func TestHandlers_HandleProxyCall(t *testing.T) {
 			"/api/2.0/mlflow-artifacts/artifact",
 			"/api/2.0/mlflow-artifacts/get-artifact?path=x",
 			"/api/2.0/mlflow-custom/endpoint",
+			"/api/3.0/mlflow/traces/search",
+			"/api/3.0/mlflow/traces/tr-abc123",
+			"/api/3.0/mlflow/server-info",
 		} {
 			req := httptest.NewRequest(http.MethodGet, path, nil)
 			rw := httptest.NewRecorder()
@@ -227,6 +230,10 @@ func TestIsMLflowProxyPath(t *testing.T) {
 		{"/api/2.0/mlflow-artifactsmalicious", true},
 		{"/api/2.0/ml", false},
 		{"/prefix/api/2.0/mlflow/runs", false},
+		{"/api/3.0/mlflow/server-info", true},
+		{"/api/3.0/mlflow/traces/search", true},
+		{"/api/3.0/ml", false},
+		{"/prefix/api/3.0/mlflow/server-info", false},
 	}
 	for _, tt := range tests {
 		if got := isMLflowProxyPath(tt.path); got != tt.want {


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

This PR adds `/api/3.0/mlflow/...` to the MLflow reverse proxy routes, so that MLflow 3.x trace calls (e.g. traces, traces/search) are not rejected as unknown proxy call.

I tested this by adding sample code in the lm-eval adapter to open mlflow.start_span() around the benchmark run so a trace is created for the job, and I also downloaded the traces. I see traces are visible in the MLflow UI and as local JSON files.

MlFlow logs:
```
INFO:     10.129.1.130:36260 - "POST /api/3.0/mlflow/traces HTTP/1.1" 200 OK
INFO:     10.129.1.130:36260 - "PUT /api/2.0/mlflow-artifacts/artifacts/workspaces/dataplane/28/traces/tr-ef636c95d2f601d619c3bb850666eaf6/artifacts/traces.json HTTP/1.1" 200 OK
INFO:     10.129.1.130:36260 - "GET /api/2.0/mlflow/experiments/get-by-name?experiment_name=test+traces HTTP/1.1" 200 OK
INFO:     10.129.1.130:36260 - "POST /api/2.0/mlflow/runs/create HTTP/1.1" 200 OK
INFO:     10.129.1.130:36260 - "POST /api/2.0/mlflow/runs/log-batch HTTP/1.1" 200 OK
INFO:     10.129.1.130:36260 - "POST /api/2.0/mlflow/runs/update HTTP/1.1" 200 OK
INFO:     10.129.1.130:36260 - "GET /api/2.0/mlflow/experiments/get-by-name?experiment_name=test+traces HTTP/1.1" 200 OK
INFO:     10.129.1.130:36260 - "GET /api/2.0/mlflow/experiments/get-by-name?experiment_name=test+traces HTTP/1.1" 200 OK
INFO:     10.129.1.130:36260 - "POST /api/3.0/mlflow/traces/search HTTP/1.1" 200 OK
INFO:     10.129.1.130:36260 - "GET /api/3.0/mlflow/traces/tr-ef636c95d2f601d619c3bb850666eaf6?trace_id=tr-ef636c95d2f601d619c3bb850666eaf6 HTTP/1.1" 200 OK
Downloading artifacts: 100%|██████████| 1/1 [00:00<00:00, 1046.48it/s]
INFO:     10.129.1.130:36260 - "GET /api/2.0/mlflow-artifacts/artifacts/workspaces/dataplane/28/traces/tr-ef636c95d2f601d619c3bb850666eaf6/artifacts/traces.json HTTP/1.1" 200 OK
```

Adapter code snippet:
```
with mlflow.start_span(name="lmeval_adapter_run", span_type="AGENT") as span:
    span.set_inputs(
        {
            "job_id": adapter.job_spec.id,
            "benchmark_id": adapter.job_spec.benchmark_id,
            "model": adapter.job_spec.model.name,
            "num_examples": adapter.job_spec.num_examples,
        }
    )
    results = adapter.run_benchmark_job(adapter.job_spec, callbacks)
    span.set_outputs(
        {
            "overall_score": results.overall_score,
            "num_examples_evaluated": results.num_examples_evaluated,
            "duration_seconds": results.duration_seconds,
        }
    )
```
Mlflow UI:
<img width="1468" height="816" alt="image" src="https://github.com/user-attachments/assets/6991e6f2-934b-4a16-9d2b-bc7e06161029" />

Downloaded json file:
```
/tmp/mlflow-traces/tr-ef636c95d2f601d619c3bb850666eaf6.json ===
{
    "data": "TraceData(spans=[Span(name='lmeval_adapter_run', trace_id='tr-ef636c95d2f601d619c3bb850666eaf6', span_id='6f8effd14cdd9ce7', parent_id=None)])",
    "info": "TraceInfo(trace_id='tr-ef636c95d2f601d619c3bb850666eaf6', trace_location=TraceLocation(type=<TraceLocationType.MLFLOW_EXPERIMENT: 'MLFLOW_EXPERIMENT'>, mlflow_experiment=MlflowExperimentLocation(experiment_id='28'), inference_table=None, uc_schema=None, uc_table_prefix=None), request_time=1777377835997, state=<TraceState.OK: 'OK'>, request_preview='{\"job_id\": \"61314b3b-d308-46fd-95d2-5f6834781333\", \"benchmark_id\": \"arc_easy\", \"model\": \"granite-llm\", \"num_examples\": null}', response_preview='{\"overall_score\": 0.6776094276094277, \"num_examples_evaluated\": 2376, \"duration_seconds\": 490.3156063556671}', client_request_id=None, execution_duration=490437, trace_metadata={'mlflow.source.git.branch': '', 'mlflow.trace.sizeStats': '{\"total_size_bytes\": 1886, \"num_spans\": 1, \"max\": 695, \"p25\": 695, \"p50\": 695, \"p75\": 695}', 'mlflow.traceInputs': '{\"job_id\": \"61314b3b-d308-46fd-95d2-5f6834781333\", \"benchmark_id\": \"arc_easy\", \"model\": \"granite-llm\", \"num_examples\": null}', 'mlflow.source.name': '/opt/app-root/src/main.py', 'mlflow.source.git.repoURL': '', 'mlflow.source.git.commit': '', 'mlflow.traceOutputs': '{\"overall_score\": 0.6776094276094277, \"num_examples_evaluated\": 2376, \"duration_seconds\": 490.3156063556671}', 'mlflow.trace.sizeBytes': '1886', 'mlflow.source.type': 'LOCAL', 'mlflow.user': '1000900000', 'mlflow.trace_schema.version': '3'}, tags={'mlflow.artifactLocation': 'mlflow-artifacts:/workspaces/dataplane/28/traces/tr-ef636c95d2f601d619c3bb850666eaf6/artifacts', 'mlflow.traceName': 'lmeval_adapter_run'}, assessments=[])"
}
```


Closes # https://redhat.atlassian.net/browse/RHOAIENG-56085

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MLflow integration now supports both API v2 and v3 request paths for enhanced compatibility.
  * Added routing support for MLflow v3 endpoints including traces and server information operations.

* **Tests**
  * Expanded test coverage for v3 API endpoint routing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->