### PR TITLE
refactor: split sidecar proxy handlers per backend

### DIFF
--- a/internal/eval_runtime_sidecar/handlers/evalhub.go
+++ b/internal/eval_runtime_sidecar/handlers/evalhub.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_runtime_sidecar/proxy"
+)
+
+// ServiceAccountTokenPathDefault is the in-cluster path for the k8s SA token (Eval Hub API auth).
+const ServiceAccountTokenPathDefault = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+// newEvalhubProxy builds a reverse proxy to eval_hub.base_url (Eval Hub REST API, e.g. /api/v1/evaluations/ for job callbacks to the hub).
+func newEvalhubProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, error) {
+	evalHubHTTPClient, err := proxy.NewEvalHubHTTPClient(config, config.IsOTELEnabled(), logger)
+	if err != nil {
+		logger.Error("failed to create eval-hub HTTP client", "error", err)
+		return nil, fmt.Errorf("failed to create eval-hub HTTP client: %w", err)
+	}
+	evalHubBaseURL := ""
+	if config.Sidecar != nil && config.Sidecar.EvalHub != nil {
+		evalHubBaseURL = strings.TrimSpace(config.Sidecar.EvalHub.BaseURL)
+	}
+	if evalHubBaseURL == "" {
+		return nil, fmt.Errorf("eval_hub.base_url is not set in sidecar config")
+	}
+	evalHubTarget, err := url.Parse(strings.TrimSuffix(evalHubBaseURL, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid eval_hub.base_url: %w", err)
+	}
+	evalHubProxy := proxy.NewReverseProxy(evalHubTarget, evalHubHTTPClient, logger, nil)
+	return evalHubProxy, nil
+}

--- a/internal/eval_runtime_sidecar/handlers/handlers.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers.go
@@ -6,33 +6,11 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 	"github.com/eval-hub/eval-hub/internal/eval_runtime_sidecar/proxy"
 )
-
-const ServiceAccountTokenPathDefault = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-const MLFlowTokenPathDefault = "/var/run/secrets/mlflow/token"
-
-// OCIAuthConfigPathDefault is the default path for the registry auth config file. Must match the OCI secret
-// mount path on adapter and sidecar: internal/runtimes/k8s/job_builders.go ociCredentialsMountPath.
-const OCIAuthConfigPathDefault = "/etc/evalhub/.docker/config.json"
-
-// JobSpecPathDefault is the default path for the job spec file. Must match the job-spec mount on the sidecar:
-// internal/runtimes/k8s/job_builders.go jobSpecMountPath + subPath jobSpecFileName.
-const JobSpecPathDefault = "/meta/job.json"
-
-// /api/2.0|3.0/mlflow/* proxied to mlflow.tracking_uri.
-const (
-	mlflowAPIv2PathPrefix = "/api/2.0/mlflow"
-	mlflowAPIv3PathPrefix = "/api/3.0/mlflow"
-)
-
-func isMLflowProxyPath(path string) bool {
-	return strings.HasPrefix(path, mlflowAPIv2PathPrefix) || strings.HasPrefix(path, mlflowAPIv3PathPrefix)
-}
 
 // Handlers holds service state for HTTP handlers.
 // Reverse proxies are created once at startup and reused for all requests.
@@ -46,6 +24,7 @@ type Handlers struct {
 	ociRepository    string                  // from job spec; used to route requests to /registry/{ociRepository}
 }
 
