### PR TITLE
refactor: update logging messages to specify server context

### DIFF
--- a/cmd/eval_hub/main.go
+++ b/cmd/eval_hub/main.go
@@ -139,11 +139,11 @@ func main() {
 
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, err, "Failed to create server", logger)
+		startUpFailed(serviceConfig, err, "Failed to create API server", logger)
 	}
 
 	// log the start up details
-	logger.Info("Server starting",
+	logger.Info("API Server starting",
 		"server_port", srv.GetPort(),
 		"version", serviceConfig.Service.Version,
 		"build", serviceConfig.Service.Build,
@@ -165,10 +165,10 @@ func main() {
 		if err := srv.Start(); err != nil {
 			// we do this as no point trying to continue
 			if errors.Is(err, &server.ServerClosedError{}) {
-				logger.Info("Server closed gracefully")
+				logger.Info("API Server closed gracefully")
 				return
 			}
-			startUpFailed(serviceConfig, err, "Server failed to start", logger)
+			startUpFailed(serviceConfig, err, "API Server failed to start", logger)
 		}
 	}()
 
@@ -178,7 +178,7 @@ func main() {
 	<-quit
 
 	// Stop config watcher
-	logger.Info("Shutting down config watcher...")
+	logger.Info("Shutting down API config watcher...")
 	watcherCancel()
 	<-watcherDone // Wait for Watch() to fully complete
 
@@ -188,26 +188,26 @@ func main() {
 	defer cancel()
 
 	// shutdown the storage
-	logger.Info("Shutting down storage...")
+	logger.Info("Shutting down API storage...")
 	if err := storage.Close(); err != nil {
-		logger.Error("Failed to close storage", "error", err.Error())
+		logger.Error("Failed to close API storage", "error", err.Error())
 	}
 
 	// shutdown the otel tracing
 	if otelShutdown != nil {
-		logger.Info("Shutting down OTEL...")
+		logger.Info("Shutting down API OTEL...")
 		if err := otelShutdown(shutdownCtx); err != nil {
-			logger.Error("Failed to shutdown OTEL", "error", err.Error())
+			logger.Error("Failed to shutdown API OTEL", "error", err.Error())
 		}
 	}
 
 	// shutdown the logger
-	logger.Info("Shutting down server...")
+	logger.Info("Shutting down API server...")
 	if err := srv.Shutdown(shutdownCtx); err != nil {
-		logger.Error("Server forced to shutdown", "error", err.Error(), "timeout", waitForShutdown)
+		logger.Error("API Server forced to shutdown", "error", err.Error(), "timeout", waitForShutdown)
 		_ = logShutdown() // ignore the error
 	} else {
-		logger.Info("Server shutdown gracefully")
+		logger.Info("API Server shutdown gracefully")
 		_ = logShutdown() // ignore the error
 	}
 }

--- a/cmd/eval_runtime_sidecar/main.go
+++ b/cmd/eval_runtime_sidecar/main.go
@@ -60,7 +60,7 @@ func main() {
 	if svcConfig.Service != nil {
 		version, build, buildDate = svcConfig.Service.Version, svcConfig.Service.Build, svcConfig.Service.BuildDate
 	}
-	logger.Info("Server starting",
+	logger.Info("Sidecar server starting",
 		"server_port", srv.GetPort(),
 		"sidecar_config", cfgPath,
 		"version", version,
@@ -74,10 +74,10 @@ func main() {
 		if err := srv.Start(); err != nil {
 			// we do this as no point trying to continue
 			if errors.Is(err, &sidecarServer.ServerClosedError{}) {
-				logger.Info("Server closed gracefully")
+				logger.Info("Sidecar server closed gracefully")
 				return
 			}
-			startUpFailed(terminationFilePath(), err, "Server failed to start", logger)
+			startUpFailed(terminationFilePath(), err, "Sidecar server failed to start", logger)
 		}
 	}()
 
@@ -93,12 +93,12 @@ func main() {
 	defer cancel()
 
 	// shutdown the logger
-	logger.Info("Shutting down server...")
+	logger.Info("Shutting down sidecar server...")
 	if err := srv.Shutdown(shutdownCtx); err != nil {
-		logger.Error("Server forced to shutdown", "error", err.Error(), "timeout", waitForShutdown)
+		logger.Error("Sidecar server forced to shutdown", "error", err.Error(), "timeout", waitForShutdown)
 		_ = logShutdown() // ignore the error
 	} else {
-		logger.Info("Server shutdown gracefully")
+		logger.Info("Sidecar server shutdown gracefully")
 		_ = logShutdown() // ignore the error
 	}
 }

--- a/cmd/evalhub_mcp/main.go
+++ b/cmd/evalhub_mcp/main.go
@@ -95,7 +95,7 @@ func run(args []string) int {
 	}
 
 	if err := mcpserver.Run(ctx, cfg, info, logger); err != nil {
-		logger.Error("server error", "error", err)
+		logger.Error("MCP Server error", "error", err)
 		return 1
 	}
 

--- a/internal/eval_hub/server/server.go
+++ b/internal/eval_hub/server/server.go
@@ -499,14 +499,14 @@ func (s *Server) Start() error {
 		return fmt.Errorf("FIPS mode enabled, but TLS certificate verification is required")
 	}
 
-	s.logger.Info("Writing the server ready message", "file", s.serviceConfig.Service.ReadyFile)
+	s.logger.Info("Writing the API server ready message", "file", s.serviceConfig.Service.ReadyFile)
 	err = SetReady(s.serviceConfig, s.logger)
 	if err != nil {
 		return err
 	}
 
 	tlsEnabled := s.serviceConfig.Service.TLSEnabled()
-	s.logger.Info("Server starting", "addr", addr, "tls", tlsEnabled)
+	s.logger.Info("API Server starting", "addr", addr, "tls", tlsEnabled)
 
 	if tlsEnabled {
 		err = s.httpServer.ListenAndServeTLS(
@@ -518,14 +518,14 @@ func (s *Server) Start() error {
 	}
 
 	if err == http.ErrServerClosed {
-		s.logger.Info("Server closed gracefully")
+		s.logger.Info("API Server closed gracefully")
 		return &ServerClosedError{}
 	}
 	return err
 }
 
 func (s *Server) Shutdown(ctx context.Context) error {
-	s.logger.Info("Shutting down server gracefully...")
+	s.logger.Info("Shutting down API server gracefully...")
 	return s.httpServer.Shutdown(ctx)
 }
 
@@ -533,7 +533,7 @@ type ServerClosedError struct {
 }
 
 func (e *ServerClosedError) Error() string {
-	return "Server closed"
+	return "API Server closed"
 }
 
 func (e *ServerClosedError) Is(target error) bool {

--- a/internal/eval_runtime_sidecar/server/server.go
+++ b/internal/eval_runtime_sidecar/server/server.go
@@ -111,17 +111,17 @@ func (s *SidecarServer) Start() error {
 	if s.config.Service != nil {
 		readyFile = s.config.Service.ReadyFile
 	}
-	s.logger.Info("Writing the server ready message", "file", readyFile)
+	s.logger.Info("Writing the sidecar server ready message", "file", readyFile)
 	err = server.SetReady(s.config, s.logger)
 	if err != nil {
 		return err
 	}
 
-	s.logger.Info("Server starting", "port", s.port)
+	s.logger.Info("Sidecar server starting", "port", s.port)
 	err = s.httpServer.ListenAndServe()
 
 	if err == http.ErrServerClosed {
-		s.logger.Info("Server closed gracefully")
+		s.logger.Info("Sidecar server closed gracefully")
 		return &ServerClosedError{}
 	}
 	return err
@@ -129,7 +129,7 @@ func (s *SidecarServer) Start() error {
 
 func (s *SidecarServer) Shutdown(ctx context.Context) error {
 	//TODO: Explore sending metrics on sidecar shutdown
-	s.logger.Info("Shutting down server gracefully...")
+	s.logger.Info("Shutting down sidecar server gracefully...")
 	return s.httpServer.Shutdown(ctx)
 }
 
@@ -137,7 +137,7 @@ type ServerClosedError struct {
 }
 
 func (e *ServerClosedError) Error() string {
-	return "Server closed"
+	return "Sidecar server closed"
 }
 
 func (e *ServerClosedError) Is(target error) bool {

--- a/internal/eval_runtime_sidecar/server/server_test.go
+++ b/internal/eval_runtime_sidecar/server/server_test.go
@@ -139,8 +139,8 @@ func TestSidecarServer_HealthEndpoint(t *testing.T) {
 
 func TestServerClosedError(t *testing.T) {
 	err := &sidecarServer.ServerClosedError{}
-	if err.Error() != "Server closed" {
-		t.Errorf("ServerClosedError.Error() = %q, want %q", err.Error(), "Server closed")
+	if err.Error() != "Sidecar server closed" {
+		t.Errorf("ServerClosedError.Error() = %q, want %q", err.Error(), "Sidecar server closed")
 	}
 	if !errors.Is(err, &sidecarServer.ServerClosedError{}) {
 		t.Error("errors.Is should match two distinct ServerClosedError pointers")

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -124,7 +124,7 @@ func runHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *s
 
 	errCh := make(chan error, 1)
 	go func() {
-		logger.Info("HTTP transport listening", "addr", addr)
+		logger.Info("MCP HTTP Server listening", "addr", addr)
 		errCh <- httpServer.ListenAndServe()
 	}()
 
@@ -133,18 +133,18 @@ func runHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *s
 		if err == http.ErrServerClosed {
 			return nil
 		}
-		return fmt.Errorf("HTTP server error: %w", err)
+		return fmt.Errorf("MCP HTTP Server error: %w", err)
 	case <-ctx.Done():
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if shutdownErr := httpServer.Shutdown(shutdownCtx); shutdownErr != nil {
-			logger.Error("HTTP server graceful shutdown failed", "error", shutdownErr)
+			logger.Error("MCP HTTP Server graceful shutdown failed", "error", shutdownErr)
 			if closeErr := httpServer.Close(); closeErr != nil {
 				return errors.Join(shutdownErr, closeErr)
 			}
 			return shutdownErr
 		}
-		logger.Info("HTTP server stopped gracefully")
+		logger.Info("MCP HTTP Server stopped gracefully")
 		return nil
 	}
 }


### PR DESCRIPTION
## What and why

This commit modifies log messages across the eval_hub, eval_runtime_sidecar, and evalhub_mcp components to clarify that they pertain to the API, MCP and sidecar servers. Changes include updating startup, shutdown, and error messages to enhance clarity and consistency in logging.

No functional changes were made; this is purely a logging improvement for better traceability when looking at aggregated logs.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized logging messages across API, sidecar, and MCP server components for improved clarity and consistency
  * Enhanced error handling in server shutdown sequences with better error identification mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->