### PR TITLE
feat(mcp): add MCP resources for collections and jobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@ make vet                # Run go vet (same as lint)
 
 **Always run `make fmt lint` after file changes and before committing.** This ensures consistent formatting and catches issues early.
 
+### Go Version
+
+**Do not modify the Go version in `go.mod`.** The version specified there is the source of truth. If your local Go toolchain is older, use `GOTOOLCHAIN=auto` to let Go automatically download the required version. Never downgrade `go.mod` to match a locally installed toolchain.
+
 ### Dependencies
 
 ```bash

--- a/internal/evalhub_mcp/server/resources.go
+++ b/internal/evalhub_mcp/server/resources.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/eval-hub/eval-hub/pkg/api"
@@ -23,6 +24,11 @@ type EvalHubDiscovery interface {
 	ListBenchmarks() ([]api.BenchmarkResource, error)
 	GetBenchmark(id string) (*api.BenchmarkResource, error)
 	ListBenchmarksByLabel(labels []string) ([]api.BenchmarkResource, error)
+	ListCollections(opts ...evalhubclient.ListOption) (*api.CollectionResourceList, error)
+	GetCollection(id string) (*api.CollectionResource, error)
+	ListJobs(opts ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error)
+	GetJob(id string) (*api.EvaluationJobResource, error)
+	ListJobsByStatus(status api.OverallState, opts ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error)
 }
 
 func registerResources(srv *mcp.Server, ds EvalHubDiscovery, logger *slog.Logger) {
@@ -62,6 +68,43 @@ func registerResources(srv *mcp.Server, ds EvalHubDiscovery, logger *slog.Logger
 		MIMEType:    "application/json",
 		URITemplate: "evalhub://benchmarks/{id}",
 	}, getBenchmarkHandler(ds, logger))
+
+	srv.AddResource(&mcp.Resource{
+		Name:        "collections",
+		Description: "List all benchmark collections",
+		MIMEType:    "application/json",
+		URI:         "evalhub://collections",
+	}, listCollectionsHandler(ds, logger))
+
+	srv.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "collection",
+		Description: "Get a benchmark collection by ID",
+		MIMEType:    "application/json",
+		URITemplate: "evalhub://collections/{id}",
+	}, getCollectionHandler(ds, logger))
+
+	jobsHandler := listJobsHandler(ds, logger)
+
+	srv.AddResource(&mcp.Resource{
+		Name:        "jobs",
+		Description: "List all evaluation jobs",
+		MIMEType:    "application/json",
+		URI:         "evalhub://jobs",
+	}, jobsHandler)
+
+	srv.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "jobs-by-status",
+		Description: "Filter evaluation jobs by status (pending, running, completed, failed, cancelled, partially_failed)",
+		MIMEType:    "application/json",
+		URITemplate: "evalhub://jobs{?status}",
+	}, jobsHandler)
+
+	srv.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:        "job",
+		Description: "Get an evaluation job by ID (includes full status detail and per-benchmark progress)",
+		MIMEType:    "application/json",
+		URITemplate: "evalhub://jobs/{id}",
+	}, getJobHandler(ds, logger))
 }
 
 func listProvidersHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceHandler {
@@ -131,6 +174,78 @@ func getBenchmarkHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceH
 	}
 }
 
+func listCollectionsHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceHandler {
+	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		logger.Debug("reading resource", "uri", req.Params.URI)
+		opts := extractPagination(req.Params.URI)
+		list, err := ds.ListCollections(opts...)
+		if err != nil {
+			return nil, fmt.Errorf("listing collections: %w", err)
+		}
+		items := list.Items
+		if items == nil {
+			items = []api.CollectionResource{}
+		}
+		return jsonResult(items)
+	}
+}
+
+func getCollectionHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceHandler {
+	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		id, err := extractPathID(req.Params.URI, "collections")
+		if err != nil {
+			return nil, err
+		}
+		logger.Debug("reading resource", "uri", req.Params.URI, "id", id)
+		collection, err := ds.GetCollection(id)
+		if err != nil {
+			return nil, toMCPError(req.Params.URI, err)
+		}
+		return jsonResult(collection)
+	}
+}
+
+func listJobsHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceHandler {
+	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		logger.Debug("reading resource", "uri", req.Params.URI)
+		status, hasStatus, err := extractStatus(req.Params.URI)
+		if err != nil {
+			return nil, err
+		}
+		opts := extractPagination(req.Params.URI)
+
+		var list *api.EvaluationJobResourceList
+		if hasStatus {
+			list, err = ds.ListJobsByStatus(status, opts...)
+		} else {
+			list, err = ds.ListJobs(opts...)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("listing jobs: %w", err)
+		}
+		items := list.Items
+		if items == nil {
+			items = []api.EvaluationJobResource{}
+		}
+		return jsonResult(items)
+	}
+}
+
+func getJobHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceHandler {
+	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		id, err := extractPathID(req.Params.URI, "jobs")
+		if err != nil {
+			return nil, err
+		}
+		logger.Debug("reading resource", "uri", req.Params.URI, "id", id)
+		job, err := ds.GetJob(id)
+		if err != nil {
+			return nil, toMCPError(req.Params.URI, err)
+		}
+		return jsonResult(job)
+	}
+}
+
 func extractPathID(rawURI, kind string) (string, error) {
 	u, err := url.Parse(rawURI)
 	if err != nil {
@@ -153,6 +268,41 @@ func extractLabels(rawURI string, logger *slog.Logger) []string {
 		return nil
 	}
 	return u.Query()["label"]
+}
+
+func extractStatus(rawURI string) (api.OverallState, bool, error) {
+	u, err := url.Parse(rawURI)
+	if err != nil {
+		return "", false, nil
+	}
+	s := u.Query().Get("status")
+	if s == "" {
+		return "", false, nil
+	}
+	state, err := api.GetOverallState(s)
+	if err != nil {
+		return "", true, fmt.Errorf("invalid job status %q: valid values are pending, running, completed, failed, cancelled, partially_failed", s)
+	}
+	return state, true, nil
+}
+
+func extractPagination(rawURI string) []evalhubclient.ListOption {
+	u, err := url.Parse(rawURI)
+	if err != nil {
+		return nil
+	}
+	var opts []evalhubclient.ListOption
+	if v := u.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			opts = append(opts, evalhubclient.WithLimit(n))
+		}
+	}
+	if v := u.Query().Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			opts = append(opts, evalhubclient.WithOffset(n))
+		}
+	}
+	return opts
 }
 
 func toMCPError(uri string, err error) error {

--- a/internal/evalhub_mcp/server/resources.go
+++ b/internal/evalhub_mcp/server/resources.go
@@ -177,7 +177,10 @@ func getBenchmarkHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceH
 func listCollectionsHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceHandler {
 	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		logger.Debug("reading resource", "uri", req.Params.URI)
-		opts := extractPagination(req.Params.URI)
+		opts, err := extractPagination(req.Params.URI)
+		if err != nil {
+			return nil, err
+		}
 		list, err := ds.ListCollections(opts...)
 		if err != nil {
 			return nil, fmt.Errorf("listing collections: %w", err)
@@ -212,7 +215,10 @@ func listJobsHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceHandl
 		if err != nil {
 			return nil, err
 		}
-		opts := extractPagination(req.Params.URI)
+		opts, pErr := extractPagination(req.Params.URI)
+		if pErr != nil {
+			return nil, pErr
+		}
 
 		var list *api.EvaluationJobResourceList
 		if hasStatus {
@@ -286,23 +292,31 @@ func extractStatus(rawURI string) (api.OverallState, bool, error) {
 	return state, true, nil
 }
 
-func extractPagination(rawURI string) []evalhubclient.ListOption {
+func extractPagination(rawURI string) ([]evalhubclient.ListOption, error) {
 	u, err := url.Parse(rawURI)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	var opts []evalhubclient.ListOption
 	if v := u.Query().Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid limit %q: must be a positive integer", v)
+		}
+		if n > 0 {
 			opts = append(opts, evalhubclient.WithLimit(n))
 		}
 	}
 	if v := u.Query().Get("offset"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid offset %q: must be a non-negative integer", v)
+		}
+		if n >= 0 {
 			opts = append(opts, evalhubclient.WithOffset(n))
 		}
 	}
-	return opts
+	return opts, nil
 }
 
 func toMCPError(uri string, err error) error {

--- a/internal/evalhub_mcp/server/resources_test.go
+++ b/internal/evalhub_mcp/server/resources_test.go
@@ -16,8 +16,10 @@ import (
 // --- mock data source ---
 
 type mockDataSource struct {
-	providers  []api.ProviderResource
-	benchmarks []api.BenchmarkResource
+	providers   []api.ProviderResource
+	benchmarks  []api.BenchmarkResource
+	collections []api.CollectionResource
+	jobs        []api.EvaluationJobResource
 }
 
 func (m *mockDataSource) ListProviders(_ ...evalhubclient.ListOption) (*api.ProviderResourceList, error) {
@@ -53,6 +55,57 @@ func (m *mockDataSource) GetBenchmark(id string) (*api.BenchmarkResource, error)
 		StatusCode: http.StatusNotFound,
 		Message:    fmt.Sprintf("benchmark %q not found", id),
 	}
+}
+
+func (m *mockDataSource) ListCollections(_ ...evalhubclient.ListOption) (*api.CollectionResourceList, error) {
+	return &api.CollectionResourceList{
+		Items: m.collections,
+		Page:  api.Page{TotalCount: len(m.collections)},
+	}, nil
+}
+
+func (m *mockDataSource) GetCollection(id string) (*api.CollectionResource, error) {
+	for i := range m.collections {
+		if m.collections[i].Resource.ID == id {
+			return &m.collections[i], nil
+		}
+	}
+	return nil, &evalhubclient.APIError{
+		StatusCode: http.StatusNotFound,
+		Message:    fmt.Sprintf("collection %q not found", id),
+	}
+}
+
+func (m *mockDataSource) ListJobs(_ ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error) {
+	return &api.EvaluationJobResourceList{
+		Items: m.jobs,
+		Page:  api.Page{TotalCount: len(m.jobs)},
+	}, nil
+}
+
+func (m *mockDataSource) GetJob(id string) (*api.EvaluationJobResource, error) {
+	for i := range m.jobs {
+		if m.jobs[i].Resource.ID == id {
+			return &m.jobs[i], nil
+		}
+	}
+	return nil, &evalhubclient.APIError{
+		StatusCode: http.StatusNotFound,
+		Message:    fmt.Sprintf("job %q not found", id),
+	}
+}
+
+func (m *mockDataSource) ListJobsByStatus(status api.OverallState, _ ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error) {
+	var filtered []api.EvaluationJobResource
+	for _, j := range m.jobs {
+		if j.Status != nil && j.Status.State == status {
+			filtered = append(filtered, j)
+		}
+	}
+	return &api.EvaluationJobResourceList{
+		Items: filtered,
+		Page:  api.Page{TotalCount: len(filtered)},
+	}, nil
 }
 
 func (m *mockDataSource) ListBenchmarksByLabel(labels []string) ([]api.BenchmarkResource, error) {
@@ -97,6 +150,74 @@ func testDataSource() *mockDataSource {
 			{ID: "mmlu", Name: "MMLU", Category: "knowledge", Tags: []string{"knowledge", "general"}},
 			{ID: "rag_eval", Name: "RAG Evaluation", Category: "rag", Tags: []string{"rag", "safety"}},
 			{ID: "toxigen", Name: "ToxiGen", Category: "safety", Tags: []string{"safety"}},
+		},
+		collections: []api.CollectionResource{
+			{
+				Resource: api.Resource{ID: "safety-suite"},
+				CollectionConfig: api.CollectionConfig{
+					Name:     "Safety Suite",
+					Category: "safety",
+					Tags:     []string{"safety", "production"},
+					Benchmarks: []api.CollectionBenchmarkConfig{
+						{Ref: api.Ref{ID: "toxigen"}, ProviderID: "lighteval"},
+					},
+				},
+			},
+			{
+				Resource: api.Resource{ID: "general-eval"},
+				CollectionConfig: api.CollectionConfig{
+					Name:     "General Evaluation",
+					Category: "general",
+					Tags:     []string{"general"},
+					Benchmarks: []api.CollectionBenchmarkConfig{
+						{Ref: api.Ref{ID: "hellaswag"}, ProviderID: "lighteval"},
+						{Ref: api.Ref{ID: "mmlu"}, ProviderID: "unitxt"},
+					},
+				},
+			},
+		},
+		jobs: []api.EvaluationJobResource{
+			{
+				Resource: api.EvaluationResource{Resource: api.Resource{ID: "job-1"}},
+				Status: &api.EvaluationJobStatus{
+					EvaluationJobState: api.EvaluationJobState{State: api.OverallStateRunning},
+					Benchmarks: []api.BenchmarkStatus{
+						{ID: "hellaswag", ProviderID: "lighteval", Status: api.StateRunning, StartedAt: "2026-04-30T10:00:00Z"},
+					},
+				},
+				EvaluationJobConfig: api.EvaluationJobConfig{
+					Name:  "test-eval-1",
+					Model: api.ModelRef{URL: "http://model:8080", Name: "test-model"},
+				},
+			},
+			{
+				Resource: api.EvaluationResource{Resource: api.Resource{ID: "job-2"}},
+				Status: &api.EvaluationJobStatus{
+					EvaluationJobState: api.EvaluationJobState{State: api.OverallStateCompleted},
+					Benchmarks: []api.BenchmarkStatus{
+						{ID: "mmlu", ProviderID: "unitxt", Status: api.StateCompleted, CompletedAt: "2026-04-30T11:00:00Z"},
+					},
+				},
+				EvaluationJobConfig: api.EvaluationJobConfig{
+					Name:  "test-eval-2",
+					Model: api.ModelRef{URL: "http://model:8080", Name: "test-model"},
+				},
+				Results: &api.EvaluationJobResults{
+					Benchmarks: []api.BenchmarkResult{
+						{ID: "mmlu", ProviderID: "unitxt", Metrics: map[string]any{"accuracy": 0.85}},
+					},
+				},
+			},
+			{
+				Resource: api.EvaluationResource{Resource: api.Resource{ID: "job-3"}},
+				Status: &api.EvaluationJobStatus{
+					EvaluationJobState: api.EvaluationJobState{State: api.OverallStateCompleted},
+				},
+				EvaluationJobConfig: api.EvaluationJobConfig{
+					Name:  "test-eval-3",
+					Model: api.ModelRef{URL: "http://model:8080", Name: "test-model"},
+				},
+			},
 		},
 	}
 }
@@ -160,7 +281,12 @@ func TestResourcesListIncludesProvidersAndBenchmarks(t *testing.T) {
 		t.Fatalf("ListResources failed: %v", err)
 	}
 
-	want := map[string]bool{"evalhub://providers": false, "evalhub://benchmarks": false}
+	want := map[string]bool{
+		"evalhub://providers":   false,
+		"evalhub://benchmarks":  false,
+		"evalhub://collections": false,
+		"evalhub://jobs":        false,
+	}
 	for _, r := range result.Resources {
 		if _, ok := want[r.URI]; ok {
 			want[r.URI] = true
@@ -185,6 +311,9 @@ func TestResourceTemplatesListIncludesExpected(t *testing.T) {
 		"evalhub://providers/{id}":      false,
 		"evalhub://benchmarks/{id}":     false,
 		"evalhub://benchmarks{?label*}": false,
+		"evalhub://collections/{id}":    false,
+		"evalhub://jobs/{id}":           false,
+		"evalhub://jobs{?status}":       false,
 	}
 	for _, rt := range result.ResourceTemplates {
 		if _, ok := wantTemplates[rt.URITemplate]; ok {
@@ -370,6 +499,164 @@ func TestReadResourceInvalidURI(t *testing.T) {
 	_, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://unknown/resource"})
 	if err == nil {
 		t.Fatal("expected error for unknown resource URI")
+	}
+}
+
+// --- collections ---
+
+func TestListCollections(t *testing.T) {
+	ctx, cs := connectWithResources(t, testDataSource())
+
+	collections := readResourceJSON[[]api.CollectionResource](t, ctx, cs, "evalhub://collections")
+	if len(collections) != 2 {
+		t.Fatalf("expected 2 collections, got %d", len(collections))
+	}
+	if collections[0].Resource.ID != "safety-suite" {
+		t.Errorf("first collection ID = %q, want %q", collections[0].Resource.ID, "safety-suite")
+	}
+	if collections[1].Resource.ID != "general-eval" {
+		t.Errorf("second collection ID = %q, want %q", collections[1].Resource.ID, "general-eval")
+	}
+}
+
+func TestGetCollectionByID(t *testing.T) {
+	ctx, cs := connectWithResources(t, testDataSource())
+
+	collection := readResourceJSON[api.CollectionResource](t, ctx, cs, "evalhub://collections/safety-suite")
+	if collection.Resource.ID != "safety-suite" {
+		t.Errorf("collection ID = %q, want %q", collection.Resource.ID, "safety-suite")
+	}
+	if collection.Name != "Safety Suite" {
+		t.Errorf("collection name = %q, want %q", collection.Name, "Safety Suite")
+	}
+	if len(collection.Benchmarks) != 1 {
+		t.Fatalf("expected 1 benchmark in collection, got %d", len(collection.Benchmarks))
+	}
+	if collection.Benchmarks[0].ID != "toxigen" {
+		t.Errorf("benchmark ID = %q, want %q", collection.Benchmarks[0].ID, "toxigen")
+	}
+}
+
+func TestGetCollectionNotFound(t *testing.T) {
+	ctx, cs := connectWithResources(t, testDataSource())
+
+	_, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://collections/nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for non-existent collection")
+	}
+}
+
+func TestListCollectionsEmpty(t *testing.T) {
+	ctx, cs := connectWithResources(t, emptyDataSource())
+
+	collections := readResourceJSON[[]api.CollectionResource](t, ctx, cs, "evalhub://collections")
+	if collections == nil {
+		t.Fatal("expected empty array, got nil")
+	}
+	if len(collections) != 0 {
+		t.Errorf("expected 0 collections, got %d", len(collections))
+	}
+}
+
+// --- jobs ---
+
+func TestListJobs(t *testing.T) {
+	ctx, cs := connectWithResources(t, testDataSource())
+
+	jobs := readResourceJSON[[]api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs")
+	if len(jobs) != 3 {
+		t.Fatalf("expected 3 jobs, got %d", len(jobs))
+	}
+}
+
+func TestGetJobByID(t *testing.T) {
+	ctx, cs := connectWithResources(t, testDataSource())
+
+	job := readResourceJSON[api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs/job-2")
+	if job.Resource.ID != "job-2" {
+		t.Errorf("job ID = %q, want %q", job.Resource.ID, "job-2")
+	}
+	if job.Name != "test-eval-2" {
+		t.Errorf("job name = %q, want %q", job.Name, "test-eval-2")
+	}
+}
+
+func TestGetJobByIDFullStatus(t *testing.T) {
+	ctx, cs := connectWithResources(t, testDataSource())
+
+	job := readResourceJSON[api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs/job-1")
+	if job.Status == nil {
+		t.Fatal("expected job status, got nil")
+	}
+	if job.Status.State != api.OverallStateRunning {
+		t.Errorf("job state = %q, want %q", job.Status.State, api.OverallStateRunning)
+	}
+	if len(job.Status.Benchmarks) != 1 {
+		t.Fatalf("expected 1 benchmark status, got %d", len(job.Status.Benchmarks))
+	}
+	if job.Status.Benchmarks[0].Status != api.StateRunning {
+		t.Errorf("benchmark status = %q, want %q", job.Status.Benchmarks[0].Status, api.StateRunning)
+	}
+	if job.Status.Benchmarks[0].StartedAt != "2026-04-30T10:00:00Z" {
+		t.Errorf("benchmark started_at = %q, want %q", job.Status.Benchmarks[0].StartedAt, "2026-04-30T10:00:00Z")
+	}
+}
+
+func TestGetJobNotFound(t *testing.T) {
+	ctx, cs := connectWithResources(t, testDataSource())
+
+	_, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://jobs/nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for non-existent job")
+	}
+}
+
+func TestListJobsFilterByStatusRunning(t *testing.T) {
+	ctx, cs := connectWithResources(t, testDataSource())
+
+	jobs := readResourceJSON[[]api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs?status=running")
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 running job, got %d", len(jobs))
+	}
+	if jobs[0].Resource.ID != "job-1" {
+		t.Errorf("job ID = %q, want %q", jobs[0].Resource.ID, "job-1")
+	}
+}
+
+func TestListJobsFilterByStatusCompleted(t *testing.T) {
+	ctx, cs := connectWithResources(t, testDataSource())
+
+	jobs := readResourceJSON[[]api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs?status=completed")
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 completed jobs, got %d", len(jobs))
+	}
+	ids := map[string]bool{}
+	for _, j := range jobs {
+		ids[j.Resource.ID] = true
+	}
+	if !ids["job-2"] || !ids["job-3"] {
+		t.Errorf("expected job-2 and job-3, got %v", ids)
+	}
+}
+
+func TestListJobsFilterByInvalidStatus(t *testing.T) {
+	ctx, cs := connectWithResources(t, testDataSource())
+
+	_, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://jobs?status=invalid"})
+	if err == nil {
+		t.Fatal("expected error for invalid status filter")
+	}
+}
+
+func TestListJobsEmpty(t *testing.T) {
+	ctx, cs := connectWithResources(t, emptyDataSource())
+
+	jobs := readResourceJSON[[]api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs")
+	if jobs == nil {
+		t.Fatal("expected empty array, got nil")
+	}
+	if len(jobs) != 0 {
+		t.Errorf("expected 0 jobs, got %d", len(jobs))
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements [RHOAIENG-60346](https://redhat.atlassian.net/browse/RHOAIENG-60346) — exposes eval-hub collections and evaluation jobs as MCP Resources.

- Adds `evalhub://collections` and `evalhub://collections/{id}` resources for listing and retrieving benchmark collections
- Adds `evalhub://jobs`, `evalhub://jobs{?status}`, and `evalhub://jobs/{id}` resources for listing, filtering, and retrieving evaluation jobs
- Status filtering validates against all valid states (pending, running, completed, failed, cancelled, partially_failed) with clear error messages for invalid values
- Pagination support (limit/offset) for collection and job list operations
- Extends the `EvalHubDiscovery` interface with 5 new methods matching the existing `evalhubclient.Client` API
- 12 new unit tests covering all acceptance criteria from the JIRA issue

