### PR TITLE
fix(deps): patch npm CVEs in postcss and uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "eval-hub",
       "devDependencies": {
         "@redocly/cli": "^2.28.1",
         "cucumber-html-reporter": "^7.2.0"
@@ -286,16 +285,6 @@
         "node": "^12.20.0 || >=14"
       }
     },
-    "node_modules/@cucumber/gherkin-utils/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@cucumber/html-formatter": {
       "version": "20.2.1",
       "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-20.2.1.tgz",
@@ -327,16 +316,6 @@
         "class-transformer": "0.5.1",
         "reflect-metadata": "0.1.13",
         "uuid": "9.0.0"
-      }
-    },
-    "node_modules/@cucumber/messages/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cucumber/tag-expressions": {
@@ -2578,9 +2557,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -2598,7 +2577,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3509,14 +3488,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/verror": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "cucumber-html-reporter": "^7.2.0"
   },
   "overrides": {
-    "semver": "^7.5.2"
+    "semver": "7.7.4",
+    "postcss": "8.5.12",
+    "uuid": "14.0.0"
   },
   "scripts": {
     "lint-openapi": "redocly lint docs/src/openapi.yaml",


### PR DESCRIPTION
## Summary

- **postcss** (GHSA-qx2v-qp2m-jg93, moderate): XSS via unescaped `</style>` in CSS stringify output. Fixed by overriding to exact version `8.5.12` (affects `@redocly/cli` → `styled-components` → `postcss`).
- **uuid** (GHSA-w5hq-g745-h8pq, moderate): Missing buffer bounds check in v3/v5/v6 when `buf` is provided. Fixed by overriding to exact version `14.0.0` (affects `cucumber-html-reporter` → `@cucumber/cucumber` → `@cucumber/messages` → `uuid`).
- **semver**: Existing override pinned from range `^7.5.2` to exact version `7.7.4` to follow project convention of exact version pinning for overrides.

All overrides use exact versions (no ranges) per project guidelines.

## Verification

- `npm audit` returns **0 vulnerabilities**
- `npm ls postcss --all` confirms postcss@8.5.12 (overridden)
- `npm ls uuid --all` confirms uuid@14.0.0 (overridden)
- `make documentation` completes successfully with no new doc changes
- `package-lock.json` regenerated via `npm install`

## Test plan

- [x] `npm audit` passes with 0 vulnerabilities
- [x] `npm install` succeeds without errors
- [x] `make documentation` builds successfully
- [x] No documentation output files changed by this PR

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies for stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->