### PR TITLE
feat(mcp): implement resource URI autocompletion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ make clean              # Remove build artifacts and coverage files
 
 ## Git commits
 
-Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, etc., with an optional scope (e.g. `feat(http): …`).
+Use [Conventional Commits](https://www.conventionalcommits.org/) with an optional scope (e.g. `feat(http): …`). Accepted type prefixes: `build`, `bump`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
 
 When a change is assisted by Cursor, add one of these lines, as appropriate, to the **end** of the commit message body (after the subject and any description), as Git trailers:
 

--- a/internal/evalhub_mcp/server/completions.go
+++ b/internal/evalhub_mcp/server/completions.go
@@ -1,0 +1,222 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const defaultCacheTTL = 30 * time.Second
+
+var statusValues = []string{
+	string(api.OverallStatePending),
+	string(api.OverallStateRunning),
+	string(api.OverallStateCompleted),
+	string(api.OverallStateFailed),
+	string(api.OverallStateCancelled),
+	string(api.OverallStatePartiallyFailed),
+}
+
+type completionCache struct {
+	mu      sync.Mutex
+	entries map[string]*cacheEntry
+	ttl     time.Duration
+	now     func() time.Time
+}
+
+type cacheEntry struct {
+	values    []string
+	expiresAt time.Time
+}
+
+func newCompletionCache(ttl time.Duration) *completionCache {
+	return &completionCache{
+		entries: make(map[string]*cacheEntry),
+		ttl:     ttl,
+		now:     time.Now,
+	}
+}
+
+func (c *completionCache) get(key string) ([]string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok || c.now().After(e.expiresAt) {
+		return nil, false
+	}
+	return e.values, true
+}
+
+func (c *completionCache) set(key string, values []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = &cacheEntry{
+		values:    values,
+		expiresAt: c.now().Add(c.ttl),
+	}
+}
+
+type completionProvider struct {
+	ds     EvalHubDiscovery
+	cache  *completionCache
+	logger *slog.Logger
+}
+
+func newCompletionProvider(ds EvalHubDiscovery, logger *slog.Logger) *completionProvider {
+	return &completionProvider{
+		ds:     ds,
+		cache:  newCompletionCache(defaultCacheTTL),
+		logger: logger,
+	}
+}
+
+func (cp *completionProvider) handle(_ context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+	if req.Params.Ref == nil || req.Params.Ref.Type != "ref/resource" {
+		return emptyResult(), nil
+	}
+
+	uri := req.Params.Ref.URI
+	argName := req.Params.Argument.Name
+	prefix := req.Params.Argument.Value
+
+	values := cp.resolveValues(uri, argName)
+	filtered := filterByPrefix(values, prefix)
+
+	return &mcp.CompleteResult{
+		Completion: mcp.CompletionResultDetails{
+			Values:  filtered,
+			Total:   len(filtered),
+			HasMore: false,
+		},
+	}, nil
+}
+
+func (cp *completionProvider) resolveValues(uri, argName string) []string {
+	switch {
+	case matchesTemplate(uri, "evalhub://providers/{id}") && argName == "id":
+		return cp.cachedFetch("providers", cp.fetchProviderIDs)
+	case matchesTemplate(uri, "evalhub://benchmarks/{id}") && argName == "id":
+		return cp.cachedFetch("benchmarks", cp.fetchBenchmarkIDs)
+	case matchesTemplate(uri, "evalhub://collections/{id}") && argName == "id":
+		return cp.cachedFetch("collections", cp.fetchCollectionIDs)
+	case matchesTemplate(uri, "evalhub://jobs/{id}") && argName == "id":
+		return cp.cachedFetch("jobs", cp.fetchJobIDs)
+	case matchesTemplate(uri, "evalhub://jobs{?status}") && argName == "status":
+		return statusValues
+	case matchesTemplate(uri, "evalhub://benchmarks{?label*}") && argName == "label":
+		return cp.cachedFetch("labels", cp.fetchLabels)
+	default:
+		return nil
+	}
+}
+
+func matchesTemplate(uri, template string) bool {
+	return uri == template
+}
+
+func (cp *completionProvider) cachedFetch(key string, fetch func() []string) []string {
+	if values, ok := cp.cache.get(key); ok {
+		return values
+	}
+	values := fetch()
+	cp.cache.set(key, values)
+	return values
+}
+
+func (cp *completionProvider) fetchProviderIDs() []string {
+	list, err := cp.ds.ListProviders()
+	if err != nil {
+		cp.logger.Warn("completion: failed to list providers", "error", err)
+		return nil
+	}
+	ids := make([]string, len(list.Items))
+	for i, p := range list.Items {
+		ids[i] = p.Resource.ID
+	}
+	return ids
+}
+
+func (cp *completionProvider) fetchBenchmarkIDs() []string {
+	benchmarks, err := cp.ds.ListBenchmarks()
+	if err != nil {
+		cp.logger.Warn("completion: failed to list benchmarks", "error", err)
+		return nil
+	}
+	ids := make([]string, len(benchmarks))
+	for i, b := range benchmarks {
+		ids[i] = b.ID
+	}
+	return ids
+}
+
+func (cp *completionProvider) fetchCollectionIDs() []string {
+	list, err := cp.ds.ListCollections()
+	if err != nil {
+		cp.logger.Warn("completion: failed to list collections", "error", err)
+		return nil
+	}
+	ids := make([]string, len(list.Items))
+	for i, c := range list.Items {
+		ids[i] = c.Resource.ID
+	}
+	return ids
+}
+
+func (cp *completionProvider) fetchJobIDs() []string {
+	list, err := cp.ds.ListJobs()
+	if err != nil {
+		cp.logger.Warn("completion: failed to list jobs", "error", err)
+		return nil
+	}
+	ids := make([]string, len(list.Items))
+	for i, j := range list.Items {
+		ids[i] = j.Resource.ID
+	}
+	return ids
+}
+
+func (cp *completionProvider) fetchLabels() []string {
+	benchmarks, err := cp.ds.ListBenchmarks()
+	if err != nil {
+		cp.logger.Warn("completion: failed to list benchmarks for labels", "error", err)
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var labels []string
+	for _, b := range benchmarks {
+		for _, tag := range b.Tags {
+			if _, ok := seen[tag]; !ok {
+				seen[tag] = struct{}{}
+				labels = append(labels, tag)
+			}
+		}
+	}
+	return labels
+}
+
+func filterByPrefix(values []string, prefix string) []string {
+	if prefix == "" {
+		return values
+	}
+	lower := strings.ToLower(prefix)
+	var result []string
+	for _, v := range values {
+		if strings.HasPrefix(strings.ToLower(v), lower) {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+func emptyResult() *mcp.CompleteResult {
+	return &mcp.CompleteResult{
+		Completion: mcp.CompletionResultDetails{
+			Values: []string{},
+		},
+	}
+}

--- a/internal/evalhub_mcp/server/completions.go
+++ b/internal/evalhub_mcp/server/completions.go
@@ -124,7 +124,9 @@ func (cp *completionProvider) cachedFetch(key string, fetch func() []string) []s
 		return values
 	}
 	values := fetch()
-	cp.cache.set(key, values)
+	if values != nil {
+		cp.cache.set(key, values)
+	}
 	return values
 }
 

--- a/internal/evalhub_mcp/server/completions_test.go
+++ b/internal/evalhub_mcp/server/completions_test.go
@@ -337,6 +337,38 @@ func TestCompletionAPIErrorLabels(t *testing.T) {
 	}
 }
 
+func TestCompletionAPIErrorNotCached(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	ds := &switchableDataSource{
+		listProvidersFn: func() (*api.ProviderResourceList, error) {
+			calls++
+			if calls == 1 {
+				return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "transient"}
+			}
+			return &api.ProviderResourceList{
+				Items: []api.ProviderResource{{Resource: api.Resource{ID: "recovered"}}},
+				Page:  api.Page{TotalCount: 1},
+			}, nil
+		},
+	}
+	cp := newCompletionProvider(ds, discardLogger)
+
+	got := cp.resolveValues("evalhub://providers/{id}", "id")
+	if len(got) != 0 {
+		t.Fatalf("expected empty on first (errored) call, got %v", got)
+	}
+
+	got = cp.resolveValues("evalhub://providers/{id}", "id")
+	if len(got) != 1 || got[0] != "recovered" {
+		t.Fatalf("expected [recovered] on retry, got %v", got)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 API calls (error not cached), got %d", calls)
+	}
+}
+
 // --- empty data source ---
 
 func TestCompletionEmptyDataSource(t *testing.T) {
@@ -471,9 +503,45 @@ func (d *errorDataSource) ListJobsByStatus(_ api.OverallState, _ ...evalhubclien
 	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
 }
 
+// switchableDataSource delegates ListProviders to a caller-supplied function,
+// allowing tests to change behavior between calls (e.g. error then success).
+type switchableDataSource struct {
+	listProvidersFn func() (*api.ProviderResourceList, error)
+}
+
+func (d *switchableDataSource) ListProviders(_ ...evalhubclient.ListOption) (*api.ProviderResourceList, error) {
+	return d.listProvidersFn()
+}
+func (d *switchableDataSource) GetProvider(_ string) (*api.ProviderResource, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusNotFound}
+}
+func (d *switchableDataSource) ListBenchmarks() ([]api.BenchmarkResource, error) { return nil, nil }
+func (d *switchableDataSource) GetBenchmark(_ string) (*api.BenchmarkResource, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusNotFound}
+}
+func (d *switchableDataSource) ListBenchmarksByLabel(_ []string) ([]api.BenchmarkResource, error) {
+	return nil, nil
+}
+func (d *switchableDataSource) ListCollections(_ ...evalhubclient.ListOption) (*api.CollectionResourceList, error) {
+	return nil, nil
+}
+func (d *switchableDataSource) GetCollection(_ string) (*api.CollectionResource, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusNotFound}
+}
+func (d *switchableDataSource) ListJobs(_ ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error) {
+	return nil, nil
+}
+func (d *switchableDataSource) GetJob(_ string) (*api.EvaluationJobResource, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusNotFound}
+}
+func (d *switchableDataSource) ListJobsByStatus(_ api.OverallState, _ ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error) {
+	return nil, nil
+}
+
 // Verify errorDataSource implements EvalHubDiscovery at compile time.
 var _ EvalHubDiscovery = (*errorDataSource)(nil)
 var _ EvalHubDiscovery = (*callCountDataSource)(nil)
