### PR TITLE
fix(scripts): skip ignored paths in configmap sync check

### DIFF
--- a/scripts/check_configmap_sync.py
+++ b/scripts/check_configmap_sync.py
@@ -15,11 +15,17 @@ import yaml
 
 OPERATOR_REPO = "trustyai-explainability/trustyai-service-operator"
 CONFIGMAP_PATH = "config/configmaps/evalhub"
-GITHUB_API = f"https://api.github.com/repos/{OPERATOR_REPO}/contents/{CONFIGMAP_PATH}?ref=main"
+GITHUB_API = (
+    f"https://api.github.com/repos/{OPERATOR_REPO}/contents/{CONFIGMAP_PATH}?ref=main"
+)
 RAW_BASE = f"https://raw.githubusercontent.com/{OPERATOR_REPO}/main/{CONFIGMAP_PATH}"
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 KUSTOMIZE_VAR = re.compile(r"^\$\(.*\)$")
+
+IGNORED_PATHS = {
+    "runtime.local",
+}
 
 
 def fetch_remote_files():
@@ -63,6 +69,9 @@ def diff_yaml(remote, local, path=""):
     Yields human-readable diff strings. Skips remote leaf values that
     are Kustomize substitution variables like $(image-name).
     """
+    if path in IGNORED_PATHS:
+        return
+
     if isinstance(remote, dict) and isinstance(local, dict):
         all_keys = set(remote) | set(local)
         for key in sorted(all_keys):
@@ -85,7 +94,7 @@ def diff_yaml(remote, local, path=""):
     else:
         # leaf content check
         if isinstance(remote, str) and KUSTOMIZE_VAR.match(remote):
-            # if trustyai-service-operator leaf is a string and it's a Kustomize variable, skip. 
+            # if trustyai-service-operator leaf is a string and it's a Kustomize variable, skip.
             return
         if remote != local:
             yield f"  ~ {path}: remote={remote!r}  local={local!r}"
@@ -106,7 +115,9 @@ def main():
 
         local_content = load_local(config_type, local_filename)
         if local_content is None:
-            errors.append(f"{filename}: local file config/{config_type}/{local_filename} not found")
+            errors.append(
+                f"{filename}: local file config/{config_type}/{local_filename} not found"
+            )
             continue
 
         diffs = list(diff_yaml(remote_content, local_content))


### PR DESCRIPTION
Add IGNORED_PATHS set to allow specific YAML paths to be excluded from drift detection. Skip runtime.local.command as it legitimately differs between operator ConfigMaps and local config.

## What and why

Fix the CI  issue 
```
Run python scripts/check_configmap_sync.py
Fetching ConfigMap listing from trustyai-explainability/trustyai-service-operator...
Found 9 ConfigMap(s) to check.

OK  collection-leaderboard-v2.yaml <-> config/collections/leaderboard-v2.yaml
OK  collection-safety-and-fairness-v1.yaml <-> config/collections/safety-and-fairness-v1.yaml
OK  collection-toxicity-and-ethical-principles.yaml <-> config/collections/toxicity-and-ethical-principles.yaml

Drift detected:

provider-garak-kfp.yaml vs config/providers/garak-kfp.yaml:
  ~ runtime.local.command: remote='true'  local='python tests/features/test_data/runtime/main.py'
provider-garak.yaml vs config/providers/garak.yaml:
  ~ runtime.local.command: remote='true'  local='python tests/features/test_data/runtime/main.py'
provider-guidellm.yaml vs config/providers/guidellm.yaml:
  ~ runtime.local.command: remote='true'  local='python tests/features/test_data/runtime/main.py'
provider-ibm-clear.yaml vs config/providers/ibm-clear.yaml:
  ~ runtime.local.command: remote='true'  local='python tests/features/test_data/runtime/main.py'
provider-lighteval.yaml vs config/providers/lighteval.yaml:
  ~ runtime.local.command: remote='true'  local='python tests/features/test_data/runtime/main.py'
provider-lm-evaluation-harness.yaml vs config/providers/lm_evaluation_harness.yaml:
  ~ runtime.local.command: remote='true'  local='python tests/features/test_data/runtime/main.py'
Error: Process completed with exit code 1.
```
Closes #

Assisted-by: Claude
## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually
```
╰─➤  python scripts/check_configmap_sync.py                                                                                1 ↵
Fetching ConfigMap listing from trustyai-explainability/trustyai-service-operator...
Found 9 ConfigMap(s) to check.

OK  collection-leaderboard-v2.yaml <-> config/collections/leaderboard-v2.yaml
OK  collection-safety-and-fairness-v1.yaml <-> config/collections/safety-and-fairness-v1.yaml
OK  collection-toxicity-and-ethical-principles.yaml <-> config/collections/toxicity-and-ethical-principles.yaml
OK  provider-garak-kfp.yaml <-> config/providers/garak-kfp.yaml
OK  provider-garak.yaml <-> config/providers/garak.yaml
OK  provider-guidellm.yaml <-> config/providers/guidellm.yaml
OK  provider-ibm-clear.yaml <-> config/providers/ibm-clear.yaml
OK  provider-lighteval.yaml <-> config/providers/lighteval.yaml
OK  provider-lm-evaluation-harness.yaml <-> config/providers/lm_evaluation_harness.yaml

All ConfigMaps in sync.
```

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal configuration synchronization: reduced noise from ignored subtrees during YAML comparisons and cleaned up API URL construction and error handling for better maintainability.

Note: This release contains only internal infrastructure improvements with no visible changes to end-user functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/525)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->