+// New creates handlers and builds reverse proxies for eval-hub, MLflow, and optionally OCI.
 func New(config *config.Config, logger *slog.Logger) (*Handlers, error) {
 	evalHubProxy, err := newEvalhubProxy(config, logger)
 	if err != nil {
@@ -73,107 +52,12 @@ func New(config *config.Config, logger *slog.Logger) (*Handlers, error) {
 	}, nil
 }
 
-func newMlflowProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, error) {
-	mlflowTrackingURI := ""
-	if config.MLFlow != nil {
-		mlflowTrackingURI = strings.TrimSpace(config.MLFlow.TrackingURI)
-	}
-	if mlflowTrackingURI == "" {
-		logger.Warn("mlflow.tracking_uri is not set in sidecar config")
-		return nil, nil
-	}
-	mlflowHTTPClient, err := proxy.NewMLFlowHTTPClient(config, config.IsOTELEnabled(), logger)
-	if err != nil {
-		logger.Error("failed to create mlflow HTTP client", "error", err)
-		return nil, fmt.Errorf("failed to create mlflow HTTP client: %w", err)
-	}
-	mlflowTarget, err := url.Parse(strings.TrimSuffix(mlflowTrackingURI, "/"))
-	if err != nil {
-		return nil, fmt.Errorf("invalid mlflow.tracking_uri: %w", err)
-	}
-
-	mlflowProxy := proxy.NewReverseProxy(mlflowTarget, mlflowHTTPClient, logger, nil)
-	return mlflowProxy, nil
-}
-
-func newEvalhubProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, error) {
-	evalHubHTTPClient, err := proxy.NewEvalHubHTTPClient(config, config.IsOTELEnabled(), logger)
-	if err != nil {
-		logger.Error("failed to create eval-hub HTTP client", "error", err)
-		return nil, fmt.Errorf("failed to create eval-hub HTTP client: %w", err)
-	}
-	evalHubBaseURL := ""
-	if config.Sidecar != nil && config.Sidecar.EvalHub != nil {
-		evalHubBaseURL = strings.TrimSpace(config.Sidecar.EvalHub.BaseURL)
-	}
-	if evalHubBaseURL == "" {
-		return nil, fmt.Errorf("eval_hub.base_url is not set in sidecar config")
-	}
-	evalHubTarget, err := url.Parse(strings.TrimSuffix(evalHubBaseURL, "/"))
-	if err != nil {
-		return nil, fmt.Errorf("invalid EVALHUB_URL: %w", err)
-	}
-	evalHubProxy := proxy.NewReverseProxy(evalHubTarget, evalHubHTTPClient, logger, nil)
-	return evalHubProxy, nil
-}
-
-func newOciProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, *proxy.OCITokenProducer, string, error) {
-	if config == nil || config.Sidecar == nil {
-		return nil, nil, "", nil
-	}
-	jobSpecPath := os.Getenv("JOB_SPEC_PATH")
-	if jobSpecPath == "" {
-		jobSpecPath = JobSpecPathDefault
-	}
-	host, repository, err := proxy.GetOCICoordinatesFromJobSpec(jobSpecPath)
-	if err != nil {
-		logger.Debug("OCI proxy disabled: could not read job spec for OCI coordinates", "path", jobSpecPath, "error", err)
-		return nil, nil, "", nil
-	}
-	if host == "" {
-		logger.Debug("OCI proxy disabled: job spec has no exports.oci with registry host", "path", jobSpecPath)
-		return nil, nil, "", nil
-	}
-	// OCI reverse proxy is enabled from job spec (exports.oci + coordinates), not from eval-hub
-	// service YAML sidecar.oci. sidecar_config.json "oci" is optional: TLS/timeout overrides only
-	// (see NewOCIHTTPClient).
-	ociHTTPClient, err := proxy.NewOCIHTTPClient(config, config.IsOTELEnabled(), logger)
-	if err != nil {
-		logger.Error("failed to create OCI HTTP client", "error", err)
-		return nil, nil, "", fmt.Errorf("failed to create OCI HTTP client: %w", err)
-	}
-	if ociHTTPClient == nil {
-		return nil, nil, "", fmt.Errorf("OCI HTTP client is required for OCI proxy")
-	}
-	ociSecretMountPath := os.Getenv("OCI_AUTH_CONFIG_PATH")
-	if ociSecretMountPath == "" {
-		ociSecretMountPath = OCIAuthConfigPathDefault
-	}
-	tokenProducer, err := proxy.LoadTokenProducerFromOCISecret(ociSecretMountPath, host, repository, ociHTTPClient)
-	if err != nil {
-		logger.Error("failed to create OCI token producer from OCI secret", "path", ociSecretMountPath, "error", err)
-		return nil, nil, "", fmt.Errorf("OCI token producer: %w", err)
-	}
-	ociTarget, err := url.Parse(strings.TrimSuffix(host, "/"))
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("invalid OCI registry host from job spec %q: %w", host, err)
-	}
-	rp := proxy.NewReverseProxy(ociTarget, ociHTTPClient, logger, func(resp *http.Response) error {
-		proxy.ModifyOCIRegistryResponse(resp, logger, tokenProducer)
-		return nil
-	})
-	logger.Info("OCI registry proxy enabled",
-		"registry_host", host,
-		"oci_repository", repository,
-		"job_spec", jobSpecPath,
-	)
-	return rp, tokenProducer, repository, nil
-}
-
+// HandleHealth responds OK for liveness.
 func (h *Handlers) HandleHealth(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// HandleProxyCall routes the request to the correct reverse proxy (Eval Hub API, MLflow, or OCI).
 func (h *Handlers) HandleProxyCall(w http.ResponseWriter, r *http.Request) {
 	proxyHandler, tokenParams, err := h.parseProxyCall(r)
 	if err != nil {
@@ -193,63 +77,6 @@ func requestPathForRouting(uri string) string {
 		return uri
 	}
 	return u.EscapedPath()
-}
-
-func splitPathSegments(p string) []string {
-	p = strings.Trim(p, "/")
-	if p == "" {
-		return nil
-	}
-	parts := strings.Split(p, "/")
-	out := parts[:0]
-	for _, s := range parts {
-		if s != "" {
-			out = append(out, s)
-		}
-	}
-	return out
-}
-
-func pathSegmentsEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// ociRouteMatch returns true if the request should be routed to the OCI proxy.
-// Matching uses only the path (query and fragment are ignored). The job-spec repository
-// must appear as a full consecutive sequence of path segments, either at the start of
-// the path or immediately after a "v2" segment (OCI distribution API), e.g. /v2/org/repo/...
-// matches repo "org/repo" but /v2/ac/org/repo/... does not.
-func (h *Handlers) ociRouteMatch(uri string) bool {
-	if h.ociRepository == "" {
-		return false
-	}
-	path := requestPathForRouting(uri)
-	repoParts := splitPathSegments(h.ociRepository)
-	if len(repoParts) == 0 {
-		return false
-	}
-	pathParts := splitPathSegments(path)
-	if len(pathParts) < len(repoParts) {
-		return false
-	}
-	n := len(repoParts)
-	for i := 0; i+n <= len(pathParts); i++ {
-		if !pathSegmentsEqual(pathParts[i:i+n], repoParts) {
-			continue
-		}
-		if i == 0 || pathParts[i-1] == "v2" {
-			return true
-		}
-	}
-	return false
 }
 
 func (h *Handlers) parseProxyCall(r *http.Request) (*httputil.ReverseProxy, *proxy.AuthTokenInput, error) {

--- a/internal/eval_runtime_sidecar/handlers/handlers_test.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers_test.go
@@ -132,7 +132,6 @@ func TestHandlers_HandleProxyCall(t *testing.T) {
 			"/api/2.0/mlflow-artifacts",
 			"/api/2.0/mlflow-artifacts/artifact",
 			"/api/2.0/mlflow-artifacts/get-artifact?path=x",
-			"/api/2.0/mlflow-custom/endpoint",
 			"/api/3.0/mlflow/traces/search",
 			"/api/3.0/mlflow/traces/tr-abc123",
 			"/api/3.0/mlflow/server-info",
@@ -142,6 +141,24 @@ func TestHandlers_HandleProxyCall(t *testing.T) {
 			h.HandleProxyCall(rw, req)
 			if strings.Contains(rw.Body.String(), "unknown proxy call") {
 				t.Errorf("%q: expected mlflow route, got unknown proxy call", path)
+			}
+		}
+	})
+
+	t.Run("paths that look like mlflow but are not the MLflow API roots are unknown", func(t *testing.T) {
+		for _, path := range []string{
+			"/api/2.0/mlflowx/anything",
+			"/api/3.0/mlflowx/anything",
+			"/api/2.0/mlflow-custom/endpoint",
+		} {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			rw := httptest.NewRecorder()
+			h.HandleProxyCall(rw, req)
+			if rw.Code != http.StatusBadRequest {
+				t.Errorf("%q: status = %d, want 400", path, rw.Code)
+			}
+			if !strings.Contains(rw.Body.String(), "unknown proxy call") {
+				t.Errorf("%q: expected unknown proxy call", path)
 			}
 		}
 	})
@@ -223,15 +240,18 @@ func TestIsMLflowProxyPath(t *testing.T) {
 		{"/api/2.0/mlflow", true},
 		{"/api/2.0/mlflow/", true},
 		{"/api/2.0/mlflow/experiments/list", true},
-		{"/api/2.0/mlflow-extra", true},
+		{"/api/2.0/mlflowx", false},
+		{"/api/2.0/mlflowx/", false},
+		{"/api/2.0/mlflow-extra", false},
 		{"/api/2.0/mlflow-artifacts", true},
 		{"/api/2.0/mlflow-artifacts/", true},
 		{"/api/2.0/mlflow-artifacts/get-artifact", true},
-		{"/api/2.0/mlflow-artifactsmalicious", true},
+		{"/api/2.0/mlflow-artifactsmalicious", false},
 		{"/api/2.0/ml", false},
 		{"/prefix/api/2.0/mlflow/runs", false},
 		{"/api/3.0/mlflow/server-info", true},
 		{"/api/3.0/mlflow/traces/search", true},
+		{"/api/3.0/mlflowx", false},
 		{"/api/3.0/ml", false},
 		{"/prefix/api/3.0/mlflow/server-info", false},
 	}

--- a/internal/eval_runtime_sidecar/handlers/mlflow.go
+++ b/internal/eval_runtime_sidecar/handlers/mlflow.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_runtime_sidecar/proxy"
+)
+
+// MLFlowTokenPathDefault is the default path for the MLflow bearer token in the container.
+const MLFlowTokenPathDefault = "/var/run/secrets/mlflow/token"
+
+// /api/2.0|3.0/mlflow/... and /api/2.0/mlflow-artifacts/... are proxied to mlflow.tracking_uri.
+// (mlflow-artifacts is a separate top-level path on the tracking server, not under /mlflow/.)
+const (
+	mlflowAPIv2PathPrefix          = "/api/2.0/mlflow"
+	mlflowAPIv3PathPrefix          = "/api/3.0/mlflow"
+	mlflowAPIv2ArtifactsPathPrefix = "/api/2.0/mlflow-artifacts"
+)
+
+// isMLflowProxyPath returns true for the MLflow REST API roots, requiring an exact path or a
+// subpath (prefix + "/") so names like /api/2.0/mlflowx do not match /api/2.0/mlflow.
+func isMLflowProxyPath(path string) bool {
+	return mlflowPathMatchesPrefix(path, mlflowAPIv2PathPrefix) ||
+		mlflowPathMatchesPrefix(path, mlflowAPIv3PathPrefix) ||
+		mlflowPathMatchesPrefix(path, mlflowAPIv2ArtifactsPathPrefix)
+}
+
+func mlflowPathMatchesPrefix(path, prefix string) bool {
+	return path == prefix || strings.HasPrefix(path, prefix+"/")
+}
+
+func newMlflowProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, error) {
+	mlflowTrackingURI := ""
+	if config.MLFlow != nil {
+		mlflowTrackingURI = strings.TrimSpace(config.MLFlow.TrackingURI)
+	}
+	if mlflowTrackingURI == "" {
+		logger.Warn("mlflow.tracking_uri is not set in sidecar config")
+		return nil, nil
+	}
+	mlflowHTTPClient, err := proxy.NewMLFlowHTTPClient(config, config.IsOTELEnabled(), logger)
+	if err != nil {
+		logger.Error("failed to create mlflow HTTP client", "error", err)
+		return nil, fmt.Errorf("failed to create mlflow HTTP client: %w", err)
+	}
+	mlflowTarget, err := url.Parse(strings.TrimSuffix(mlflowTrackingURI, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid mlflow.tracking_uri: %w", err)
+	}
+
+	mlflowProxy := proxy.NewReverseProxy(mlflowTarget, mlflowHTTPClient, logger, nil)
+	return mlflowProxy, nil
+}

--- a/internal/eval_runtime_sidecar/handlers/oci.go
+++ b/internal/eval_runtime_sidecar/handlers/oci.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_runtime_sidecar/proxy"
+)
+
+// OCIAuthConfigPathDefault is the default path for the registry auth config file. Must match the OCI secret
+// mount path on adapter and sidecar: internal/runtimes/k8s/job_builders.go ociCredentialsMountPath.
+const OCIAuthConfigPathDefault = "/etc/evalhub/.docker/config.json"
+
+// JobSpecPathDefault is the default path for the job spec file. Must match the job-spec mount on the sidecar:
+// internal/runtimes/k8s/job_builders.go jobSpecMountPath + subPath jobSpecFileName.
+const JobSpecPathDefault = "/meta/job.json"
+
+func newOciProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, *proxy.OCITokenProducer, string, error) {
+	if config == nil || config.Sidecar == nil {
+		return nil, nil, "", nil
+	}
+	jobSpecPath := os.Getenv("JOB_SPEC_PATH")
+	if jobSpecPath == "" {
+		jobSpecPath = JobSpecPathDefault
+	}
+	host, repository, err := proxy.GetOCICoordinatesFromJobSpec(jobSpecPath)
+	if err != nil {
+		logger.Debug("OCI proxy disabled: could not read job spec for OCI coordinates", "path", jobSpecPath, "error", err)
+		return nil, nil, "", nil
+	}
+	if host == "" {
+		logger.Debug("OCI proxy disabled: job spec has no exports.oci with registry host", "path", jobSpecPath)
+		return nil, nil, "", nil
+	}
+	// OCI reverse proxy is enabled from job spec (exports.oci + coordinates), not from eval-hub
+	// service YAML sidecar.oci. sidecar_config.json "oci" is optional: TLS/timeout overrides only
+	// (see NewOCIHTTPClient).
+	ociHTTPClient, err := proxy.NewOCIHTTPClient(config, config.IsOTELEnabled(), logger)
+	if err != nil {
+		logger.Error("failed to create OCI HTTP client", "error", err)
+		return nil, nil, "", fmt.Errorf("failed to create OCI HTTP client: %w", err)
+	}
+	if ociHTTPClient == nil {
+		return nil, nil, "", fmt.Errorf("OCI HTTP client is required for OCI proxy")
+	}
+	ociSecretMountPath := os.Getenv("OCI_AUTH_CONFIG_PATH")
+	if ociSecretMountPath == "" {
+		ociSecretMountPath = OCIAuthConfigPathDefault
+	}
+	tokenProducer, err := proxy.LoadTokenProducerFromOCISecret(ociSecretMountPath, host, repository, ociHTTPClient)
+	if err != nil {
+		logger.Error("failed to create OCI token producer from OCI secret", "path", ociSecretMountPath, "error", err)
+		return nil, nil, "", fmt.Errorf("OCI token producer: %w", err)
+	}
+	ociTarget, err := url.Parse(strings.TrimSuffix(host, "/"))
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("invalid OCI registry host from job spec %q: %w", host, err)
+	}
+	rp := proxy.NewReverseProxy(ociTarget, ociHTTPClient, logger, func(resp *http.Response) error {
+		proxy.ModifyOCIRegistryResponse(resp, logger, tokenProducer)
+		return nil
+	})
+	logger.Info("OCI registry proxy enabled",
+		"registry_host", host,
+		"oci_repository", repository,
+		"job_spec", jobSpecPath,
+	)
+	return rp, tokenProducer, repository, nil
+}
+
+// ociRouteMatch returns true if the request should be routed to the OCI proxy.
+// Matching uses only the path (query and fragment are ignored). The job-spec repository
+// must appear as a full consecutive sequence of path segments, either at the start of
+// the path or immediately after a "v2" segment (OCI distribution API), e.g. /v2/org/repo/...
+// matches repo "org/repo" but /v2/ac/org/repo/... does not.
+func (h *Handlers) ociRouteMatch(uri string) bool {
+	if h.ociRepository == "" {
+		return false
+	}
+	path := requestPathForRouting(uri)
+	repoParts := splitPathSegments(h.ociRepository)
+	if len(repoParts) == 0 {
+		return false
+	}
+	pathParts := splitPathSegments(path)
+	if len(pathParts) < len(repoParts) {
+		return false
+	}
+	n := len(repoParts)
+	for i := 0; i+n <= len(pathParts); i++ {
+		if !pathSegmentsEqual(pathParts[i:i+n], repoParts) {
+			continue
+		}
+		if i == 0 || pathParts[i-1] == "v2" {
+			return true
+		}
+	}
+	return false
+}
+
+func splitPathSegments(p string) []string {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return nil
+	}
+	parts := strings.Split(p, "/")
+	out := parts[:0]
+	for _, s := range parts {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func pathSegmentsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved eval-hub, MLflow, and OCI registry proxy support in the runtime sidecar with stronger endpoint validation and clearer error logging.
  * Proxies now normalize and validate backend URLs before use.

* **Bug Fixes**
  * Stricter MLflow route matching to avoid false-positive matches for lookalike paths.

* **Tests**
  * Added tests covering invalid/ambiguous MLflow-like routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->