### PR TITLE
fix(storage): add decode hook for time.Duration config fields

### DIFF
--- a/internal/eval_hub/storage/sql/sql.go
+++ b/internal/eval_hub/storage/sql/sql.go
@@ -56,8 +56,14 @@ func NewStorage(
 	logger *slog.Logger,
 ) (abstractions.Storage, error) {
 	var sqlConfig shared.SQLDatabaseConfig
-	merr := mapstructure.Decode(config, &sqlConfig)
+	decoder, merr := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
+		Result:     &sqlConfig,
+	})
 	if merr != nil {
+		return nil, merr
+	}
+	if merr = decoder.Decode(config); merr != nil {
 		return nil, merr
 	}
 

--- a/internal/eval_hub/storage/sql/sql_test.go
+++ b/internal/eval_hub/storage/sql/sql_test.go
@@ -15,6 +15,35 @@ var (
 	dbIndex = atomic.Int32{}
 )
 
+func TestNewStorageConnMaxLifetime(t *testing.T) {
+	logger := logging.FallbackLogger()
+
+	t.Run("accepts conn_max_lifetime as duration string", func(t *testing.T) {
+		config := map[string]any{
+			"driver":            "sqlite",
+			"url":               getDBInMemoryURL(getDBName()),
+			"conn_max_lifetime": "30m",
+		}
+		s, err := storage.NewStorage(&config, nil, nil, false, logger)
+		if err != nil {
+			t.Fatalf("NewStorage failed with duration string: %v", err)
+		}
+		s.Close()
+	})
+
+	t.Run("accepts config without conn_max_lifetime", func(t *testing.T) {
+		config := map[string]any{
+			"driver": "sqlite",
+			"url":    getDBInMemoryURL(getDBName()),
+		}
+		s, err := storage.NewStorage(&config, nil, nil, false, logger)
+		if err != nil {
+			t.Fatalf("NewStorage failed without conn_max_lifetime: %v", err)
+		}
+		s.Close()
+	})
+}
+
 func TestSQLStorage(t *testing.T) {
 	t.Run("Check database name is extracted correctly", func(t *testing.T) {
 		data := [][]string{


### PR DESCRIPTION

## What and why

mapstructure.Decode cannot convert string duration values (e.g. "30m") to time.Duration without an explicit StringToTimeDurationHookFunc hook, causing the service to fail on startup when conn_max_lifetime is set in config.


Closes # https://redhat.atlassian.net/browse/RHOAIENG-60507

Assisted-by: Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

```
make clean test-all
make clean test-all-coverage
```


## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration parsing to properly handle duration values specified as string format in storage configuration parameters.

* **Tests**
  * Added test coverage for SQL storage initialization with duration-based configuration settings, including scenarios with and without optional parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->