### PR TITLE
fix(storage): prevent SQLite deadlock by using transactional reads wi…

### DIFF
--- a/internal/eval_hub/storage/sql/collections.go
+++ b/internal/eval_hub/storage/sql/collections.go
@@ -85,7 +85,10 @@ func (s *sqlStorage) getCollectionTransactional(txn *sql.Tx, id string) (*api.Co
 }
 
 func (s *sqlStorage) GetCollections(filter *abstractions.QueryFilter) (*abstractions.QueryResults[api.CollectionResource], error) {
-	var txn *sql.Tx
+	return s.getCollectionsTransactional(nil, filter)
+}
+
+func (s *sqlStorage) getCollectionsTransactional(txn *sql.Tx, filter *abstractions.QueryFilter) (*abstractions.QueryResults[api.CollectionResource], error) {
 	return listEntities[api.CollectionResource](s, txn, shared.TABLE_COLLECTIONS, filter)
 }
 

--- a/internal/eval_hub/storage/sql/evaluations.go
+++ b/internal/eval_hub/storage/sql/evaluations.go
@@ -257,7 +257,7 @@ func (s *sqlStorage) validateBenchmarkExists(job *api.EvaluationJobResource, run
 }
 
 // GetOverallJobStatus returns overall state and message. getCollection is used to resolve job benchmark count when job has only a collection reference.