## Changes

| File | Description |
|------|-------------|
| `internal/evalhub_mcp/server/resources.go` | Extended `EvalHubDiscovery` interface, added collection/job handlers, resource registration, and `extractStatus`/`extractPagination` helpers |
| `internal/evalhub_mcp/server/resources_test.go` | Added mock methods, test fixtures, and 12 new tests for collections and jobs |

## Test plan

All tests pass (`go test -v ./internal/evalhub_mcp/... ./cmd/evalhub_mcp/`):

- [x] List collections returns correct structure matching `pkg/api.CollectionResource`
- [x] Get collection by valid ID returns correct collection with benchmark references
- [x] Get collection by non-existent ID returns appropriate error
- [x] List jobs returns correct structure matching `pkg/api.EvaluationJobResource`
- [x] Get job by valid ID returns full status detail (state, per-benchmark status, timestamps)
- [x] Status filtering: `status=running` returns only running jobs
- [x] Status filtering: `status=completed` returns only completed jobs
- [x] Invalid status value produces clear error
- [x] Empty results return valid empty JSON arrays
- [x] `resources/list` includes all collection and job resources
- [x] `resources/templates/list` includes all new templates

Generated with: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added contributor guidance for Go toolchain version management practices.

* **New Features**
  * Added API endpoints for discovering and retrieving benchmark collections.
  * Added API endpoints for discovering and retrieving evaluation jobs with status-based filtering.
  * Implemented pagination support (limit/offset) for collection and job listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->