### PR TITLE
docs: clarify npm devDependencies version pinning in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,8 @@ Use `go-version-file: "go.mod"` in the github actions where possible.
 
 #### npm devDependencies
 
-Ensure that version pinning is correct, regenerate package-lock.json by running npm install after modifying the overrides in package.json.
+Ensure that version pinning is correct and pins to a **single version**,
+regenerate package-lock.json by running npm install after modifying the overrides in package.json.
 
 If updating any dependencies related to `npm` then verify that the documentation
 build still works by running `make documentation`.


### PR DESCRIPTION
## What and why

Updated the npm devDependencies section to emphasize that version pinning should be to a single version. This change aims to improve clarity and ensure consistent dependency management practices.

## Type

- [ ] feat
- [ ] fix
- [x] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidelines for dependency management to clarify version pinning requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->