-func (s *sqlStorage) getOverallJobStatus(job *api.EvaluationJobResource) (api.OverallState, *api.MessageInfo, error) {
+func (s *sqlStorage) getOverallJobStatus(txn *sql.Tx, job *api.EvaluationJobResource) (api.OverallState, *api.MessageInfo, error) {
 	// to be safe - do an initial check to see if the job is finished
 	if job.Status.State.IsTerminalState() {
 		return job.Status.State, job.Status.Message, nil
@@ -277,7 +277,7 @@ func (s *sqlStorage) getOverallJobStatus(job *api.EvaluationJobResource) (api.Ov
 	var collection *api.CollectionResource
 	var err error
 	if job.Collection != nil && job.Collection.ID != "" {
-		collection, err = s.GetCollection(job.Collection.ID)
+		collection, err = s.getCollectionTransactional(txn, job.Collection.ID)
 		if err != nil {
 			return api.OverallStatePending, &api.MessageInfo{
 				Message:     "Evaluation job is pending",
@@ -414,7 +414,7 @@ func (s *sqlStorage) UpdateEvaluationJob(id string, runStatus *api.StatusEvent) 
 
 			var collection *api.CollectionResource
 			if job.Collection != nil && job.Collection.ID != "" {
-				collection, err = s.GetCollection(job.Collection.ID)
+				collection, err = s.getCollectionTransactional(txn, job.Collection.ID)
 				if err != nil {
 					return err
 				}
@@ -436,7 +436,7 @@ func (s *sqlStorage) UpdateEvaluationJob(id string, runStatus *api.StatusEvent) 
 			}
 			s.updateBenchmarkStatus(job, runStatus, &benchmark)
 
-			outcome := s.computeBenchmarkTestResult(job, runStatus.BenchmarkStatusEvent, collection)
+			outcome := s.computeBenchmarkTestResult(txn, job, runStatus.BenchmarkStatusEvent, collection)
 
 			// if the run status is terminal, we need to update the results
 			if api.IsBenchmarkTerminalState(runStatus.BenchmarkStatusEvent.Status) {
@@ -457,7 +457,7 @@ func (s *sqlStorage) UpdateEvaluationJob(id string, runStatus *api.StatusEvent) 
 			}
 
 			// get the overall job status
-			overallState, message, err := s.getOverallJobStatus(job)
+			overallState, message, err := s.getOverallJobStatus(txn, job)
 			if err != nil {
 				return err
 			}
@@ -554,7 +554,7 @@ func getPassCriteriaThreshold(job *api.EvaluationJobResource, collection *api.Co
 	return 0.5
 }
 
-func (s *sqlStorage) computeBenchmarkTestResult(job *api.EvaluationJobResource, benchmarkStatusEvent *api.BenchmarkStatusEvent, collection *api.CollectionResource) *api.BenchmarkTest {
+func (s *sqlStorage) computeBenchmarkTestResult(txn *sql.Tx, job *api.EvaluationJobResource, benchmarkStatusEvent *api.BenchmarkStatusEvent, collection *api.CollectionResource) *api.BenchmarkTest {
 	// job could have benchmarks array or it could have collection. If it has collection, we need to get the benchmarks from the collection
 	benchmarks, err := handlers.GetJobBenchmarks(job, collection)
 	if err != nil {
@@ -572,7 +572,7 @@ func (s *sqlStorage) computeBenchmarkTestResult(job *api.EvaluationJobResource, 
 		var providerBench *api.BenchmarkResource
 		// if the primary score is not defined, we need to get the primary score from the provider
 		if (primaryScore == nil || primaryScore.Metric == "") && benchmark.ProviderID != "" {
-			provider, err := s.GetProvider(benchmark.ProviderID)
+			provider, err := s.getUserProviderTransactional(txn, benchmark.ProviderID)
 			if err == nil && provider != nil {
 				for i := range provider.Benchmarks {
 					if provider.Benchmarks[i].ID == benchmark.ID {

--- a/internal/eval_hub/storage/sql/evaluations.go
+++ b/internal/eval_hub/storage/sql/evaluations.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
-	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/constants"
@@ -370,119 +368,90 @@ func (s *sqlStorage) updateBenchmarkResults(job *api.EvaluationJobResource, runS
 	return nil
 }
 
-// String-matched because ServiceError does not preserve the original driver error.
-// SQLite error strings come from the C library via modernc.org/sqlite conn.errstr()
-// (sqlite3_errstr + sqlite3_errmsg), not from the ErrorCodeString map in error.go:
-//
-//	SQLITE_BUSY  (5) → "database is locked (5) (SQLITE_BUSY)"
-//	SQLITE_LOCKED(6) → "database table is locked: database is deadlocked (6)"
-func isRetryableDBError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "database is locked") ||
-		strings.Contains(msg, "database is deadlocked") ||
-		strings.Contains(msg, "database table is locked")
-}
-
 // UpdateEvaluationJobWithRunStatus runs in a transaction: fetches the job, merges RunStatusInternal into the entity, and persists.
-// Concurrent benchmark status events for the same job can cause lock contention;
-// the transaction is retried on retryable database errors.
 func (s *sqlStorage) UpdateEvaluationJob(id string, runStatus *api.StatusEvent) error {
-	maxRetries := s.sqlConfig.GetTxRetryMax()
-	retryInterval := s.sqlConfig.GetTxRetryInterval()
-	var err error
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		if attempt > 0 {
-			s.logger.Info("Retrying evaluation job update after lock contention", "id", id, "attempt", attempt)
-			time.Sleep(time.Duration(attempt) * retryInterval)
-		}
-		err = s.withTransaction("update evaluation job", id, func(txn *sql.Tx) error {
-			s.logger.Info("Updating evaluation job", "id", id, "status", runStatus.BenchmarkStatusEvent.Status, "runStatus", runStatus)
+	err := s.withTransaction("update evaluation job", id, func(txn *sql.Tx) error {
+		s.logger.Info("Updating evaluation job", "id", id, "status", runStatus.BenchmarkStatusEvent.Status, "runStatus", runStatus)
 
-			job, err := s.getEvaluationJobTransactional(txn, id)
-			if err != nil {
-				return err
-			}
-
-			// Guard: reject benchmark updates if job is already in a terminal state.
-			// We pass OverallStateRunning as the target to leverage checkEvaluationJobState's terminal-state check.
-			if _, err := s.checkEvaluationJobState(job.Resource.ID, job.Status.State, api.OverallStateRunning); err != nil {
-				return err
-			}
-
-			var collection *api.CollectionResource
-			if job.Collection != nil && job.Collection.ID != "" {
-				collection, err = s.getCollectionTransactional(txn, job.Collection.ID)
-				if err != nil {
-					return err
-				}
-			}
-			err = s.validateBenchmarkExists(job, runStatus, collection)
-			if err != nil {
-				return err
-			}
-
-			// first we store the benchmark status
-			benchmark := api.BenchmarkStatus{
-				ProviderID:     runStatus.BenchmarkStatusEvent.ProviderID,
-				ID:             runStatus.BenchmarkStatusEvent.ID,
-				Status:         runStatus.BenchmarkStatusEvent.Status,
-				ErrorMessage:   runStatus.BenchmarkStatusEvent.ErrorMessage,
-				StartedAt:      runStatus.BenchmarkStatusEvent.StartedAt,
-				CompletedAt:    runStatus.BenchmarkStatusEvent.CompletedAt,
-				BenchmarkIndex: runStatus.BenchmarkStatusEvent.BenchmarkIndex,
-			}
-			s.updateBenchmarkStatus(job, runStatus, &benchmark)
-
-			outcome := s.computeBenchmarkTestResult(txn, job, runStatus.BenchmarkStatusEvent, collection)
-
-			// if the run status is terminal, we need to update the results
-			if api.IsBenchmarkTerminalState(runStatus.BenchmarkStatusEvent.Status) {
-				result := api.BenchmarkResult{
-					ID:             runStatus.BenchmarkStatusEvent.ID,
-					ProviderID:     runStatus.BenchmarkStatusEvent.ProviderID,
-					Metrics:        runStatus.BenchmarkStatusEvent.Metrics,
-					Artifacts:      runStatus.BenchmarkStatusEvent.Artifacts,
-					MLFlowRunID:    runStatus.BenchmarkStatusEvent.MLFlowRunID,
-					LogsPath:       runStatus.BenchmarkStatusEvent.LogsPath,
-					BenchmarkIndex: runStatus.BenchmarkStatusEvent.BenchmarkIndex,
-					Test:           outcome,
-				}
-				err := s.updateBenchmarkResults(job, runStatus, &result)
-				if err != nil {
-					return err
-				}
-			}
-
-			// get the overall job status
-			overallState, message, err := s.getOverallJobStatus(txn, job)
-			if err != nil {
-				return err
-			}
-			job.Status.State = overallState
-			job.Status.Message = message
-
-			s.logger.Info("Calculated overall job status", "id", id, "overall_state", overallState, "status", runStatus.BenchmarkStatusEvent.Status)
-
-			// compute the job test result only if the job is completed
-			if overallState == api.OverallStateCompleted {
-				s.computeJobTestResult(job, collection)
-			}
-
-			entity := EvaluationJobEntity{
-				Config:  &job.EvaluationJobConfig,
-				Status:  job.Status,
-				Results: job.Results,
-			}
-
-			return s.updateEvaluationJobTxn(txn, id, overallState, &entity)
-		})
-		if err == nil || !isRetryableDBError(err) {
+		job, err := s.getEvaluationJobTransactional(txn, id)
+		if err != nil {
 			return err
 		}
-	}
+
+		// Guard: reject benchmark updates if job is already in a terminal state.
+		// We pass OverallStateRunning as the target to leverage checkEvaluationJobState's terminal-state check.
+		if _, err := s.checkEvaluationJobState(job.Resource.ID, job.Status.State, api.OverallStateRunning); err != nil {
+			return err
+		}
+
+		var collection *api.CollectionResource
+		if job.Collection != nil && job.Collection.ID != "" {
+			collection, err = s.getCollectionTransactional(txn, job.Collection.ID)
+			if err != nil {
+				return err
+			}
+		}
+		err = s.validateBenchmarkExists(job, runStatus, collection)
+		if err != nil {
+			return err
+		}
+
+		// first we store the benchmark status
+		benchmark := api.BenchmarkStatus{
+			ProviderID:     runStatus.BenchmarkStatusEvent.ProviderID,
+			ID:             runStatus.BenchmarkStatusEvent.ID,
+			Status:         runStatus.BenchmarkStatusEvent.Status,
+			ErrorMessage:   runStatus.BenchmarkStatusEvent.ErrorMessage,
+			StartedAt:      runStatus.BenchmarkStatusEvent.StartedAt,
+			CompletedAt:    runStatus.BenchmarkStatusEvent.CompletedAt,
+			BenchmarkIndex: runStatus.BenchmarkStatusEvent.BenchmarkIndex,
+		}
+		s.updateBenchmarkStatus(job, runStatus, &benchmark)
+
+		outcome := s.computeBenchmarkTestResult(txn, job, runStatus.BenchmarkStatusEvent, collection)
+
+		// if the run status is terminal, we need to update the results
+		if api.IsBenchmarkTerminalState(runStatus.BenchmarkStatusEvent.Status) {
+			result := api.BenchmarkResult{
+				ID:             runStatus.BenchmarkStatusEvent.ID,
+				ProviderID:     runStatus.BenchmarkStatusEvent.ProviderID,
+				Metrics:        runStatus.BenchmarkStatusEvent.Metrics,
+				Artifacts:      runStatus.BenchmarkStatusEvent.Artifacts,
+				MLFlowRunID:    runStatus.BenchmarkStatusEvent.MLFlowRunID,
+				LogsPath:       runStatus.BenchmarkStatusEvent.LogsPath,
+				BenchmarkIndex: runStatus.BenchmarkStatusEvent.BenchmarkIndex,
+				Test:           outcome,
+			}
+			err := s.updateBenchmarkResults(job, runStatus, &result)
+			if err != nil {
+				return err
+			}
+		}
+
+		// get the overall job status
+		overallState, message, err := s.getOverallJobStatus(txn, job)
+		if err != nil {
+			return err
+		}
+		job.Status.State = overallState
+		job.Status.Message = message
+
+		s.logger.Info("Calculated overall job status", "id", id, "overall_state", overallState, "status", runStatus.BenchmarkStatusEvent.Status)
+
+		// compute the job test result only if the job is completed
+		if overallState == api.OverallStateCompleted {
+			s.computeJobTestResult(job, collection)
+		}
+
+		entity := EvaluationJobEntity{
+			Config:  &job.EvaluationJobConfig,
+			Status:  job.Status,
+			Results: job.Results,
+		}
+
+		return s.updateEvaluationJobTxn(txn, id, overallState, &entity)
+	})
+
 	return err
 }
 

--- a/internal/eval_hub/storage/sql/providers.go
+++ b/internal/eval_hub/storage/sql/providers.go
@@ -108,7 +108,10 @@ func (s *sqlStorage) DeleteProvider(id string) error {
 }
 
 func (s *sqlStorage) GetProviders(filter *abstractions.QueryFilter) (*abstractions.QueryResults[api.ProviderResource], error) {
-	var txn *sql.Tx
+	return s.getProvidersTransactional(nil, filter)
+}
+
+func (s *sqlStorage) getProvidersTransactional(txn *sql.Tx, filter *abstractions.QueryFilter) (*abstractions.QueryResults[api.ProviderResource], error) {
 	return listEntities[api.ProviderResource](s, txn, shared.TABLE_PROVIDERS, filter)
 }
 

--- a/internal/eval_hub/storage/sql/shared/database_config.go
+++ b/internal/eval_hub/storage/sql/shared/database_config.go
@@ -19,29 +19,8 @@ type SQLDatabaseConfig struct {
 	MaxIdleConns    *int           `mapstructure:"max_idle_conns,omitempty"`
 	MaxOpenConns    *int           `mapstructure:"max_open_conns,omitempty"`
 	Fallback        bool           `mapstructure:"fallback,omitempty"`
-	TxRetryMax      int            `mapstructure:"tx_retry_max,omitempty"`
-	TxRetryInterval time.Duration  `mapstructure:"tx_retry_interval,omitempty"`
 
 	// Other map[string]any `mapstructure:",remain"`
-}
-
-const (
-	DefaultTxRetryMax      = 3
-	DefaultTxRetryInterval = 50 * time.Millisecond
-)
-
-func (s *SQLDatabaseConfig) GetTxRetryMax() int {
-	if s.TxRetryMax <= 0 {
-		return DefaultTxRetryMax
-	}
-	return s.TxRetryMax
-}
-
-func (s *SQLDatabaseConfig) GetTxRetryInterval() time.Duration {
-	if s.TxRetryInterval <= 0 {
-		return DefaultTxRetryInterval
-	}
-	return s.TxRetryInterval
 }
 
 func (s *SQLDatabaseConfig) GetDriverName() string {

--- a/internal/eval_hub/storage/sql/sql.go
+++ b/internal/eval_hub/storage/sql/sql.go
@@ -56,14 +56,8 @@ func NewStorage(
 	logger *slog.Logger,
 ) (abstractions.Storage, error) {
 	var sqlConfig shared.SQLDatabaseConfig
-	decoder, merr := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
-		Result:     &sqlConfig,
-	})
+	merr := mapstructure.Decode(config, &sqlConfig)
 	if merr != nil {
-		return nil, merr
-	}
-	if merr = decoder.Decode(config); merr != nil {
 		return nil, merr
 	}
 

--- a/internal/eval_hub/storage/sql/sql_test.go
+++ b/internal/eval_hub/storage/sql/sql_test.go
@@ -4,69 +4,16 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/storage"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/storage/sql/shared"
 	"github.com/eval-hub/eval-hub/internal/logging"
-	"github.com/go-viper/mapstructure/v2"
 )
 
 var (
 	dbIndex = atomic.Int32{}
 )
-
-func TestTxRetryConfig(t *testing.T) {
-	t.Run("defaults when unset", func(t *testing.T) {
-		cfg := shared.SQLDatabaseConfig{}
-		if cfg.GetTxRetryMax() != shared.DefaultTxRetryMax {
-			t.Errorf("want %d, got %d", shared.DefaultTxRetryMax, cfg.GetTxRetryMax())
-		}
-		if cfg.GetTxRetryInterval() != shared.DefaultTxRetryInterval {
-			t.Errorf("want %v, got %v", shared.DefaultTxRetryInterval, cfg.GetTxRetryInterval())
-		}
-	})
-
-	t.Run("custom values", func(t *testing.T) {
-		cfg := shared.SQLDatabaseConfig{
-			TxRetryMax:      5,
-			TxRetryInterval: 200 * time.Millisecond,
-		}
-		if cfg.GetTxRetryMax() != 5 {
-			t.Errorf("want 5, got %d", cfg.GetTxRetryMax())
-		}
-		if cfg.GetTxRetryInterval() != 200*time.Millisecond {
-			t.Errorf("want 200ms, got %v", cfg.GetTxRetryInterval())
-		}
-	})
-
-	t.Run("mapstructure decodes duration strings", func(t *testing.T) {
-		config := map[string]any{
-			"driver":            "sqlite",
-			"url":               "file::test:?mode=memory&cache=shared",
-			"tx_retry_max":      7,
-			"tx_retry_interval": "5s",
-		}
-		var sqlConfig shared.SQLDatabaseConfig
-		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-			DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
-			Result:     &sqlConfig,
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if err = decoder.Decode(config); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if sqlConfig.GetTxRetryMax() != 7 {
-			t.Errorf("want 7, got %d", sqlConfig.GetTxRetryMax())
-		}
-		if sqlConfig.GetTxRetryInterval() != 5*time.Second {
-			t.Errorf("want 5s, got %v", sqlConfig.GetTxRetryInterval())
-		}
-	})
-}
 
 func TestSQLStorage(t *testing.T) {
 	t.Run("Check database name is extracted correctly", func(t *testing.T) {

--- a/internal/eval_hub/storage/sql/sqlite/setup.go
+++ b/internal/eval_hub/storage/sql/sqlite/setup.go
@@ -10,9 +10,9 @@ import (
 )
 
 func Setup(logger *slog.Logger, pool *sql.DB, config *shared.SQLDatabaseConfig) (shared.SQLStatementsFactory, error) {
-	// SQLite only supports one writer at a time; serializing access through
-	// a single connection eliminates lock contention and deadlocks.
-	pool.SetMaxOpenConns(5)
+	// SQLite only supports one writer at a time; a single connection
+	// serializes all access and eliminates lock contention.
+	pool.SetMaxOpenConns(1)
 	if _, err := pool.Exec("PRAGMA busy_timeout = 5000"); err != nil {
 		return nil, fmt.Errorf("failed to set busy_timeout: %w", err)
 	}

--- a/internal/eval_hub/storage/sql/system_resources.go
+++ b/internal/eval_hub/storage/sql/system_resources.go
@@ -37,7 +37,7 @@ func (s *sqlStorage) LoadSystemResources(systemCollections map[string]api.Collec
 					Offset: offset,
 					Params: map[string]any{},
 				}
-				collections, err := s.GetCollections(&filter)
+				collections, err := s.getCollectionsTransactional(txn, &filter)
 				if err != nil {
 					return serviceerrors.WithRollback(err)
 				}
@@ -101,7 +101,7 @@ func (s *sqlStorage) LoadSystemResources(systemCollections map[string]api.Collec
 					Offset: offset,
 					Params: map[string]any{},
 				}
-				providers, err := s.GetProviders(&filter)
+				providers, err := s.getProvidersTransactional(txn, &filter)
 				if err != nil {
 					return serviceerrors.WithRollback(err)
 				}


### PR DESCRIPTION
…thin transactions

With MaxOpenConns(1), calling public Get* methods inside a withTransaction block attempted to acquire a second connection from the pool while the transaction held the only one, causing a deadlock. Switch all in-transaction reads to their transactional variants that reuse the existing transaction connection, and restore MaxOpenConns to 1 to properly serialize SQLite access.

## What and why

Changes:
- All reads that happen inside a withTransaction block were leaking out to pool-level Get* methods, which tried to acquire a second DB connection — deadlocking SQLite 
- Fixed by adding *Transactional variants of the read methods (getCollectionTransactional, getUserProviderTransactional) that accept and reuse the in-flight *sql.Tx 
- MaxOpenConns(1) restored on SQLite to enforce connection serialization
- Revert the changes in : https://github.com/eval-hub/eval-hub/pull/502 as this PR fixed it at broader scope.

Closes # https://redhat.atlassian.net/browse/RHOAIENG-60232

Assisted-by: Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually
```
make clean test-all
make clean test-all-coverage
```


Tested in Cluster as well

```
# Create a collection:
╰─➤  cat mycol.yaml                                                                                                  130 ↵
name: lmeval-collection-v1
description: "Testing subset of collection"
category: leaderboard
tags: []
benchmarks:
  - id: hellaswag_ar
    provider_id: lm_evaluation_harness
    parameters:
      num_examples: 10
      limit: 5
      tokenizer: google/flan-t5-small
  - id: arc_easy
    provider_id: lm_evaluation_harness
    parameters:
      num_examples: 10
      limit: 5
      tokenizer: google/flan-t5-small%                                                                                     (eval-hub-sdk) ╭─gnaulak@gnaulak-mac ~/workspace/worktrees/eval-hub-sdk/cli-dev  ‹cli-dev2*›
╰─➤  evalhub collections create --file mycol.yaml


╰─➤  evalhub collections run 04886927-16ca-463d-8919-341844442e13 \                                                  130 ↵
  --model-url http://vllm-llama3-8b-instruct-svc.evalhub-test.svc.cluster.local:8000/v1 \
  --model-name meta-llama/Llama-3.1-8B-Instruct
```

<img width="1057" height="165" alt="Screenshot 2026-04-30 at 2 58 05 PM" src="https://github.com/user-attachments/assets/62a3e2e8-2586-4c92-8e40-633f874418b3" />

## Breaking changes
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal database transaction handling to use transactional query helpers consistently across collections, providers, and system resources.
  * Removed transaction retry configuration options and simplified configuration decoding.
  * Adjusted SQLite connection pool settings for improved stability.

* **Tests**
  * Removed tests related to transaction retry configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->