### PR TITLE
feat(mcp): core MCP server & transport layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,11 @@ go run cmd/eval_hub/main.go       # Direct Go execution
 ### Building
 
 ```bash
-make build              # Build service, eval_runtime_init, and eval_runtime_sidecar into bin/
+make build              # Build all binaries (service, init, sidecar, mcp) into bin/
+make build-service      # Build only the API service binary
+make build-mcp          # Build only the evalhub-mcp MCP server binary
 ./bin/eval-hub          # Run the API service binary
+./bin/evalhub-mcp       # Run the MCP server binary
 ```
 
 ### Testing
@@ -38,10 +41,12 @@ go test -v ./tests/features -run TestFeatureName
 ### Code Quality
 
 ```bash
-make lint               # Run go vet
-make vet                # Run go vet
 make fmt                # Format code with go fmt
+make lint               # Run go vet
+make vet                # Run go vet (same as lint)
 ```
+
+**Always run `make fmt lint` after file changes and before committing.** This ensures consistent formatting and catches issues early.
 
 ### Dependencies
 
@@ -89,9 +94,11 @@ Generated with: Claude Code
 This project follows the standard Go project layout with a clear separation between public entry points (`cmd/`) and private application code (`internal/`). See **ARCHITECTURE.md** for a concise layout and request flow.
 
 - **cmd/eval_hub/** - Main API service entry point
+- **cmd/evalhub_mcp/** - MCP server entry point (stdio and HTTP transports)
 - **cmd/eval_runtime_init/** - Init container for Kubernetes job pods
 - **cmd/eval_runtime_sidecar/** - Sidecar for job pods (proxy, readiness, termination log)
 - **pkg/api/** - Shared API types (IDs, errors, request/response shapes)
+- **pkg/evalhubclient/** - HTTP client library for the eval-hub REST API (used by MCP server and external consumers)
 - **auth/** - Authentication configuration and HTTP middleware helpers
 - **internal/eval_hub/abstractions/** - `Storage`, `Runtime`, and related interfaces
 - **internal/eval_hub/config/** - Configuration loading with Viper
@@ -104,6 +111,8 @@ This project follows the standard Go project layout with a clear separation betw
 - **internal/logging/** - Logger creation (zap backend, `slog` API)
 - **internal/eval_hub/metrics/** - Prometheus metrics and middleware
 - **internal/eval_hub/server/** - Server setup, routing, auth wiring, `newExecutionContext`
+- **internal/evalhub_mcp/config/** - MCP server configuration (CLI flags, YAML profiles, env vars)
+- **internal/evalhub_mcp/server/** - MCP server setup (transport selection, capabilities, client wiring)
 - **docs/src/openapi.yaml** - OpenAPI 3.1.0 specification source; bundled/public copies under **docs/** (see `make generate-public-docs`)
 - **tests/features/** - BDD-style FVT tests using godog
 
@@ -209,7 +218,8 @@ Located alongside code in `*_test.go` files:
 
 - Test individual handlers, middleware, server setup
 - Use standard library `testing` package
-- Found in: `auth/**/*_test.go`, `internal/**/*_test.go`, `cmd/**/*_test.go`
+- Found in: `auth/**/*_test.go`, `internal/**/*_test.go`, `cmd/**/*_test.go`, `pkg/**/*_test.go`
+- MCP server tests use `mcp.NewInMemoryTransports()` for in-process initialize handshake and capability verification
 
 #### FVT (Functional Verification Tests)
 
@@ -238,6 +248,38 @@ Main function (`cmd/eval_hub/main.go`) implements graceful shutdown:
 4. Starts server in a goroutine
 5. Waits for SIGINT/SIGTERM
 6. Gracefully shuts down with a bounded timeout
+
+### MCP Server
+
+The MCP (Model Context Protocol) server exposes eval-hub functionality to AI agents. Entry point: `cmd/evalhub_mcp/main.go`.
+
+```bash
+# Run directly
+go run cmd/evalhub_mcp/main.go                          # stdio transport (default)
+go run cmd/evalhub_mcp/main.go --transport http          # HTTP/SSE transport on localhost:3001
+go run cmd/evalhub_mcp/main.go --transport http --port 4000 --host 0.0.0.0
+
+# Build and run
+make build-mcp
+./bin/evalhub-mcp --version
+./bin/evalhub-mcp --transport http
+
+# Run MCP-specific tests
+go test -v ./cmd/evalhub_mcp/ ./internal/evalhub_mcp/...
+```
+
+**CLI flags:** `--transport stdio|http`, `--host`, `--port`, `--config`, `--insecure`, `--version`
+
+**Configuration precedence:** CLI flags > YAML config (`~/.evalhub/config.yaml`) > env vars (`EVALHUB_BASE_URL`, `EVALHUB_TOKEN`, `EVALHUB_TENANT`, `EVALHUB_INSECURE`)
+
+**Architecture:**
+
+- `server.New()` creates the MCP server with advertised capabilities (tools, resources, prompts)
+- `server.NewEvalHubClient()` creates an eval-hub API client from config
+- `server.RegisterHandlers()` wires tool/resource/prompt handlers; handlers access the API client via closures
+- Server metadata (name, version+build hash) is returned in the MCP `initialize` handshake
+- Both transports share the same `*mcp.Server` instance, so capability listings are identical
+- Uses `github.com/modelcontextprotocol/go-sdk` (Go MCP SDK)
 
 ### Important Implementation Notes
 

--- a/cmd/evalhub_mcp/main.go
+++ b/cmd/evalhub_mcp/main.go
@@ -24,6 +24,13 @@ func main() {
 }
 
 func run(args []string) int {
+	logger, shutdown, err := logging.NewLogger()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
+		return 1
+	}
+	defer shutdown() //nolint:errcheck
+
 	fs := flag.NewFlagSet("evalhub-mcp", flag.ContinueOnError)
 
 	transport := fs.String("transport", "stdio", "Transport mode: stdio or http")
@@ -34,7 +41,7 @@ func run(args []string) int {
 	version := fs.Bool("version", false, "Print version information and exit")
 
 	if err := fs.Parse(args); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		logger.Error("failed to parse flags", "error", err)
 		return 1
 	}
 
@@ -42,13 +49,6 @@ func run(args []string) int {
 		printVersion()
 		return 0
 	}
-
-	logger, shutdown, err := logging.NewLogger()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
-		return 1
-	}
-	defer shutdown() //nolint:errcheck
 
 	flags := &config.Flags{
 		ConfigPath: *configPath,

--- a/cmd/evalhub_mcp/main.go
+++ b/cmd/evalhub_mcp/main.go
@@ -112,4 +112,3 @@ func printVersion() {
 	}
 	fmt.Println()
 }
-

--- a/cmd/evalhub_mcp/main.go
+++ b/cmd/evalhub_mcp/main.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/eval-hub/eval-hub/internal/evalhub_mcp/config"
 	mcpserver "github.com/eval-hub/eval-hub/internal/evalhub_mcp/server"
+	"github.com/eval-hub/eval-hub/internal/logging"
 	flag "github.com/spf13/pflag"
 )
 
@@ -43,6 +43,13 @@ func run(args []string) int {
 		return 0
 	}
 
+	logger, shutdown, err := logging.NewLogger()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
+		return 1
+	}
+	defer shutdown() //nolint:errcheck
+
 	flags := &config.Flags{
 		ConfigPath: *configPath,
 	}
@@ -61,12 +68,12 @@ func run(args []string) int {
 
 	cfg, err := config.Load(flags)
 	if err != nil {
-		log.Printf("Failed to load configuration: %v", err)
+		logger.Error("failed to load configuration", "error", err)
 		return 1
 	}
 
 	if err := config.Validate(cfg); err != nil {
-		log.Printf("Invalid configuration: %v", err)
+		logger.Error("invalid configuration", "error", err)
 		return 1
 	}
 
@@ -81,8 +88,14 @@ func run(args []string) int {
 		cancel()
 	}()
 
-	if err := mcpserver.Run(ctx, cfg, Version); err != nil {
-		log.Printf("Server error: %v", err)
+	info := &mcpserver.ServerInfo{
+		Version:   Version,
+		Build:     Build,
+		BuildDate: BuildDate,
+	}
+
+	if err := mcpserver.Run(ctx, cfg, info, logger); err != nil {
+		logger.Error("server error", "error", err)
 		return 1
 	}
 
@@ -99,3 +112,4 @@ func printVersion() {
 	}
 	fmt.Println()
 }
+

--- a/cmd/evalhub_mcp/main_test.go
+++ b/cmd/evalhub_mcp/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"log"
 	"os"
 	"testing"
 )
@@ -70,10 +69,6 @@ func TestInvalidFlag(t *testing.T) {
 }
 
 func TestInvalidTransportFlag(t *testing.T) {
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	t.Cleanup(func() { log.SetOutput(os.Stderr) })
-
 	code := run([]string{"--transport", "grpc"})
 	if code != 1 {
 		t.Fatalf("expected exit code 1 for invalid transport, got %d", code)
@@ -81,10 +76,6 @@ func TestInvalidTransportFlag(t *testing.T) {
 }
 
 func TestConfigLoadError(t *testing.T) {
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	t.Cleanup(func() { log.SetOutput(os.Stderr) })
-
 	code := run([]string{"--config", "/nonexistent/config.yaml"})
 	if code != 1 {
 		t.Fatalf("expected exit code 1 for missing config, got %d", code)

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -4,29 +4,92 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/evalhub_mcp/config"
+	"github.com/eval-hub/eval-hub/pkg/evalhubclient"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func Run(ctx context.Context, cfg *config.Config, version string) error {
-	srv := mcp.NewServer(
+type ServerInfo struct {
+	Version   string
+	Build     string
+	BuildDate string
+}
+
+func (s *ServerInfo) VersionString() string {
+	if s.Build != "" {
+		return s.Version + "+" + s.Build
+	}
+	return s.Version
+}
+
+// New creates a configured MCP server with capabilities advertised for tools,
+// resources, and prompts. The returned server is ready to be connected to a
+// transport via Run, or used directly with in-memory transports for testing.
+func New(info *ServerInfo, logger *slog.Logger) *mcp.Server {
+	return mcp.NewServer(
 		&mcp.Implementation{
 			Name:    "evalhub-mcp",
-			Version: version,
+			Version: info.VersionString(),
 		},
-		nil,
+		&mcp.ServerOptions{
+			Logger: logger,
+			Capabilities: &mcp.ServerCapabilities{
+				Logging:   &mcp.LoggingCapabilities{},
+				Tools:     &mcp.ToolCapabilities{ListChanged: true},
+				Resources: &mcp.ResourceCapabilities{ListChanged: true},
+				Prompts:   &mcp.PromptCapabilities{ListChanged: true},
+			},
+		},
+	)
+}
+
+// NewEvalHubClient creates an EvalHub API client from the MCP server configuration.
+// Returns nil when no BaseURL is configured.
+func NewEvalHubClient(cfg *config.Config, logger *slog.Logger) *evalhubclient.Client {
+	if cfg.BaseURL == "" {
+		return nil
+	}
+	client := evalhubclient.NewClient(cfg.BaseURL).WithLogger(logger)
+	if cfg.Token != "" {
+		client = client.WithToken(cfg.Token)
+	}
+	if cfg.Tenant != "" {
+		client = client.WithTenant(cfg.Tenant)
+	}
+	if cfg.Insecure {
+		client = client.WithInsecureSkipVerify()
+	}
+	return client
+}
+
+// RegisterHandlers wires tool, resource, and prompt handlers into the MCP
+// server. The EvalHub client is captured by handler closures so that every
+// handler has access to the API without global state.
+func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, logger *slog.Logger) {
+	// Handlers will be registered here by subsequent tickets.
+	// The client and logger are available to all handler closures added below.
+}
+
+func Run(ctx context.Context, cfg *config.Config, info *ServerInfo, logger *slog.Logger) error {
+	client := NewEvalHubClient(cfg, logger)
+	srv := New(info, logger)
+	RegisterHandlers(srv, client, logger)
+
+	logger.Info("starting evalhub-mcp server",
+		"version", info.VersionString(),
+		"transport", cfg.Transport,
 	)
 
 	switch cfg.Transport {
 	case "stdio":
 		return runStdio(ctx, srv)
 	case "http":
-		return runHTTP(ctx, srv, cfg)
+		return runHTTP(ctx, srv, cfg, logger)
 	default:
 		return fmt.Errorf("unsupported transport: %s", cfg.Transport)
 	}
@@ -36,7 +99,7 @@ func runStdio(ctx context.Context, srv *mcp.Server) error {
 	return srv.Run(ctx, &mcp.StdioTransport{})
 }
 
-func runHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config) error {
+func runHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *slog.Logger) error {
 	handler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server { return srv },
 		nil,
@@ -50,6 +113,7 @@ func runHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config) error {
 
 	errCh := make(chan error, 1)
 	go func() {
+		logger.Info("HTTP transport listening", "addr", addr)
 		errCh <- httpServer.ListenAndServe()
 	}()
 
@@ -63,12 +127,13 @@ func runHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config) error {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if shutdownErr := httpServer.Shutdown(shutdownCtx); shutdownErr != nil {
-			log.Printf("HTTP server graceful shutdown failed: %v", shutdownErr)
+			logger.Error("HTTP server graceful shutdown failed", "error", shutdownErr)
 			if closeErr := httpServer.Close(); closeErr != nil {
 				return errors.Join(shutdownErr, closeErr)
 			}
 			return shutdownErr
 		}
+		logger.Info("HTTP server stopped gracefully")
 		return nil
 	}
 }

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -31,10 +31,14 @@ func (s *ServerInfo) VersionString() string {
 // resources, and prompts. The returned server is ready to be connected to a
 // transport via Run, or used directly with in-memory transports for testing.
 func New(info *ServerInfo, logger *slog.Logger) *mcp.Server {
+	version := "unknown"
+	if info != nil {
+		version = info.VersionString()
+	}
 	return mcp.NewServer(
 		&mcp.Implementation{
 			Name:    "evalhub-mcp",
-			Version: info.VersionString(),
+			Version: version,
 		},
 		&mcp.ServerOptions{
 			Logger: logger,

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -84,8 +84,12 @@ func Run(ctx context.Context, cfg *config.Config, info *ServerInfo, logger *slog
 	srv := New(info, logger)
 	RegisterHandlers(srv, client, logger)
 
+	version := "unknown"
+	if info != nil {
+		version = info.VersionString()
+	}
 	logger.Info("starting evalhub-mcp server",
-		"version", info.VersionString(),
+		"version", version,
 		"transport", cfg.Transport,
 	)
 

--- a/internal/evalhub_mcp/server/server_test.go
+++ b/internal/evalhub_mcp/server/server_test.go
@@ -3,12 +3,252 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/evalhub_mcp/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+var discardLogger = slog.New(slog.DiscardHandler)
+
+// --- ServerInfo ---
+
+func TestVersionString(t *testing.T) {
+	tests := []struct {
+		info *ServerInfo
+		want string
+	}{
+		{&ServerInfo{Version: "0.1.0"}, "0.1.0"},
+		{&ServerInfo{Version: "0.1.0", Build: "abc123"}, "0.1.0+abc123"},
+		{&ServerInfo{Version: "0.4.0", Build: "deadbeef", BuildDate: "2026-01-01"}, "0.4.0+deadbeef"},
+	}
+	for _, tt := range tests {
+		if got := tt.info.VersionString(); got != tt.want {
+			t.Errorf("VersionString() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+// --- NewEvalHubClient ---
+
+func TestNewEvalHubClientNilWhenNoBaseURL(t *testing.T) {
+	cfg := &config.Config{}
+	client := NewEvalHubClient(cfg, discardLogger)
+	if client != nil {
+		t.Error("expected nil client when BaseURL is empty")
+	}
+}
+
+func TestNewEvalHubClientCreated(t *testing.T) {
+	cfg := &config.Config{
+		BaseURL:  "http://localhost:8080",
+		Token:    "test-token",
+		Tenant:   "test-tenant",
+		Insecure: true,
+	}
+	client := NewEvalHubClient(cfg, discardLogger)
+	if client == nil {
+		t.Fatal("expected non-nil client when BaseURL is set")
+	}
+}
+
+// --- MCP server via in-memory transport ---
+
+func TestInitializeHandshake(t *testing.T) {
+	info := &ServerInfo{Version: "0.1.0", Build: "test123"}
+	srv := New(info, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect failed: %v", err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	defer clientSession.Close()
+}
+
+func TestServerMetadata(t *testing.T) {
+	info := &ServerInfo{Version: "0.2.0", Build: "deadbeef"}
+	srv := New(info, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect failed: %v", err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	defer clientSession.Close()
+
+	initResult := clientSession.InitializeResult()
+	if initResult == nil {
+		t.Fatal("InitializeResult is nil")
+	}
+	if initResult.ServerInfo.Name != "evalhub-mcp" {
+		t.Errorf("server name = %q, want %q", initResult.ServerInfo.Name, "evalhub-mcp")
+	}
+	if initResult.ServerInfo.Version != "0.2.0+deadbeef" {
+		t.Errorf("server version = %q, want %q", initResult.ServerInfo.Version, "0.2.0+deadbeef")
+	}
+}
+
+func TestCapabilitiesAdvertised(t *testing.T) {
+	info := &ServerInfo{Version: "0.1.0"}
+	srv := New(info, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect failed: %v", err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	defer clientSession.Close()
+
+	initResult := clientSession.InitializeResult()
+	if initResult == nil {
+		t.Fatal("InitializeResult is nil")
+	}
+	caps := initResult.Capabilities
+	if caps.Tools == nil {
+		t.Error("expected tools capability to be advertised")
+	}
+	if caps.Resources == nil {
+		t.Error("expected resources capability to be advertised")
+	}
+	if caps.Prompts == nil {
+		t.Error("expected prompts capability to be advertised")
+	}
+	if caps.Logging == nil {
+		t.Error("expected logging capability to be advertised")
+	}
+}
+
+func TestToolsListEmpty(t *testing.T) {
+	info := &ServerInfo{Version: "0.1.0"}
+	srv := New(info, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect failed: %v", err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	defer clientSession.Close()
+
+	toolsResult, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+	if len(toolsResult.Tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(toolsResult.Tools))
+	}
+}
+
+func TestResourcesListEmpty(t *testing.T) {
+	info := &ServerInfo{Version: "0.1.0"}
+	srv := New(info, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect failed: %v", err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	defer clientSession.Close()
+
+	resourcesResult, err := clientSession.ListResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResources failed: %v", err)
+	}
+	if len(resourcesResult.Resources) != 0 {
+		t.Errorf("expected 0 resources, got %d", len(resourcesResult.Resources))
+	}
+}
+
+func TestPromptsListEmpty(t *testing.T) {
+	info := &ServerInfo{Version: "0.1.0"}
+	srv := New(info, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect failed: %v", err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	defer clientSession.Close()
+
+	promptsResult, err := clientSession.ListPrompts(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListPrompts failed: %v", err)
+	}
+	if len(promptsResult.Prompts) != 0 {
+		t.Errorf("expected 0 prompts, got %d", len(promptsResult.Prompts))
+	}
+}
+
+// --- Transport selection ---
 
 func TestRunHTTPStartsAndStops(t *testing.T) {
 	port := freePort(t)
@@ -18,12 +258,13 @@ func TestRunHTTPStartsAndStops(t *testing.T) {
 		Host:      "127.0.0.1",
 		Port:      port,
 	}
+	info := &ServerInfo{Version: "test"}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- Run(ctx, cfg, "test")
+		errCh <- Run(ctx, cfg, info, discardLogger)
 	}()
 
 	waitForPort(t, cfg.Host, port, 3*time.Second)
@@ -53,8 +294,9 @@ func TestRunHTTPPortInUse(t *testing.T) {
 		Host:      "127.0.0.1",
 		Port:      port,
 	}
+	info := &ServerInfo{Version: "test"}
 
-	err = Run(context.Background(), cfg, "test")
+	err = Run(context.Background(), cfg, info, discardLogger)
 	if err == nil {
 		t.Fatal("expected error when port is in use")
 	}
@@ -64,11 +306,15 @@ func TestRunInvalidTransport(t *testing.T) {
 	cfg := &config.Config{
 		Transport: "grpc",
 	}
-	err := Run(context.Background(), cfg, "test")
+	info := &ServerInfo{Version: "test"}
+
+	err := Run(context.Background(), cfg, info, discardLogger)
 	if err == nil {
 		t.Fatal("expected error for unsupported transport")
 	}
 }
+
+// --- helpers ---
 
 func freePort(t *testing.T) int {
 	t.Helper()


### PR DESCRIPTION
## Summary

Implements [RHOAIENG-60344](https://redhat.atlassian.net/browse/RHOAIENG-60344): Core MCP Server & Transport Layer.

- Initialize MCP server with advertised capabilities for tools, resources, and prompts
- Wire EvalHub API client into server context so all future handlers can access it via closures
- Expose server name (`evalhub-mcp`), version, and build hash in MCP `initialize` response metadata
- Support both **stdio** (default) and **HTTP/SSE** transports via `--transport stdio|http` CLI flag
- Replace `log.Printf` with structured `slog` logging (zap backend, consistent with eval-hub patterns)
- Export `New()`, `NewEvalHubClient()`, and `RegisterHandlers()` for testability and future handler registration

### Files changed

| File | Change |
|------|--------|
| `cmd/evalhub_mcp/main.go` | Structured logging, `ServerInfo` with build hash |
| `cmd/evalhub_mcp/main_test.go` | Remove `log.SetOutput` stubs (now uses slog) |
| `internal/evalhub_mcp/server/server.go` | `New()`, `NewEvalHubClient()`, `RegisterHandlers()`, capabilities, slog |
| `internal/evalhub_mcp/server/server_test.go` | MCP in-memory transport tests for handshake, metadata, capabilities |

## Test plan

All tests pass (`go test -v ./cmd/evalhub_mcp/ ./internal/evalhub_mcp/...`):

- [x] `TestVersionString` — version string with/without build hash
- [x] `TestNewEvalHubClientNilWhenNoBaseURL` — nil client when no BaseURL configured
- [x] `TestNewEvalHubClientCreated` — client created with token, tenant, insecure
- [x] `TestInitializeHandshake` — MCP initialize succeeds over in-memory transport
- [x] `TestServerMetadata` — server name and version+build in initialize response
- [x] `TestCapabilitiesAdvertised` — tools, resources, prompts, logging capabilities present
- [x] `TestToolsListEmpty` — `tools/list` returns empty list (capability advertised, no handlers yet)
- [x] `TestResourcesListEmpty` — `resources/list` returns empty list
- [x] `TestPromptsListEmpty` — `prompts/list` returns empty list
- [x] `TestRunHTTPStartsAndStops` — HTTP transport starts and shuts down gracefully
- [x] `TestRunHTTPPortInUse` — error when port is occupied
- [x] `TestRunInvalidTransport` — error for unsupported transport value
- [x] All existing config and main tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build and run instructions with MCP server configuration and test commands.
  * Expanded project structure documentation including MCP server architecture and HTTP client library.

* **Bug Fixes**
  * Improved error reporting with structured logging for better diagnostics during initialization and runtime failures.

* **Tests**
  * Expanded test coverage for server initialization, client configuration, and MCP protocol handshakes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->