### PR TITLE
fix(deps): bump postcss override to 8.5.13 for security fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2534,9 +2534,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "overrides": {
     "semver": "7.7.4",
-    "postcss": "8.5.12",
+    "postcss": "8.5.13",
     "uuid": "14.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps the `postcss` npm override from `8.5.12` to `8.5.13`
- PostCSS 8.5.12 included a security fix for arbitrary file read via user-generated CSS source maps
- PostCSS 8.5.13 fixes a postcss-scss comment regression introduced in 8.5.12
- Regenerated `package-lock.json` via `npm install`
- Verified `make documentation` builds successfully with no changes to docs output

## CVE Scan Results

Comprehensive dependency scan performed using `govulncheck`, `npm audit`, and `osv-scanner`:

### Go Dependencies
- **govulncheck**: 0 vulnerabilities found (155 modules scanned against go1.25.9 stdlib)
- **osv-scanner**: 0 issues found (173 Go packages scanned)
- Go 1.25.9 is the latest patch release, containing fixes for CVE-2026-32280, CVE-2026-32281, CVE-2026-32283, CVE-2026-27140, CVE-2026-27143, CVE-2026-27144, and others
- All `golang.org/x/*` packages are at patched versions
- `google.golang.org/grpc@v1.80.0` is patched (CVE-2026-33186 fixed in v1.79.3)
- `github.com/jackc/pgx/v5@v5.9.2` is patched (CVE-2026-33815, CVE-2026-33816, CVE-2025-54236)

### npm Dependencies
- **npm audit**: 0 vulnerabilities found (309 packages audited)
- **osv-scanner**: 0 issues found (304 npm packages scanned)
- `postcss` override bumped from `8.5.12` to `8.5.13` (security + regression fix)
- `semver@7.7.4`, `uuid@14.0.0` overrides verified at latest versions
- `@redocly/cli@2.30.3` is the latest version with all transitive CVEs patched
- `lodash@4.18.1` is the latest version (CVE-2026-2950, CVE-2026-4800 patched)
- `fast-xml-parser@5.7.1` is patched (CVE-2026-27942 fixed in 5.3.8, CVE-2026-41650 fixed in 5.7.0)
- All `minimatch` versions in tree are patched (CVE-2026-26996, CVE-2026-27903, CVE-2026-27904)
- `undici@6.24.0` is patched (CVE-2026-1525, CVE-2026-1526, CVE-2026-1527, CVE-2026-1528)

## Test plan

- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm ls postcss` confirms `postcss@8.5.13` is installed
- [x] `make documentation` builds successfully
- [x] No documentation output files changed by this update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling dependency to the latest patch version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->