+var _ EvalHubDiscovery = (*switchableDataSource)(nil)
 
 // --- filterByPrefix unit tests ---
 

--- a/internal/evalhub_mcp/server/completions_test.go
+++ b/internal/evalhub_mcp/server/completions_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"sort"
 	"testing"
@@ -640,6 +639,3 @@ func TestCompleteStatusPrefixComp(t *testing.T) {
 		t.Errorf("expected 'completed', got %q", result.Completion.Values[0])
 	}
 }
-
-// Silence unused import warning for fmt.
-var _ = fmt.Sprint

--- a/internal/evalhub_mcp/server/completions_test.go
+++ b/internal/evalhub_mcp/server/completions_test.go
@@ -1,0 +1,577 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/eval-hub/eval-hub/pkg/evalhubclient"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// --- test helpers ---
+
+func connectWithCompletions(t *testing.T, ds EvalHubDiscovery) (context.Context, *mcp.ClientSession) {
+	t.Helper()
+
+	srv := New(&ServerInfo{Version: "test"}, discardLogger, CompletionHandlerOption(ds, discardLogger))
+	registerResources(srv, ds, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect failed: %v", err)
+	}
+	t.Cleanup(func() { serverSession.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	t.Cleanup(func() { clientSession.Close() })
+
+	return ctx, clientSession
+}
+
+func complete(t *testing.T, ctx context.Context, cs *mcp.ClientSession, uri, argName, argValue string) *mcp.CompleteResult {
+	t.Helper()
+	result, err := cs.Complete(ctx, &mcp.CompleteParams{
+		Ref: &mcp.CompleteReference{
+			Type: "ref/resource",
+			URI:  uri,
+		},
+		Argument: mcp.CompleteParamsArgument{
+			Name:  argName,
+			Value: argValue,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete(%q, %q=%q) failed: %v", uri, argName, argValue, err)
+	}
+	return result
+}
+
+// --- provider ID completion ---
+
+func TestCompleteProviderIDs(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://providers/{id}", "id", "")
+	if len(result.Completion.Values) != 2 {
+		t.Fatalf("expected 2 provider IDs, got %d: %v", len(result.Completion.Values), result.Completion.Values)
+	}
+	want := map[string]bool{"lighteval": false, "unitxt": false}
+	for _, v := range result.Completion.Values {
+		want[v] = true
+	}
+	for id, found := range want {
+		if !found {
+			t.Errorf("missing provider ID %q", id)
+		}
+	}
+}
+
+func TestCompleteProviderIDsPrefix(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://providers/{id}", "id", "light")
+	if len(result.Completion.Values) != 1 {
+		t.Fatalf("expected 1 match for prefix 'light', got %d", len(result.Completion.Values))
+	}
+	if result.Completion.Values[0] != "lighteval" {
+		t.Errorf("expected 'lighteval', got %q", result.Completion.Values[0])
+	}
+}
+
+func TestCompleteProviderIDsNoMatch(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://providers/{id}", "id", "zzz")
+	if len(result.Completion.Values) != 0 {
+		t.Errorf("expected 0 matches for 'zzz', got %d", len(result.Completion.Values))
+	}
+}
+
+// --- benchmark ID completion ---
+
+func TestCompleteBenchmarkIDs(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://benchmarks/{id}", "id", "")
+	if len(result.Completion.Values) != 4 {
+		t.Fatalf("expected 4 benchmark IDs, got %d", len(result.Completion.Values))
+	}
+}
+
+func TestCompleteBenchmarkIDsPrefix(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://benchmarks/{id}", "id", "mm")
+	if len(result.Completion.Values) != 1 {
+		t.Fatalf("expected 1 match for 'mm', got %d", len(result.Completion.Values))
+	}
+	if result.Completion.Values[0] != "mmlu" {
+		t.Errorf("expected 'mmlu', got %q", result.Completion.Values[0])
+	}
+}
+
+// --- collection ID completion ---
+
+func TestCompleteCollectionIDs(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://collections/{id}", "id", "")
+	if len(result.Completion.Values) != 2 {
+		t.Fatalf("expected 2 collection IDs, got %d", len(result.Completion.Values))
+	}
+}
+
+func TestCompleteCollectionIDsPrefix(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://collections/{id}", "id", "safe")
+	if len(result.Completion.Values) != 1 {
+		t.Fatalf("expected 1 match for 'safe', got %d", len(result.Completion.Values))
+	}
+	if result.Completion.Values[0] != "safety-suite" {
+		t.Errorf("expected 'safety-suite', got %q", result.Completion.Values[0])
+	}
+}
+
+// --- job ID completion ---
+
+func TestCompleteJobIDs(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://jobs/{id}", "id", "")
+	if len(result.Completion.Values) != 3 {
+		t.Fatalf("expected 3 job IDs, got %d", len(result.Completion.Values))
+	}
+}
+
+func TestCompleteJobIDsPrefix(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://jobs/{id}", "id", "job-2")
+	if len(result.Completion.Values) != 1 {
+		t.Fatalf("expected 1 match for 'job-2', got %d", len(result.Completion.Values))
+	}
+	if result.Completion.Values[0] != "job-2" {
+		t.Errorf("expected 'job-2', got %q", result.Completion.Values[0])
+	}
+}
+
+// --- status completion (static values) ---
+
+func TestCompleteStatus(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://jobs{?status}", "status", "")
+	if len(result.Completion.Values) != 6 {
+		t.Fatalf("expected 6 status values, got %d: %v", len(result.Completion.Values), result.Completion.Values)
+	}
+	want := []string{"pending", "running", "completed", "failed", "cancelled", "partially_failed"}
+	for _, w := range want {
+		found := false
+		for _, v := range result.Completion.Values {
+			if v == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing status value %q", w)
+		}
+	}
+}
+
+func TestCompleteStatusPrefix(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://jobs{?status}", "status", "p")
+	sort.Strings(result.Completion.Values)
+	if len(result.Completion.Values) != 2 {
+		t.Fatalf("expected 2 matches for 'p' (pending, partially_failed), got %d: %v",
+			len(result.Completion.Values), result.Completion.Values)
+	}
+}
+
+func TestCompleteStatusNoAPICall(t *testing.T) {
+	t.Parallel()
+	ds := &callCountDataSource{inner: testDataSource()}
+	ctx, cs := connectWithCompletions(t, ds)
+
+	_ = complete(t, ctx, cs, "evalhub://jobs{?status}", "status", "")
+	if ds.listJobsCalls > 0 {
+		t.Error("status completion should not call ListJobs")
+	}
+}
+
+// --- label completion ---
+
+func TestCompleteLabels(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://benchmarks{?label*}", "label", "")
+	want := map[string]bool{"reasoning": false, "general": false, "knowledge": false, "rag": false, "safety": false}
+	for _, v := range result.Completion.Values {
+		want[v] = true
+	}
+	for label, found := range want {
+		if !found {
+			t.Errorf("missing label %q", label)
+		}
+	}
+}
+
+func TestCompleteLabelsPrefix(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://benchmarks{?label*}", "label", "ra")
+	if len(result.Completion.Values) != 1 {
+		t.Fatalf("expected 1 match for 'ra', got %d", len(result.Completion.Values))
+	}
+	if result.Completion.Values[0] != "rag" {
+		t.Errorf("expected 'rag', got %q", result.Completion.Values[0])
+	}
+}
+
+// --- caching ---
+
+func TestCompletionCachePreventsRedundantCalls(t *testing.T) {
+	t.Parallel()
+	ds := &callCountDataSource{inner: testDataSource()}
+	ctx, cs := connectWithCompletions(t, ds)
+
+	_ = complete(t, ctx, cs, "evalhub://providers/{id}", "id", "")
+	_ = complete(t, ctx, cs, "evalhub://providers/{id}", "id", "light")
+
+	if ds.listProvidersCalls != 1 {
+		t.Errorf("expected 1 ListProviders call (cached), got %d", ds.listProvidersCalls)
+	}
+}
+
+// --- cache expiry ---
+
+func TestCompletionCacheExpiry(t *testing.T) {
+	t.Parallel()
+
+	ds := &callCountDataSource{inner: testDataSource()}
+	cp := newCompletionProvider(ds, discardLogger)
+
+	now := time.Now()
+	cp.cache.now = func() time.Time { return now }
+
+	cp.resolveValues("evalhub://providers/{id}", "id")
+	if ds.listProvidersCalls != 1 {
+		t.Fatalf("expected 1 call, got %d", ds.listProvidersCalls)
+	}
+
+	cp.resolveValues("evalhub://providers/{id}", "id")
+	if ds.listProvidersCalls != 1 {
+		t.Fatalf("expected still 1 call (cached), got %d", ds.listProvidersCalls)
+	}
+
+	cp.cache.now = func() time.Time { return now.Add(defaultCacheTTL + time.Second) }
+
+	cp.resolveValues("evalhub://providers/{id}", "id")
+	if ds.listProvidersCalls != 2 {
+		t.Errorf("expected 2 calls after TTL expiry, got %d", ds.listProvidersCalls)
+	}
+}
+
+// --- graceful degradation ---
+
+func TestCompletionAPIErrorReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	ds := &errorDataSource{}
+	ctx, cs := connectWithCompletions(t, ds)
+
+	result := complete(t, ctx, cs, "evalhub://providers/{id}", "id", "")
+	if len(result.Completion.Values) != 0 {
+		t.Errorf("expected empty result on API error, got %v", result.Completion.Values)
+	}
+}
+
+func TestCompletionAPIErrorBenchmarks(t *testing.T) {
+	t.Parallel()
+	ds := &errorDataSource{}
+	ctx, cs := connectWithCompletions(t, ds)
+
+	result := complete(t, ctx, cs, "evalhub://benchmarks/{id}", "id", "")
+	if len(result.Completion.Values) != 0 {
+		t.Errorf("expected empty result on API error, got %v", result.Completion.Values)
+	}
+}
+
+func TestCompletionAPIErrorLabels(t *testing.T) {
+	t.Parallel()
+	ds := &errorDataSource{}
+	ctx, cs := connectWithCompletions(t, ds)
+
+	result := complete(t, ctx, cs, "evalhub://benchmarks{?label*}", "label", "")
+	if len(result.Completion.Values) != 0 {
+		t.Errorf("expected empty result on API error, got %v", result.Completion.Values)
+	}
+}
+
+// --- empty data source ---
+
+func TestCompletionEmptyDataSource(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, emptyDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://providers/{id}", "id", "")
+	if result.Completion.Values == nil {
+		t.Fatal("expected non-nil empty slice")
+	}
+	if len(result.Completion.Values) != 0 {
+		t.Errorf("expected 0 values, got %d", len(result.Completion.Values))
+	}
+}
+
+// --- unknown URI template ---
+
+func TestCompletionUnknownTemplate(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://unknown/{id}", "id", "")
+	if len(result.Completion.Values) != 0 {
+		t.Errorf("expected 0 values for unknown template, got %d", len(result.Completion.Values))
+	}
+}
+
+// --- case-insensitive prefix matching ---
+
+func TestCompletePrefixCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://providers/{id}", "id", "LIGHT")
+	if len(result.Completion.Values) != 1 {
+		t.Fatalf("expected 1 match for 'LIGHT', got %d", len(result.Completion.Values))
+	}
+	if result.Completion.Values[0] != "lighteval" {
+		t.Errorf("expected 'lighteval', got %q", result.Completion.Values[0])
+	}
+}
+
+// --- mock data sources ---
+
+type callCountDataSource struct {
+	inner              EvalHubDiscovery
+	listProvidersCalls int
+	listJobsCalls      int
+}
+
+func (d *callCountDataSource) ListProviders(opts ...evalhubclient.ListOption) (*api.ProviderResourceList, error) {
+	d.listProvidersCalls++
+	return d.inner.ListProviders(opts...)
+}
+
+func (d *callCountDataSource) GetProvider(id string) (*api.ProviderResource, error) {
+	return d.inner.GetProvider(id)
+}
+
+func (d *callCountDataSource) ListBenchmarks() ([]api.BenchmarkResource, error) {
+	return d.inner.ListBenchmarks()
+}
+
+func (d *callCountDataSource) GetBenchmark(id string) (*api.BenchmarkResource, error) {
+	return d.inner.GetBenchmark(id)
+}
+
+func (d *callCountDataSource) ListBenchmarksByLabel(labels []string) ([]api.BenchmarkResource, error) {
+	return d.inner.ListBenchmarksByLabel(labels)
+}
+
+func (d *callCountDataSource) ListCollections(opts ...evalhubclient.ListOption) (*api.CollectionResourceList, error) {
+	return d.inner.ListCollections(opts...)
+}
+
+func (d *callCountDataSource) GetCollection(id string) (*api.CollectionResource, error) {
+	return d.inner.GetCollection(id)
+}
+
+func (d *callCountDataSource) ListJobs(opts ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error) {
+	d.listJobsCalls++
+	return d.inner.ListJobs(opts...)
+}
+
+func (d *callCountDataSource) GetJob(id string) (*api.EvaluationJobResource, error) {
+	return d.inner.GetJob(id)
+}
+
+func (d *callCountDataSource) ListJobsByStatus(status api.OverallState, opts ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error) {
+	return d.inner.ListJobsByStatus(status, opts...)
+}
+
+type errorDataSource struct{}
+
+func (d *errorDataSource) ListProviders(_ ...evalhubclient.ListOption) (*api.ProviderResourceList, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+}
+
+func (d *errorDataSource) GetProvider(_ string) (*api.ProviderResource, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+}
+
+func (d *errorDataSource) ListBenchmarks() ([]api.BenchmarkResource, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+}
+
+func (d *errorDataSource) GetBenchmark(_ string) (*api.BenchmarkResource, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+}
+
+func (d *errorDataSource) ListBenchmarksByLabel(_ []string) ([]api.BenchmarkResource, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+}
+
+func (d *errorDataSource) ListCollections(_ ...evalhubclient.ListOption) (*api.CollectionResourceList, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+}
+
+func (d *errorDataSource) GetCollection(_ string) (*api.CollectionResource, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+}
+
+func (d *errorDataSource) ListJobs(_ ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+}
+
+func (d *errorDataSource) GetJob(_ string) (*api.EvaluationJobResource, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+}
+
+func (d *errorDataSource) ListJobsByStatus(_ api.OverallState, _ ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error) {
+	return nil, &evalhubclient.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+}
+
+// Verify errorDataSource implements EvalHubDiscovery at compile time.
+var _ EvalHubDiscovery = (*errorDataSource)(nil)
+var _ EvalHubDiscovery = (*callCountDataSource)(nil)
+
+// --- filterByPrefix unit tests ---
+
+func TestFilterByPrefix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		values []string
+		prefix string
+		want   int
+	}{
+		{"empty prefix returns all", []string{"a", "b", "c"}, "", 3},
+		{"exact match", []string{"foo", "bar"}, "foo", 1},
+		{"partial match", []string{"foo", "foobar", "baz"}, "foo", 2},
+		{"no match", []string{"foo", "bar"}, "xyz", 0},
+		{"case insensitive", []string{"FooBar", "foobar", "baz"}, "foo", 2},
+		{"nil values", nil, "foo", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterByPrefix(tt.values, tt.prefix)
+			if len(got) != tt.want {
+				t.Errorf("filterByPrefix(%v, %q) = %d results, want %d", tt.values, tt.prefix, len(got), tt.want)
+			}
+		})
+	}
+}
+
+// --- completionCache unit tests ---
+
+func TestCompletionCacheGetMiss(t *testing.T) {
+	t.Parallel()
+	c := newCompletionCache(time.Minute)
+	_, ok := c.get("nonexistent")
+	if ok {
+		t.Error("expected cache miss for nonexistent key")
+	}
+}
+
+func TestCompletionCacheGetHit(t *testing.T) {
+	t.Parallel()
+	c := newCompletionCache(time.Minute)
+	c.set("key", []string{"a", "b"})
+	vals, ok := c.get("key")
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if len(vals) != 2 {
+		t.Errorf("expected 2 values, got %d", len(vals))
+	}
+}
+
+func TestCompletionCacheExpired(t *testing.T) {
+	t.Parallel()
+	c := newCompletionCache(time.Second)
+	now := time.Now()
+	c.now = func() time.Time { return now }
+
+	c.set("key", []string{"a"})
+	_, ok := c.get("key")
+	if !ok {
+		t.Fatal("expected cache hit before expiry")
+	}
+
+	c.now = func() time.Time { return now.Add(2 * time.Second) }
+	_, ok = c.get("key")
+	if ok {
+		t.Error("expected cache miss after expiry")
+	}
+}
+
+// --- matchesTemplate ---
+
+func TestMatchesTemplate(t *testing.T) {
+	t.Parallel()
+	if !matchesTemplate("evalhub://providers/{id}", "evalhub://providers/{id}") {
+		t.Error("expected match")
+	}
+	if matchesTemplate("evalhub://providers/{id}", "evalhub://benchmarks/{id}") {
+		t.Error("expected no match")
+	}
+}
+
+// --- status completion prefix "comp" ---
+
+func TestCompleteStatusPrefixComp(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithCompletions(t, testDataSource())
+
+	result := complete(t, ctx, cs, "evalhub://jobs{?status}", "status", "comp")
+	if len(result.Completion.Values) != 1 {
+		t.Fatalf("expected 1 match for 'comp', got %d: %v", len(result.Completion.Values), result.Completion.Values)
+	}
+	if result.Completion.Values[0] != "completed" {
+		t.Errorf("expected 'completed', got %q", result.Completion.Values[0])
+	}
+}
+
+// Silence unused import warning for fmt.
+var _ = fmt.Sprint

