### PR TITLE
feat(mcp): add server version and build metadata resource

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,7 @@ Located alongside code in `*_test.go` files:
 - Use standard library `testing` package
 - Found in: `auth/**/*_test.go`, `internal/**/*_test.go`, `cmd/**/*_test.go`, `pkg/**/*_test.go`
 - MCP server tests use `mcp.NewInMemoryTransports()` for in-process initialize handshake and capability verification
+- Add `t.Parallel()` to new tests where safe — avoid it when the test mutates process-wide state (e.g. `t.Setenv`, `os.Stdout`, package-level globals)
 
 #### FVT (Functional Verification Tests)
 

--- a/internal/evalhub_mcp/config/config_test.go
+++ b/internal/evalhub_mcp/config/config_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestDefaultConfig(t *testing.T) {
+	t.Parallel()
 	cfg := DefaultConfig()
 
 	if cfg.Transport != "stdio" {
@@ -217,6 +218,7 @@ profiles:
 }
 
 func TestValidateTransport(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		transport string
 		wantErr   bool
@@ -230,6 +232,7 @@ func TestValidateTransport(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.transport, func(t *testing.T) {
+			t.Parallel()
 			cfg := &Config{Transport: tt.transport, Host: "localhost", Port: 3001}
 			err := Validate(cfg)
 			if (err != nil) != tt.wantErr {
@@ -240,6 +243,7 @@ func TestValidateTransport(t *testing.T) {
 }
 
 func TestValidatePort(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		port    int
 		wantErr bool
@@ -254,6 +258,7 @@ func TestValidatePort(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
 			cfg := &Config{Transport: "http", Host: "localhost", Port: tt.port}
 			err := Validate(cfg)
 			if (err != nil) != tt.wantErr {
@@ -264,6 +269,7 @@ func TestValidatePort(t *testing.T) {
 }
 
 func TestValidateStdioIgnoresPort(t *testing.T) {
+	t.Parallel()
 	cfg := &Config{Transport: "stdio", Host: "localhost", Port: 0}
 	if err := Validate(cfg); err != nil {
 		t.Errorf("stdio transport should not validate port, got: %v", err)
@@ -271,7 +277,9 @@ func TestValidateStdioIgnoresPort(t *testing.T) {
 }
 
 func TestValidateBaseURL(t *testing.T) {
+	t.Parallel()
 	t.Run("valid URL passes", func(t *testing.T) {
+		t.Parallel()
 		cfg := &Config{Transport: "stdio", Host: "localhost", BaseURL: "http://example.com:8080"}
 		if err := Validate(cfg); err != nil {
 			t.Errorf("expected valid URL to pass, got: %v", err)
@@ -279,6 +287,7 @@ func TestValidateBaseURL(t *testing.T) {
 	})
 
 	t.Run("empty URL passes (omitempty)", func(t *testing.T) {
+		t.Parallel()
 		cfg := &Config{Transport: "stdio", Host: "localhost"}
 		if err := Validate(cfg); err != nil {
 			t.Errorf("expected empty URL to pass, got: %v", err)
@@ -286,6 +295,7 @@ func TestValidateBaseURL(t *testing.T) {
 	})
 
 	t.Run("invalid URL fails", func(t *testing.T) {
+		t.Parallel()
 		cfg := &Config{Transport: "stdio", Host: "localhost", BaseURL: "not-a-url"}
 		if err := Validate(cfg); err == nil {
 			t.Error("expected invalid URL to fail validation")
@@ -397,6 +407,7 @@ func TestLoadNilFlags(t *testing.T) {
 }
 
 func TestValidateEmptyHost(t *testing.T) {
+	t.Parallel()
 	cfg := &Config{Transport: "http", Host: "", Port: 3001}
 	if err := Validate(cfg); err == nil {
 		t.Error("expected validation error for empty host")

--- a/internal/evalhub_mcp/server/resources_test.go
+++ b/internal/evalhub_mcp/server/resources_test.go
@@ -663,8 +663,9 @@ func TestListJobsEmpty(t *testing.T) {
 // --- RegisterHandlers nil client ---
 
 func TestRegisterHandlersNilClient(t *testing.T) {
-	srv := New(&ServerInfo{Version: "test"}, discardLogger)
-	RegisterHandlers(srv, nil, discardLogger)
+	info := &ServerInfo{Version: "test"}
+	srv := New(info, discardLogger)
+	RegisterHandlers(srv, nil, info, discardLogger)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -688,7 +689,10 @@ func TestRegisterHandlersNilClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListResources failed: %v", err)
 	}
-	if len(result.Resources) != 0 {
-		t.Errorf("expected 0 resources with nil client, got %d", len(result.Resources))
+	if len(result.Resources) != 1 {
+		t.Errorf("expected 1 resource (server/version) with nil client, got %d", len(result.Resources))
+	}
+	if len(result.Resources) > 0 && result.Resources[0].URI != "evalhub://server/version" {
+		t.Errorf("expected server/version resource, got %q", result.Resources[0].URI)
 	}
 }

--- a/internal/evalhub_mcp/server/resources_test.go
+++ b/internal/evalhub_mcp/server/resources_test.go
@@ -274,6 +274,7 @@ func readResourceJSON[T any](t *testing.T, ctx context.Context, cs *mcp.ClientSe
 // --- resources/list ---
 
 func TestResourcesListIncludesProvidersAndBenchmarks(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	result, err := cs.ListResources(ctx, nil)
@@ -300,6 +301,7 @@ func TestResourcesListIncludesProvidersAndBenchmarks(t *testing.T) {
 }
 
 func TestResourceTemplatesListIncludesExpected(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	result, err := cs.ListResourceTemplates(ctx, nil)
@@ -330,6 +332,7 @@ func TestResourceTemplatesListIncludesExpected(t *testing.T) {
 // --- providers ---
 
 func TestListProviders(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	providers := readResourceJSON[[]api.ProviderResource](t, ctx, cs, "evalhub://providers")
@@ -345,6 +348,7 @@ func TestListProviders(t *testing.T) {
 }
 
 func TestGetProviderByID(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	provider := readResourceJSON[api.ProviderResource](t, ctx, cs, "evalhub://providers/lighteval")
@@ -357,6 +361,7 @@ func TestGetProviderByID(t *testing.T) {
 }
 
 func TestGetProviderNotFound(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	_, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://providers/nonexistent"})
@@ -368,6 +373,7 @@ func TestGetProviderNotFound(t *testing.T) {
 // --- benchmarks ---
 
 func TestListBenchmarks(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	benchmarks := readResourceJSON[[]api.BenchmarkResource](t, ctx, cs, "evalhub://benchmarks")
@@ -377,6 +383,7 @@ func TestListBenchmarks(t *testing.T) {
 }
 
 func TestGetBenchmarkByID(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	benchmark := readResourceJSON[api.BenchmarkResource](t, ctx, cs, "evalhub://benchmarks/hellaswag")
@@ -389,6 +396,7 @@ func TestGetBenchmarkByID(t *testing.T) {
 }
 
 func TestGetBenchmarkNotFound(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	_, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://benchmarks/nonexistent"})
@@ -400,6 +408,7 @@ func TestGetBenchmarkNotFound(t *testing.T) {
 // --- label filtering ---
 
 func TestListBenchmarksSingleLabel(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	benchmarks := readResourceJSON[[]api.BenchmarkResource](t, ctx, cs, "evalhub://benchmarks?label=rag")
@@ -412,6 +421,7 @@ func TestListBenchmarksSingleLabel(t *testing.T) {
 }
 
 func TestListBenchmarksMultipleLabels(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	benchmarks := readResourceJSON[[]api.BenchmarkResource](t, ctx, cs, "evalhub://benchmarks?label=rag&label=safety")
@@ -424,6 +434,7 @@ func TestListBenchmarksMultipleLabels(t *testing.T) {
 }
 
 func TestListBenchmarksNonExistentLabel(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	benchmarks := readResourceJSON[[]api.BenchmarkResource](t, ctx, cs, "evalhub://benchmarks?label=nonexistent")
@@ -433,6 +444,7 @@ func TestListBenchmarksNonExistentLabel(t *testing.T) {
 }
 
 func TestListBenchmarksSafetyLabel(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	benchmarks := readResourceJSON[[]api.BenchmarkResource](t, ctx, cs, "evalhub://benchmarks?label=safety")
@@ -451,6 +463,7 @@ func TestListBenchmarksSafetyLabel(t *testing.T) {
 // --- empty results ---
 
 func TestListProvidersEmpty(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, emptyDataSource())
 
 	providers := readResourceJSON[[]api.ProviderResource](t, ctx, cs, "evalhub://providers")
@@ -463,6 +476,7 @@ func TestListProvidersEmpty(t *testing.T) {
 }
 
 func TestListBenchmarksEmpty(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, emptyDataSource())
 
 	benchmarks := readResourceJSON[[]api.BenchmarkResource](t, ctx, cs, "evalhub://benchmarks")
@@ -477,6 +491,7 @@ func TestListBenchmarksEmpty(t *testing.T) {
 // --- MIME type ---
 
 func TestResourceContentType(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	result, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://providers"})
@@ -494,6 +509,7 @@ func TestResourceContentType(t *testing.T) {
 // --- URI edge cases ---
 
 func TestReadResourceInvalidURI(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	_, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://unknown/resource"})
@@ -505,6 +521,7 @@ func TestReadResourceInvalidURI(t *testing.T) {
 // --- collections ---
 
 func TestListCollections(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	collections := readResourceJSON[[]api.CollectionResource](t, ctx, cs, "evalhub://collections")
@@ -520,6 +537,7 @@ func TestListCollections(t *testing.T) {
 }
 
 func TestGetCollectionByID(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	collection := readResourceJSON[api.CollectionResource](t, ctx, cs, "evalhub://collections/safety-suite")
@@ -538,6 +556,7 @@ func TestGetCollectionByID(t *testing.T) {
 }
 
 func TestGetCollectionNotFound(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	_, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://collections/nonexistent"})
@@ -547,6 +566,7 @@ func TestGetCollectionNotFound(t *testing.T) {
 }
 
 func TestListCollectionsEmpty(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, emptyDataSource())
 
 	collections := readResourceJSON[[]api.CollectionResource](t, ctx, cs, "evalhub://collections")
@@ -561,6 +581,7 @@ func TestListCollectionsEmpty(t *testing.T) {
 // --- jobs ---
 
 func TestListJobs(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	jobs := readResourceJSON[[]api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs")
@@ -570,6 +591,7 @@ func TestListJobs(t *testing.T) {
 }
 
 func TestGetJobByID(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	job := readResourceJSON[api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs/job-2")
@@ -582,6 +604,7 @@ func TestGetJobByID(t *testing.T) {
 }
 
 func TestGetJobByIDFullStatus(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	job := readResourceJSON[api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs/job-1")
@@ -603,6 +626,7 @@ func TestGetJobByIDFullStatus(t *testing.T) {
 }
 
 func TestGetJobNotFound(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	_, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://jobs/nonexistent"})
@@ -612,6 +636,7 @@ func TestGetJobNotFound(t *testing.T) {
 }
 
 func TestListJobsFilterByStatusRunning(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	jobs := readResourceJSON[[]api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs?status=running")
@@ -624,6 +649,7 @@ func TestListJobsFilterByStatusRunning(t *testing.T) {
 }
 
 func TestListJobsFilterByStatusCompleted(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	jobs := readResourceJSON[[]api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs?status=completed")
@@ -640,6 +666,7 @@ func TestListJobsFilterByStatusCompleted(t *testing.T) {
 }
 
 func TestListJobsFilterByInvalidStatus(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, testDataSource())
 
 	_, err := cs.ReadResource(ctx, &mcp.ReadResourceParams{URI: "evalhub://jobs?status=invalid"})
@@ -649,6 +676,7 @@ func TestListJobsFilterByInvalidStatus(t *testing.T) {
 }
 
 func TestListJobsEmpty(t *testing.T) {
+	t.Parallel()
 	ctx, cs := connectWithResources(t, emptyDataSource())
 
 	jobs := readResourceJSON[[]api.EvaluationJobResource](t, ctx, cs, "evalhub://jobs")
@@ -663,6 +691,7 @@ func TestListJobsEmpty(t *testing.T) {
 // --- RegisterHandlers nil client ---
 
 func TestRegisterHandlersNilClient(t *testing.T) {
+	t.Parallel()
 	info := &ServerInfo{Version: "test"}
 	srv := New(info, discardLogger)
 	RegisterHandlers(srv, nil, info, discardLogger)
@@ -690,9 +719,9 @@ func TestRegisterHandlersNilClient(t *testing.T) {
 		t.Fatalf("ListResources failed: %v", err)
 	}
 	if len(result.Resources) != 1 {
-		t.Errorf("expected 1 resource (server/version) with nil client, got %d", len(result.Resources))
+		t.Fatalf("expected 1 resource (server/version) with nil client, got %d", len(result.Resources))
 	}
-	if len(result.Resources) > 0 && result.Resources[0].URI != "evalhub://server/version" {
+	if result.Resources[0].URI != "evalhub://server/version" {
 		t.Errorf("expected server/version resource, got %q", result.Resources[0].URI)
 	}
 }

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -72,9 +72,11 @@ func NewEvalHubClient(cfg *config.Config, logger *slog.Logger) *evalhubclient.Cl
 }
 
 // RegisterHandlers wires tool, resource, and prompt handlers into the MCP
-// server. The EvalHub client is captured by handler closures so that every
-// handler has access to the API without global state.
-func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, logger *slog.Logger) {
+// server. The server version resource is always registered. The EvalHub client
+// is captured by handler closures so that every handler has access to the API
+// without global state.
+func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, info *ServerInfo, logger *slog.Logger) {
+	registerVersionResource(srv, info, logger)
 	if client != nil {
 		registerResources(srv, client, logger)
 	}
@@ -83,7 +85,7 @@ func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, logger *slo
 func Run(ctx context.Context, cfg *config.Config, info *ServerInfo, logger *slog.Logger) error {
 	client := NewEvalHubClient(cfg, logger)
 	srv := New(info, logger)
-	RegisterHandlers(srv, client, logger)
+	RegisterHandlers(srv, client, info, logger)
 
 	version := "unknown"
 	if info != nil {

--- a/internal/evalhub_mcp/server/server_test.go
+++ b/internal/evalhub_mcp/server/server_test.go
@@ -17,6 +17,7 @@ var discardLogger = slog.New(slog.DiscardHandler)
 // --- ServerInfo ---
 
 func TestVersionString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		info *ServerInfo
 		want string
@@ -35,6 +36,7 @@ func TestVersionString(t *testing.T) {
 // --- NewEvalHubClient ---
 
 func TestNewEvalHubClientNilWhenNoBaseURL(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{}
 	client := NewEvalHubClient(cfg, discardLogger)
 	if client != nil {
@@ -43,6 +45,7 @@ func TestNewEvalHubClientNilWhenNoBaseURL(t *testing.T) {
 }
 
 func TestNewEvalHubClientCreated(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{
 		BaseURL:  "http://localhost:8080",
 		Token:    "test-token",
@@ -58,6 +61,7 @@ func TestNewEvalHubClientCreated(t *testing.T) {
 // --- MCP server via in-memory transport ---
 
 func TestInitializeHandshake(t *testing.T) {
+	t.Parallel()
 	info := &ServerInfo{Version: "0.1.0", Build: "test123"}
 	srv := New(info, discardLogger)
 
@@ -81,6 +85,7 @@ func TestInitializeHandshake(t *testing.T) {
 }
 
 func TestServerMetadata(t *testing.T) {
+	t.Parallel()
 	info := &ServerInfo{Version: "0.2.0", Build: "deadbeef"}
 	srv := New(info, discardLogger)
 
@@ -115,6 +120,7 @@ func TestServerMetadata(t *testing.T) {
 }
 
 func TestCapabilitiesAdvertised(t *testing.T) {
+	t.Parallel()
 	info := &ServerInfo{Version: "0.1.0"}
 	srv := New(info, discardLogger)
 
@@ -156,6 +162,7 @@ func TestCapabilitiesAdvertised(t *testing.T) {
 }
 
 func TestToolsListEmpty(t *testing.T) {
+	t.Parallel()
 	info := &ServerInfo{Version: "0.1.0"}
 	srv := New(info, discardLogger)
 
@@ -187,6 +194,7 @@ func TestToolsListEmpty(t *testing.T) {
 }
 
 func TestResourcesListEmpty(t *testing.T) {
+	t.Parallel()
 	info := &ServerInfo{Version: "0.1.0"}
 	srv := New(info, discardLogger)
 
@@ -218,6 +226,7 @@ func TestResourcesListEmpty(t *testing.T) {
 }
 
 func TestPromptsListEmpty(t *testing.T) {
+	t.Parallel()
 	info := &ServerInfo{Version: "0.1.0"}
 	srv := New(info, discardLogger)
 
@@ -251,6 +260,7 @@ func TestPromptsListEmpty(t *testing.T) {
 // --- Transport selection ---
 
 func TestRunHTTPStartsAndStops(t *testing.T) {
+	t.Parallel()
 	port := freePort(t)
 
 	cfg := &config.Config{
@@ -282,6 +292,7 @@ func TestRunHTTPStartsAndStops(t *testing.T) {
 }
 
 func TestRunHTTPPortInUse(t *testing.T) {
+	t.Parallel()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("setting up listener: %v", err)
@@ -303,6 +314,7 @@ func TestRunHTTPPortInUse(t *testing.T) {
 }
 
 func TestRunInvalidTransport(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{
 		Transport: "grpc",
 	}

--- a/internal/evalhub_mcp/server/version_resource.go
+++ b/internal/evalhub_mcp/server/version_resource.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"runtime/debug"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const mcpLibraryPath = "github.com/modelcontextprotocol/go-sdk"
+
+type VersionResponse struct {
+	Version           string `json:"version"`
+	GitHash           string `json:"git_hash"`
+	BuildDate         string `json:"build_date"`
+	GoVersion         string `json:"go_version"`
+	OS                string `json:"os"`
+	Arch              string `json:"arch"`
+	MCPLibrary        string `json:"mcp_library"`
+	MCPLibraryVersion string `json:"mcp_library_version"`
+}
+
+func registerVersionResource(srv *mcp.Server, info *ServerInfo, logger *slog.Logger) {
+	srv.AddResource(&mcp.Resource{
+		Name:        "server-version",
+		Description: "Server version and build metadata",
+		MIMEType:    "application/json",
+		URI:         "evalhub://server/version",
+	}, versionHandler(info, logger))
+}
+
+func versionHandler(info *ServerInfo, logger *slog.Logger) mcp.ResourceHandler {
+	resp := VersionResponse{
+		GoVersion:         runtime.Version(),
+		OS:                runtime.GOOS,
+		Arch:              runtime.GOARCH,
+		MCPLibrary:        mcpLibraryPath,
+		MCPLibraryVersion: mcpLibraryVersion(),
+	}
+	if info != nil {
+		resp.Version = info.Version
+		resp.GitHash = info.Build
+		resp.BuildDate = info.BuildDate
+	}
+
+	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		logger.Debug("reading resource", "uri", req.Params.URI)
+		return jsonResult(resp)
+	}
+}
+
+func mcpLibraryVersion() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, dep := range bi.Deps {
+		if dep.Path == mcpLibraryPath {
+			return dep.Version
+		}
+	}
+	return "unknown"
+}

--- a/internal/evalhub_mcp/server/version_resource.go
+++ b/internal/evalhub_mcp/server/version_resource.go
@@ -58,6 +58,9 @@ func mcpLibraryVersion() string {
 	}
 	for _, dep := range bi.Deps {
 		if dep.Path == mcpLibraryPath {
+			if dep.Replace != nil {
+				return dep.Replace.Version
+			}
 			return dep.Version
 		}
 	}

--- a/internal/evalhub_mcp/server/version_resource_test.go
+++ b/internal/evalhub_mcp/server/version_resource_test.go
@@ -11,14 +11,8 @@ import (
 
 // --- test helpers ---
 
-func connectWithVersion(t *testing.T, info *ServerInfo) (context.Context, *mcp.ClientSession) {
+func connectClient(t *testing.T, ctx context.Context, srv *mcp.Server) *mcp.ClientSession {
 	t.Helper()
-
-	srv := New(info, discardLogger)
-	registerVersionResource(srv, info, discardLogger)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
 
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
 
@@ -35,12 +29,26 @@ func connectWithVersion(t *testing.T, info *ServerInfo) (context.Context, *mcp.C
 	}
 	t.Cleanup(func() { clientSession.Close() })
 
-	return ctx, clientSession
+	return clientSession
+}
+
+func connectWithVersion(t *testing.T, info *ServerInfo) (context.Context, *mcp.ClientSession) {
+	t.Helper()
+
+	srv := New(info, discardLogger)
+	registerVersionResource(srv, info, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	return ctx, connectClient(t, ctx, srv)
 }
 
 // --- version resource ---
 
 func TestVersionResourceJSONStructure(t *testing.T) {
+	t.Parallel()
+
 	info := &ServerInfo{
 		Version:   "0.4.0",
 		Build:     "abc123",
@@ -72,6 +80,8 @@ func TestVersionResourceJSONStructure(t *testing.T) {
 }
 
 func TestVersionResourceMatchesBuildValues(t *testing.T) {
+	t.Parallel()
+
 	info := &ServerInfo{
 		Version:   "1.2.3",
 		Build:     "deadbeef",
@@ -94,6 +104,8 @@ func TestVersionResourceMatchesBuildValues(t *testing.T) {
 }
 
 func TestVersionResourceMatchesRuntime(t *testing.T) {
+	t.Parallel()
+
 	info := &ServerInfo{Version: "0.1.0"}
 
 	ctx, cs := connectWithVersion(t, info)
@@ -112,6 +124,8 @@ func TestVersionResourceMatchesRuntime(t *testing.T) {
 }
 
 func TestVersionResourceAvailableWithoutBackend(t *testing.T) {
+	t.Parallel()
+
 	info := &ServerInfo{Version: "0.1.0"}
 	srv := New(info, discardLogger)
 	RegisterHandlers(srv, nil, info, discardLogger)
@@ -119,20 +133,7 @@ func TestVersionResourceAvailableWithoutBackend(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-
-	serverSession, err := srv.Connect(ctx, serverTransport, nil)
-	if err != nil {
-		t.Fatalf("server.Connect failed: %v", err)
-	}
-	t.Cleanup(func() { serverSession.Close() })
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
-	clientSession, err := client.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		t.Fatalf("client.Connect failed: %v", err)
-	}
-	t.Cleanup(func() { clientSession.Close() })
+	clientSession := connectClient(t, ctx, srv)
 
 	result, err := clientSession.ListResources(ctx, nil)
 	if err != nil {
@@ -157,6 +158,8 @@ func TestVersionResourceAvailableWithoutBackend(t *testing.T) {
 }
 
 func TestVersionResourceInResourcesList(t *testing.T) {
+	t.Parallel()
+
 	info := &ServerInfo{Version: "0.3.0", Build: "test"}
 
 	ctx, cs := connectWithVersion(t, info)
@@ -185,26 +188,15 @@ func TestVersionResourceInResourcesList(t *testing.T) {
 }
 
 func TestVersionResourceNilInfo(t *testing.T) {
+	t.Parallel()
+
 	srv := New(nil, discardLogger)
 	registerVersionResource(srv, nil, discardLogger)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-
-	serverSession, err := srv.Connect(ctx, serverTransport, nil)
-	if err != nil {
-		t.Fatalf("server.Connect failed: %v", err)
-	}
-	t.Cleanup(func() { serverSession.Close() })
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
-	clientSession, err := client.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		t.Fatalf("client.Connect failed: %v", err)
-	}
-	t.Cleanup(func() { clientSession.Close() })
+	clientSession := connectClient(t, ctx, srv)
 
 	resp := readResourceJSON[VersionResponse](t, ctx, clientSession, "evalhub://server/version")
 	if resp.Version != "" {

--- a/internal/evalhub_mcp/server/version_resource_test.go
+++ b/internal/evalhub_mcp/server/version_resource_test.go
@@ -1,0 +1,216 @@
+package server
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// --- test helpers ---
+
+func connectWithVersion(t *testing.T, info *ServerInfo) (context.Context, *mcp.ClientSession) {
+	t.Helper()
+
+	srv := New(info, discardLogger)
+	registerVersionResource(srv, info, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect failed: %v", err)
+	}
+	t.Cleanup(func() { serverSession.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	t.Cleanup(func() { clientSession.Close() })
+
+	return ctx, clientSession
+}
+
+// --- version resource ---
+
+func TestVersionResourceJSONStructure(t *testing.T) {
+	info := &ServerInfo{
+		Version:   "0.4.0",
+		Build:     "abc123",
+		BuildDate: "2026-04-30T10:00:00Z",
+	}
+
+	ctx, cs := connectWithVersion(t, info)
+
+	resp := readResourceJSON[VersionResponse](t, ctx, cs, "evalhub://server/version")
+
+	if resp.Version == "" {
+		t.Error("version field is empty")
+	}
+	if resp.GoVersion == "" {
+		t.Error("go_version field is empty")
+	}
+	if resp.OS == "" {
+		t.Error("os field is empty")
+	}
+	if resp.Arch == "" {
+		t.Error("arch field is empty")
+	}
+	if resp.MCPLibrary == "" {
+		t.Error("mcp_library field is empty")
+	}
+	if resp.MCPLibraryVersion == "" {
+		t.Error("mcp_library_version field is empty")
+	}
+}
+
+func TestVersionResourceMatchesBuildValues(t *testing.T) {
+	info := &ServerInfo{
+		Version:   "1.2.3",
+		Build:     "deadbeef",
+		BuildDate: "2026-01-15T12:00:00Z",
+	}
+
+	ctx, cs := connectWithVersion(t, info)
+
+	resp := readResourceJSON[VersionResponse](t, ctx, cs, "evalhub://server/version")
+
+	if resp.Version != "1.2.3" {
+		t.Errorf("version = %q, want %q", resp.Version, "1.2.3")
+	}
+	if resp.GitHash != "deadbeef" {
+		t.Errorf("git_hash = %q, want %q", resp.GitHash, "deadbeef")
+	}
+	if resp.BuildDate != "2026-01-15T12:00:00Z" {
+		t.Errorf("build_date = %q, want %q", resp.BuildDate, "2026-01-15T12:00:00Z")
+	}
+}
+
+func TestVersionResourceMatchesRuntime(t *testing.T) {
+	info := &ServerInfo{Version: "0.1.0"}
+
+	ctx, cs := connectWithVersion(t, info)
+
+	resp := readResourceJSON[VersionResponse](t, ctx, cs, "evalhub://server/version")
+
+	if resp.GoVersion != runtime.Version() {
+		t.Errorf("go_version = %q, want %q", resp.GoVersion, runtime.Version())
+	}
+	if resp.OS != runtime.GOOS {
+		t.Errorf("os = %q, want %q", resp.OS, runtime.GOOS)
+	}
+	if resp.Arch != runtime.GOARCH {
+		t.Errorf("arch = %q, want %q", resp.Arch, runtime.GOARCH)
+	}
+}
+
+func TestVersionResourceAvailableWithoutBackend(t *testing.T) {
+	info := &ServerInfo{Version: "0.1.0"}
+	srv := New(info, discardLogger)
+	RegisterHandlers(srv, nil, info, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect failed: %v", err)
+	}
+	t.Cleanup(func() { serverSession.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	t.Cleanup(func() { clientSession.Close() })
+
+	result, err := clientSession.ListResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResources failed: %v", err)
+	}
+
+	found := false
+	for _, r := range result.Resources {
+		if r.URI == "evalhub://server/version" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("server/version resource not found when backend is unreachable")
+	}
+
+	resp := readResourceJSON[VersionResponse](t, ctx, clientSession, "evalhub://server/version")
+	if resp.Version != "0.1.0" {
+		t.Errorf("version = %q, want %q", resp.Version, "0.1.0")
+	}
+}
+
+func TestVersionResourceInResourcesList(t *testing.T) {
+	info := &ServerInfo{Version: "0.3.0", Build: "test"}
+
+	ctx, cs := connectWithVersion(t, info)
+
+	result, err := cs.ListResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResources failed: %v", err)
+	}
+
+	found := false
+	for _, r := range result.Resources {
+		if r.URI == "evalhub://server/version" {
+			found = true
+			if r.MIMEType != "application/json" {
+				t.Errorf("MIME type = %q, want %q", r.MIMEType, "application/json")
+			}
+			if r.Name != "server-version" {
+				t.Errorf("name = %q, want %q", r.Name, "server-version")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("server/version resource not found in resources/list")
+	}
+}
+
+func TestVersionResourceNilInfo(t *testing.T) {
+	srv := New(nil, discardLogger)
+	registerVersionResource(srv, nil, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect failed: %v", err)
+	}
+	t.Cleanup(func() { serverSession.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	t.Cleanup(func() { clientSession.Close() })
+
+	resp := readResourceJSON[VersionResponse](t, ctx, clientSession, "evalhub://server/version")
+	if resp.Version != "" {
+		t.Errorf("version = %q, want empty string for nil info", resp.Version)
+	}
+	if resp.GoVersion == "" {
+		t.Error("go_version should still be populated from runtime")
+	}
+}


### PR DESCRIPTION
## Summary

Implements [RHOAIENG-60347](https://redhat.atlassian.net/browse/RHOAIENG-60347): Expose server version and build metadata as an MCP Resource.

- Adds `evalhub://server/version` resource returning version, git hash, build date, Go version, OS/arch, and MCP library info
- Resource is always registered regardless of eval-hub backend connectivity (no dependency on API client)
- Build-time values (`Version`, `Build`, `BuildDate`) are injected via existing `-ldflags` in the Makefile
- Runtime values (`GoVersion`, `OS`, `Arch`) come from Go's `runtime` package
- MCP library version is discovered dynamically via `runtime/debug.ReadBuildInfo()`

### Files Changed

| File | Change |
|------|--------|
| `internal/evalhub_mcp/server/version_resource.go` | New resource handler for `evalhub://server/version` |
| `internal/evalhub_mcp/server/version_resource_test.go` | 6 unit tests covering JSON structure, build values, runtime values, nil info, and backend-independent availability |
| `internal/evalhub_mcp/server/server.go` | `RegisterHandlers` now accepts `*ServerInfo` and always registers the version resource |
| `internal/evalhub_mcp/server/resources_test.go` | Updated `TestRegisterHandlersNilClient` to expect the version resource |

### Example Response

```json
{
  "version": "0.4.0",
  "git_hash": "0.4.0",
  "build_date": "2026-04-30T13:00:00+0000",
  "go_version": "go1.25.9",
  "os": "linux",
  "arch": "amd64",
  "mcp_library": "github.com/modelcontextprotocol/go-sdk",
  "mcp_library_version": "v1.5.0"
}
```

## Test plan

- [x] `go test -v ./internal/evalhub_mcp/server/...` — all 46 tests pass (6 new + 40 existing)
- [x] `go test -v ./cmd/evalhub_mcp/...` — all 5 tests pass
- [x] `go vet` passes clean
- [x] `go fmt` produces no changes
- [x] Server version resource returns correct JSON structure with all expected fields (`TestVersionResourceJSONStructure`)
- [x] Version, git hash, and build date match injected build-time values (`TestVersionResourceMatchesBuildValues`)
- [x] Go version and OS/arch match runtime values (`TestVersionResourceMatchesRuntime`)
- [x] Resource is available without a connected eval-hub backend (`TestVersionResourceAvailableWithoutBackend`)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added server version resource endpoint exposing version metadata, runtime details (Go version, OS, architecture), and MCP library information.

* **Tests**
  * Enhanced test execution performance through parallel test execution where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->