--- a/internal/evalhub_mcp/server/resources_test.go
+++ b/internal/evalhub_mcp/server/resources_test.go
@@ -231,7 +231,7 @@ func emptyDataSource() *mockDataSource {
 func connectWithResources(t *testing.T, ds EvalHubDiscovery) (context.Context, *mcp.ClientSession) {
 	t.Helper()
 
-	srv := New(&ServerInfo{Version: "test"}, discardLogger)
+	srv := New(&ServerInfo{Version: "test"}, discardLogger, nil)
 	registerResources(srv, ds, discardLogger)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -693,7 +693,7 @@ func TestListJobsEmpty(t *testing.T) {
 func TestRegisterHandlersNilClient(t *testing.T) {
 	t.Parallel()
 	info := &ServerInfo{Version: "test"}
-	srv := New(info, discardLogger)
+	srv := New(info, discardLogger, nil)
 	RegisterHandlers(srv, nil, info, discardLogger)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -30,27 +30,34 @@ func (s *ServerInfo) VersionString() string {
 // New creates a configured MCP server with capabilities advertised for tools,
 // resources, and prompts. The returned server is ready to be connected to a
 // transport via Run, or used directly with in-memory transports for testing.
-func New(info *ServerInfo, logger *slog.Logger) *mcp.Server {
+func New(info *ServerInfo, logger *slog.Logger, opts ...ServerOption) *mcp.Server {
 	version := "unknown"
 	if info != nil {
 		version = info.VersionString()
+	}
+	serverOpts := &mcp.ServerOptions{
+		Logger: logger,
+		Capabilities: &mcp.ServerCapabilities{
+			Logging:   &mcp.LoggingCapabilities{},
+			Tools:     &mcp.ToolCapabilities{ListChanged: true},
+			Resources: &mcp.ResourceCapabilities{ListChanged: true},
+			Prompts:   &mcp.PromptCapabilities{ListChanged: true},
+		},
+	}
+	for _, o := range opts {
+		o(serverOpts)
 	}
 	return mcp.NewServer(
 		&mcp.Implementation{
 			Name:    "evalhub-mcp",
 			Version: version,
 		},
-		&mcp.ServerOptions{
-			Logger: logger,
-			Capabilities: &mcp.ServerCapabilities{
-				Logging:   &mcp.LoggingCapabilities{},
-				Tools:     &mcp.ToolCapabilities{ListChanged: true},
-				Resources: &mcp.ResourceCapabilities{ListChanged: true},
-				Prompts:   &mcp.PromptCapabilities{ListChanged: true},
-			},
-		},
+		serverOpts,
 	)
 }
+
+// ServerOption configures the MCP server options.
+type ServerOption func(*mcp.ServerOptions)
 
 // NewEvalHubClient creates an EvalHub API client from the MCP server configuration.
 // Returns nil when no BaseURL is configured.
@@ -74,7 +81,8 @@ func NewEvalHubClient(cfg *config.Config, logger *slog.Logger) *evalhubclient.Cl
 // RegisterHandlers wires tool, resource, and prompt handlers into the MCP
 // server. The server version resource is always registered. The EvalHub client
 // is captured by handler closures so that every handler has access to the API
-// without global state.
+// without global state. Returns any ServerOptions that should be applied when
+// constructing the server (e.g. completion handler).
 func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, info *ServerInfo, logger *slog.Logger) {
 	registerVersionResource(srv, info, logger)
 	if client != nil {
@@ -82,9 +90,21 @@ func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, info *Serve
 	}
 }
 
+// CompletionHandlerOption returns a ServerOption that installs a completion handler
+// backed by the given data source. If ds is nil the option is a no-op.
+func CompletionHandlerOption(ds EvalHubDiscovery, logger *slog.Logger) ServerOption {
+	return func(opts *mcp.ServerOptions) {
+		if ds == nil {
+			return
+		}
+		cp := newCompletionProvider(ds, logger)
+		opts.CompletionHandler = cp.handle
+	}
+}
+
 func Run(ctx context.Context, cfg *config.Config, info *ServerInfo, logger *slog.Logger) error {
 	client := NewEvalHubClient(cfg, logger)
-	srv := New(info, logger)
+	srv := New(info, logger, CompletionHandlerOption(client, logger))
 	RegisterHandlers(srv, client, info, logger)
 
 	version := "unknown"

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -30,7 +30,7 @@ func (s *ServerInfo) VersionString() string {
 // New creates a configured MCP server with capabilities advertised for tools,
 // resources, and prompts. The returned server is ready to be connected to a
 // transport via Run, or used directly with in-memory transports for testing.
-func New(info *ServerInfo, logger *slog.Logger, opts ...ServerOption) *mcp.Server {
+func New(info *ServerInfo, logger *slog.Logger, serverOption *ServerOption) *mcp.Server {
 	version := "unknown"
 	if info != nil {
 		version = info.VersionString()
@@ -44,8 +44,8 @@ func New(info *ServerInfo, logger *slog.Logger, opts ...ServerOption) *mcp.Serve
 			Prompts:   &mcp.PromptCapabilities{ListChanged: true},
 		},
 	}
-	for _, o := range opts {
-		o(serverOpts)
+	if serverOption != nil {
+		serverOption.apply(serverOpts)
 	}
 	return mcp.NewServer(
 		&mcp.Implementation{
@@ -57,7 +57,15 @@ func New(info *ServerInfo, logger *slog.Logger, opts ...ServerOption) *mcp.Serve
 }
 
 // ServerOption configures the MCP server options.
-type ServerOption func(*mcp.ServerOptions)
+type ServerOption struct {
+	applyFn func(*mcp.ServerOptions)
+}
+
+func (o *ServerOption) apply(opts *mcp.ServerOptions) {
+	if o.applyFn != nil {
+		o.applyFn(opts)
+	}
+}
 
 // NewEvalHubClient creates an EvalHub API client from the MCP server configuration.
 // Returns nil when no BaseURL is configured.
@@ -91,15 +99,15 @@ func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, info *Serve
 }
 
 // CompletionHandlerOption returns a ServerOption that installs a completion handler
-// backed by the given data source. If ds is nil the option is a no-op.
-func CompletionHandlerOption(ds EvalHubDiscovery, logger *slog.Logger) ServerOption {
-	return func(opts *mcp.ServerOptions) {
-		if ds == nil {
-			return
-		}
-		cp := newCompletionProvider(ds, logger)
-		opts.CompletionHandler = cp.handle
+// backed by the given data source. Returns nil when ds is nil.
+func CompletionHandlerOption(ds EvalHubDiscovery, logger *slog.Logger) *ServerOption {
+	if ds == nil {
+		return nil
 	}
+	cp := newCompletionProvider(ds, logger)
+	return &ServerOption{applyFn: func(opts *mcp.ServerOptions) {
+		opts.CompletionHandler = cp.handle
+	}}
 }
 
 func Run(ctx context.Context, cfg *config.Config, info *ServerInfo, logger *slog.Logger) error {

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -89,8 +89,7 @@ func NewEvalHubClient(cfg *config.Config, logger *slog.Logger) *evalhubclient.Cl
 // RegisterHandlers wires tool, resource, and prompt handlers into the MCP
 // server. The server version resource is always registered. The EvalHub client
 // is captured by handler closures so that every handler has access to the API
-// without global state. Returns any ServerOptions that should be applied when
-// constructing the server (e.g. completion handler).
+// without global state.
 func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, info *ServerInfo, logger *slog.Logger) {
 	registerVersionResource(srv, info, logger)
 	if client != nil {

--- a/internal/evalhub_mcp/server/server_test.go
+++ b/internal/evalhub_mcp/server/server_test.go
@@ -63,7 +63,7 @@ func TestNewEvalHubClientCreated(t *testing.T) {
 func TestInitializeHandshake(t *testing.T) {
 	t.Parallel()
 	info := &ServerInfo{Version: "0.1.0", Build: "test123"}
-	srv := New(info, discardLogger)
+	srv := New(info, discardLogger, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -87,7 +87,7 @@ func TestInitializeHandshake(t *testing.T) {
 func TestServerMetadata(t *testing.T) {
 	t.Parallel()
 	info := &ServerInfo{Version: "0.2.0", Build: "deadbeef"}
-	srv := New(info, discardLogger)
+	srv := New(info, discardLogger, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -122,7 +122,7 @@ func TestServerMetadata(t *testing.T) {
 func TestCapabilitiesAdvertised(t *testing.T) {
 	t.Parallel()
 	info := &ServerInfo{Version: "0.1.0"}
-	srv := New(info, discardLogger)
+	srv := New(info, discardLogger, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -164,7 +164,7 @@ func TestCapabilitiesAdvertised(t *testing.T) {
 func TestToolsListEmpty(t *testing.T) {
 	t.Parallel()
 	info := &ServerInfo{Version: "0.1.0"}
-	srv := New(info, discardLogger)
+	srv := New(info, discardLogger, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -196,7 +196,7 @@ func TestToolsListEmpty(t *testing.T) {
 func TestResourcesListEmpty(t *testing.T) {
 	t.Parallel()
 	info := &ServerInfo{Version: "0.1.0"}
-	srv := New(info, discardLogger)
+	srv := New(info, discardLogger, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -228,7 +228,7 @@ func TestResourcesListEmpty(t *testing.T) {
 func TestPromptsListEmpty(t *testing.T) {
 	t.Parallel()
 	info := &ServerInfo{Version: "0.1.0"}
-	srv := New(info, discardLogger)
+	srv := New(info, discardLogger, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/internal/evalhub_mcp/server/server_test.go
+++ b/internal/evalhub_mcp/server/server_test.go
@@ -14,6 +14,17 @@ import (
 
 var discardLogger = slog.New(slog.DiscardHandler)
 
+func connectServer(t *testing.T, info *ServerInfo) (context.Context, *mcp.ClientSession) {
+	t.Helper()
+
+	srv := New(info, discardLogger, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	return ctx, connectClient(t, ctx, srv)
+}
+
 // --- ServerInfo ---
 
 func TestVersionString(t *testing.T) {
@@ -62,52 +73,14 @@ func TestNewEvalHubClientCreated(t *testing.T) {
 
 func TestInitializeHandshake(t *testing.T) {
 	t.Parallel()
-	info := &ServerInfo{Version: "0.1.0", Build: "test123"}
-	srv := New(info, discardLogger, nil)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-
-	serverSession, err := srv.Connect(ctx, serverTransport, nil)
-	if err != nil {
-		t.Fatalf("server.Connect failed: %v", err)
-	}
-	defer serverSession.Close()
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
-	clientSession, err := client.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		t.Fatalf("client.Connect failed: %v", err)
-	}
-	defer clientSession.Close()
+	connectServer(t, &ServerInfo{Version: "0.1.0", Build: "test123"})
 }
 
 func TestServerMetadata(t *testing.T) {
 	t.Parallel()
-	info := &ServerInfo{Version: "0.2.0", Build: "deadbeef"}
-	srv := New(info, discardLogger, nil)
+	_, cs := connectServer(t, &ServerInfo{Version: "0.2.0", Build: "deadbeef"})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-
-	serverSession, err := srv.Connect(ctx, serverTransport, nil)
-	if err != nil {
-		t.Fatalf("server.Connect failed: %v", err)
-	}
-	defer serverSession.Close()
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
-	clientSession, err := client.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		t.Fatalf("client.Connect failed: %v", err)
-	}
-	defer clientSession.Close()
-
-	initResult := clientSession.InitializeResult()
+	initResult := cs.InitializeResult()
 	if initResult == nil {
 		t.Fatal("InitializeResult is nil")
 	}
@@ -121,28 +94,9 @@ func TestServerMetadata(t *testing.T) {
 
 func TestCapabilitiesAdvertised(t *testing.T) {
 	t.Parallel()
-	info := &ServerInfo{Version: "0.1.0"}
-	srv := New(info, discardLogger, nil)
+	_, cs := connectServer(t, &ServerInfo{Version: "0.1.0"})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-
-	serverSession, err := srv.Connect(ctx, serverTransport, nil)
-	if err != nil {
-		t.Fatalf("server.Connect failed: %v", err)
-	}
-	defer serverSession.Close()
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
-	clientSession, err := client.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		t.Fatalf("client.Connect failed: %v", err)
-	}
-	defer clientSession.Close()
-
-	initResult := clientSession.InitializeResult()
+	initResult := cs.InitializeResult()
 	if initResult == nil {
 		t.Fatal("InitializeResult is nil")
 	}
@@ -163,28 +117,9 @@ func TestCapabilitiesAdvertised(t *testing.T) {
 
 func TestToolsListEmpty(t *testing.T) {
 	t.Parallel()
-	info := &ServerInfo{Version: "0.1.0"}
-	srv := New(info, discardLogger, nil)
+	ctx, cs := connectServer(t, &ServerInfo{Version: "0.1.0"})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-
-	serverSession, err := srv.Connect(ctx, serverTransport, nil)
-	if err != nil {
-		t.Fatalf("server.Connect failed: %v", err)
-	}
-	defer serverSession.Close()
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
-	clientSession, err := client.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		t.Fatalf("client.Connect failed: %v", err)
-	}
-	defer clientSession.Close()
-
-	toolsResult, err := clientSession.ListTools(ctx, nil)
+	toolsResult, err := cs.ListTools(ctx, nil)
 	if err != nil {
 		t.Fatalf("ListTools failed: %v", err)
 	}
@@ -195,28 +130,9 @@ func TestToolsListEmpty(t *testing.T) {
 
 func TestResourcesListEmpty(t *testing.T) {
 	t.Parallel()
-	info := &ServerInfo{Version: "0.1.0"}
-	srv := New(info, discardLogger, nil)
+	ctx, cs := connectServer(t, &ServerInfo{Version: "0.1.0"})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-
-	serverSession, err := srv.Connect(ctx, serverTransport, nil)
-	if err != nil {
-		t.Fatalf("server.Connect failed: %v", err)
-	}
-	defer serverSession.Close()
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
-	clientSession, err := client.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		t.Fatalf("client.Connect failed: %v", err)
-	}
-	defer clientSession.Close()
-
-	resourcesResult, err := clientSession.ListResources(ctx, nil)
+	resourcesResult, err := cs.ListResources(ctx, nil)
 	if err != nil {
 		t.Fatalf("ListResources failed: %v", err)
 	}
@@ -227,28 +143,9 @@ func TestResourcesListEmpty(t *testing.T) {
 
 func TestPromptsListEmpty(t *testing.T) {
 	t.Parallel()
-	info := &ServerInfo{Version: "0.1.0"}
-	srv := New(info, discardLogger, nil)
+	ctx, cs := connectServer(t, &ServerInfo{Version: "0.1.0"})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-
-	serverSession, err := srv.Connect(ctx, serverTransport, nil)
-	if err != nil {
-		t.Fatalf("server.Connect failed: %v", err)
-	}
-	defer serverSession.Close()
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
-	clientSession, err := client.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		t.Fatalf("client.Connect failed: %v", err)
-	}
-	defer clientSession.Close()
-
-	promptsResult, err := clientSession.ListPrompts(ctx, nil)
+	promptsResult, err := cs.ListPrompts(ctx, nil)
 	if err != nil {
 		t.Fatalf("ListPrompts failed: %v", err)
 	}

--- a/internal/evalhub_mcp/server/version_resource_test.go
+++ b/internal/evalhub_mcp/server/version_resource_test.go
@@ -35,7 +35,7 @@ func connectClient(t *testing.T, ctx context.Context, srv *mcp.Server) *mcp.Clie
 func connectWithVersion(t *testing.T, info *ServerInfo) (context.Context, *mcp.ClientSession) {
 	t.Helper()
 
-	srv := New(info, discardLogger)
+	srv := New(info, discardLogger, nil)
 	registerVersionResource(srv, info, discardLogger)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -127,7 +127,7 @@ func TestVersionResourceAvailableWithoutBackend(t *testing.T) {
 	t.Parallel()
 
 	info := &ServerInfo{Version: "0.1.0"}
-	srv := New(info, discardLogger)
+	srv := New(info, discardLogger, nil)
 	RegisterHandlers(srv, nil, info, discardLogger)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -190,7 +190,7 @@ func TestVersionResourceInResourcesList(t *testing.T) {
 func TestVersionResourceNilInfo(t *testing.T) {
 	t.Parallel()
 
-	srv := New(nil, discardLogger)
+	srv := New(nil, discardLogger, nil)
 	registerVersionResource(srv, nil, discardLogger)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
## Summary

Implements MCP `completion/complete` handler for all parameterized resource URIs so MCP clients (Claude Code, VS Code) can offer intelligent suggestions as users type.

**JIRA:** [RHOAIENG-60348](https://redhat.atlassian.net/browse/RHOAIENG-60348)

### Changes

- **`completions.go`** — New completion provider with:
  - Provider, benchmark, collection, job ID completion from live eval-hub API
  - Status completion from static enum values (no API call needed)
  - Label/tag completion aggregated from all benchmarks
  - TTL-based in-memory cache (30s default) to avoid excessive API calls during rapid typing
  - Case-insensitive prefix matching
  - Graceful degradation: API errors return empty suggestions (no client-visible errors)

- **`server.go`** — Extended `New()` with variadic `ServerOption` pattern to wire the `CompletionHandler` into `mcp.ServerOptions`. Added `CompletionHandlerOption()` factory. Updated `Run()` to install completion handler when an API client is available.

- **`completions_test.go`** — 28 comprehensive unit tests covering:
  - Each completion type (provider, benchmark, collection, job IDs) returns correct values
  - Partial input filters results by prefix
  - Caching: second request within TTL does NOT trigger additional API call
  - Caching: request after TTL expiry triggers fresh API call
  - Empty input returns full list of suggestions
  - Status completion returns static list without API call
  - Label completion returns available labels from benchmarks
  - API error during completion returns empty list (graceful degradation)
  - Case-insensitive matching
  - Unknown template returns empty result

## Test plan

- [x] All 28 new completion tests pass
- [x] All 45 existing MCP server tests pass (no regressions)
- [x] `go vet` passes
- [ ] Integration test with live eval-hub backend
- [ ] Manual testing with Claude Code MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)