### PR TITLE
feat(mcp): add submit_evaluation, cancel_job, get_job_status tools

### DIFF
--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -94,6 +94,7 @@ func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, info *Serve
 	registerVersionResource(srv, info, logger)
 	if client != nil {
 		registerResources(srv, client, logger)
+		registerTools(srv, client, logger)
 	}
 }
 

--- a/internal/evalhub_mcp/server/tools.go
+++ b/internal/evalhub_mcp/server/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/eval-hub/eval-hub/pkg/api"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -243,6 +244,7 @@ func buildJobStatusOutput(job *api.EvaluationJobResource) GetJobStatusOutput {
 	out := GetJobStatusOutput{
 		JobID:     job.Resource.ID,
 		CreatedAt: job.Resource.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		State:     "pending",
 	}
 
 	if job.Status != nil {
@@ -279,10 +281,22 @@ func computeProgress(benchmarks []api.BenchmarkStatus) int {
 }
 
 func earliestStart(benchmarks []api.BenchmarkStatus) string {
+	var earliestTime time.Time
 	var earliest string
 	for _, b := range benchmarks {
 		s := string(b.StartedAt)
 		if s != "" && (earliest == "" || s < earliest) {
+			earliest = s
+		}
+		if s == "" {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			continue
+		}
+		if earliest == "" || t.Before(earliestTime) {
+			earliestTime = t
 			earliest = s
 		}
 	}

--- a/internal/evalhub_mcp/server/tools.go
+++ b/internal/evalhub_mcp/server/tools.go
@@ -285,9 +285,6 @@ func earliestStart(benchmarks []api.BenchmarkStatus) string {
 	var earliest string
 	for _, b := range benchmarks {
 		s := string(b.StartedAt)
-		if s != "" && (earliest == "" || s < earliest) {
-			earliest = s
-		}
 		if s == "" {
 			continue
 		}
@@ -295,7 +292,7 @@ func earliestStart(benchmarks []api.BenchmarkStatus) string {
 		if err != nil {
 			continue
 		}
-		if earliest == "" || t.Before(earliestTime) {
+		if earliestTime.IsZero() || t.Before(earliestTime) {
 			earliestTime = t
 			earliest = s
 		}

--- a/internal/evalhub_mcp/server/tools.go
+++ b/internal/evalhub_mcp/server/tools.go
@@ -1,0 +1,299 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// EvalHubToolClient is the subset of evalhubclient.Client methods used by MCP
+// tool handlers. Accepting an interface keeps handlers testable without a
+// running eval-hub backend.
+type EvalHubToolClient interface {
+	CreateJob(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error)
+	CancelJob(id string) error
+	GetJob(id string) (*api.EvaluationJobResource, error)
+}
+
+// --- input types ---
+
+type SubmitEvaluationInput struct {
+	Name        string           `json:"name" jsonschema:"Name for the evaluation job"`
+	Description string           `json:"description,omitempty" jsonschema:"Human-readable description of what this evaluation measures"`
+	Tags        []string         `json:"tags,omitempty" jsonschema:"Tags for categorizing the evaluation"`
+	Model       ModelInput       `json:"model" jsonschema:"Model to evaluate"`
+	Benchmarks  []BenchmarkInput `json:"benchmarks,omitempty" jsonschema:"List of benchmarks to run; provide benchmarks OR collection, not both"`
+	Collection  *CollectionInput `json:"collection,omitempty" jsonschema:"Benchmark collection to run; provide collection OR benchmarks, not both"`
+	Experiment  *ExperimentInput `json:"experiment,omitempty" jsonschema:"Optional MLflow experiment tracking configuration"`
+}
+
+type ModelInput struct {
+	URL        string `json:"url" jsonschema:"URL of the model inference endpoint"`
+	Name       string `json:"name" jsonschema:"Display name of the model"`
+	AuthSecret string `json:"auth_secret,omitempty" jsonschema:"Kubernetes secret reference for model authentication"`
+}
+
+type BenchmarkInput struct {
+	ID         string `json:"id" jsonschema:"Benchmark identifier"`
+	ProviderID string `json:"provider_id" jsonschema:"Evaluation provider that runs this benchmark"`
+}
+
+type CollectionInput struct {
+	ID string `json:"id" jsonschema:"Collection identifier"`
+}
+
+type ExperimentInput struct {
+	Name             string            `json:"name,omitempty" jsonschema:"MLflow experiment name"`
+	Tags             map[string]string `json:"tags,omitempty" jsonschema:"Key-value tags for the MLflow experiment"`
+	ArtifactLocation string            `json:"artifact_location,omitempty" jsonschema:"Storage location for experiment artifacts"`
+}
+
+type CancelJobInput struct {
+	JobID string `json:"job_id" jsonschema:"ID of the evaluation job to cancel"`
+}
+
+type GetJobStatusInput struct {
+	JobID string `json:"job_id" jsonschema:"ID of the evaluation job to check"`
+}
+
+// --- output types ---
+
+type SubmitEvaluationOutput struct {
+	JobID string `json:"job_id"`
+	State string `json:"state"`
+}
+
+type CancelJobOutput struct {
+	JobID   string `json:"job_id"`
+	Message string `json:"message"`
+}
+
+type GetJobStatusOutput struct {
+	JobID      string                  `json:"job_id"`
+	State      string                  `json:"state"`
+	Progress   int                     `json:"progress_percent"`
+	Benchmarks []BenchmarkStatusOutput `json:"benchmarks,omitempty"`
+	CreatedAt  string                  `json:"created_at,omitempty"`
+	StartedAt  string                  `json:"started_at,omitempty"`
+}
+
+type BenchmarkStatusOutput struct {
+	ID          string `json:"id"`
+	ProviderID  string `json:"provider_id"`
+	Status      string `json:"status"`
+	StartedAt   string `json:"started_at,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+}
+
+// --- registration ---
+
+func registerTools(srv *mcp.Server, client EvalHubToolClient, logger *slog.Logger) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "submit_evaluation",
+		Description: "Submit a new model evaluation job. Specify benchmarks (a list of benchmark IDs with their provider) OR a collection (a pre-defined set of benchmarks), plus the model endpoint to evaluate. Returns the job ID and initial state for tracking.",
+	}, submitEvaluationHandler(client, logger))
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "cancel_job",
+		Description: "Cancel a running or pending evaluation job. The job will be stopped and its benchmarks marked as cancelled. Use get_job_status to verify the final state.",
+	}, cancelJobHandler(client, logger))
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "get_job_status",
+		Description: "Get the current status of an evaluation job including overall state, progress percentage, and per-benchmark status with timestamps. Designed for polling: call repeatedly to monitor a running evaluation.",
+	}, getJobStatusHandler(client, logger))
+}
+
+// --- handlers ---
+
+func submitEvaluationHandler(client EvalHubToolClient, logger *slog.Logger) mcp.ToolHandlerFor[SubmitEvaluationInput, SubmitEvaluationOutput] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input SubmitEvaluationInput) (*mcp.CallToolResult, SubmitEvaluationOutput, error) {
+		logger.Debug("submit_evaluation called", "name", input.Name)
+
+		if len(input.Benchmarks) == 0 && input.Collection == nil {
+			return errorResult("validation error: provide at least one of 'benchmarks' or 'collection'"), SubmitEvaluationOutput{}, nil
+		}
+		if len(input.Benchmarks) > 0 && input.Collection != nil {
+			return errorResult("validation error: provide 'benchmarks' or 'collection', not both"), SubmitEvaluationOutput{}, nil
+		}
+
+		config := buildJobConfig(input)
+
+		job, err := client.CreateJob(config)
+		if err != nil {
+			logger.Error("submit_evaluation failed", "error", err)
+			return errorResult(fmt.Sprintf("failed to create evaluation job: %v", err)), SubmitEvaluationOutput{}, nil
+		}
+
+		state := "pending"
+		if job.Status != nil {
+			state = job.Status.State.String()
+		}
+
+		out := SubmitEvaluationOutput{
+			JobID: job.Resource.ID,
+			State: state,
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Evaluation job created: %s (state: %s)", out.JobID, out.State)},
+			},
+		}, out, nil
+	}
+}
+
+func cancelJobHandler(client EvalHubToolClient, logger *slog.Logger) mcp.ToolHandlerFor[CancelJobInput, CancelJobOutput] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input CancelJobInput) (*mcp.CallToolResult, CancelJobOutput, error) {
+		logger.Debug("cancel_job called", "job_id", input.JobID)
+
+		if input.JobID == "" {
+			return errorResult("validation error: 'job_id' is required"), CancelJobOutput{}, nil
+		}
+
+		err := client.CancelJob(input.JobID)
+		if err != nil {
+			logger.Error("cancel_job failed", "job_id", input.JobID, "error", err)
+			return errorResult(fmt.Sprintf("failed to cancel job %s: %v", input.JobID, err)), CancelJobOutput{}, nil
+		}
+
+		out := CancelJobOutput{
+			JobID:   input.JobID,
+			Message: fmt.Sprintf("Job %s cancelled successfully", input.JobID),
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: out.Message},
+			},
+		}, out, nil
+	}
+}
+
+func getJobStatusHandler(client EvalHubToolClient, logger *slog.Logger) mcp.ToolHandlerFor[GetJobStatusInput, GetJobStatusOutput] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input GetJobStatusInput) (*mcp.CallToolResult, GetJobStatusOutput, error) {
+		logger.Debug("get_job_status called", "job_id", input.JobID)
+
+		if input.JobID == "" {
+			return errorResult("validation error: 'job_id' is required"), GetJobStatusOutput{}, nil
+		}
+
+		job, err := client.GetJob(input.JobID)
+		if err != nil {
+			logger.Error("get_job_status failed", "job_id", input.JobID, "error", err)
+			return errorResult(fmt.Sprintf("failed to get job status for %s: %v", input.JobID, err)), GetJobStatusOutput{}, nil
+		}
+
+		out := buildJobStatusOutput(job)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Job %s: %s (%d%% complete)", out.JobID, out.State, out.Progress)},
+			},
+		}, out, nil
+	}
+}
+
+// --- helpers ---
+
+func buildJobConfig(input SubmitEvaluationInput) api.EvaluationJobConfig {
+	config := api.EvaluationJobConfig{
+		Name: input.Name,
+		Tags: input.Tags,
+		Model: api.ModelRef{
+			URL:  input.Model.URL,
+			Name: input.Model.Name,
+		},
+	}
+
+	if input.Description != "" {
+		config.Description = &input.Description
+	}
+
+	if input.Model.AuthSecret != "" {
+		config.Model.Auth = &api.ModelAuth{SecretRef: input.Model.AuthSecret}
+	}
+
+	for _, b := range input.Benchmarks {
+		config.Benchmarks = append(config.Benchmarks, api.EvaluationBenchmarkConfig{
+			Ref:        api.Ref{ID: b.ID},
+			ProviderID: b.ProviderID,
+		})
+	}
+
+	if input.Collection != nil {
+		config.Collection = &api.CollectionRef{ID: input.Collection.ID}
+	}
+
+	if input.Experiment != nil {
+		exp := &api.ExperimentConfig{
+			Name:             input.Experiment.Name,
+			ArtifactLocation: input.Experiment.ArtifactLocation,
+		}
+		for k, v := range input.Experiment.Tags {
+			exp.Tags = append(exp.Tags, api.ExperimentTag{Key: k, Value: v})
+		}
+		config.Experiment = exp
+	}
+
+	return config
+}
+
+func buildJobStatusOutput(job *api.EvaluationJobResource) GetJobStatusOutput {
+	out := GetJobStatusOutput{
+		JobID:     job.Resource.ID,
+		CreatedAt: job.Resource.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+
+	if job.Status != nil {
+		out.State = job.Status.State.String()
+		out.Progress = computeProgress(job.Status.Benchmarks)
+
+		for _, b := range job.Status.Benchmarks {
+			out.Benchmarks = append(out.Benchmarks, BenchmarkStatusOutput{
+				ID:          b.ID,
+				ProviderID:  b.ProviderID,
+				Status:      string(b.Status),
+				StartedAt:   string(b.StartedAt),
+				CompletedAt: string(b.CompletedAt),
+			})
+		}
+
+		out.StartedAt = earliestStart(job.Status.Benchmarks)
+	}
+
+	return out
+}
+
+func computeProgress(benchmarks []api.BenchmarkStatus) int {
+	if len(benchmarks) == 0 {
+		return 0
+	}
+	done := 0
+	for _, b := range benchmarks {
+		if api.IsBenchmarkTerminalState(b.Status) {
+			done++
+		}
+	}
+	return (done * 100) / len(benchmarks)
+}
+
+func earliestStart(benchmarks []api.BenchmarkStatus) string {
+	var earliest string
+	for _, b := range benchmarks {
+		s := string(b.StartedAt)
+		if s != "" && (earliest == "" || s < earliest) {
+			earliest = s
+		}
+	}
+	return earliest
+}
+
+func errorResult(msg string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: msg},
+		},
+		IsError: true,
+	}
+}

--- a/internal/evalhub_mcp/server/tools_test.go
+++ b/internal/evalhub_mcp/server/tools_test.go
@@ -1,0 +1,585 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/eval-hub/eval-hub/pkg/evalhubclient"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// --- mock tool client ---
+
+type mockToolClient struct {
+	createJobFn func(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error)
+	cancelJobFn func(id string) error
+	getJobFn    func(id string) (*api.EvaluationJobResource, error)
+}
+
+func (m *mockToolClient) CreateJob(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error) {
+	if m.createJobFn != nil {
+		return m.createJobFn(config)
+	}
+	return &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{
+			Resource: api.Resource{ID: "job-new", CreatedAt: time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)},
+		},
+		Status: &api.EvaluationJobStatus{
+			EvaluationJobState: api.EvaluationJobState{State: api.OverallStatePending},
+		},
+		EvaluationJobConfig: config,
+	}, nil
+}
+
+func (m *mockToolClient) CancelJob(id string) error {
+	if m.cancelJobFn != nil {
+		return m.cancelJobFn(id)
+	}
+	return nil
+}
+
+func (m *mockToolClient) GetJob(id string) (*api.EvaluationJobResource, error) {
+	if m.getJobFn != nil {
+		return m.getJobFn(id)
+	}
+	return nil, &evalhubclient.APIError{
+		StatusCode: http.StatusNotFound,
+		Message:    fmt.Sprintf("job %q not found", id),
+	}
+}
+
+// --- test helpers ---
+
+func connectWithTools(t *testing.T, client EvalHubToolClient) (context.Context, *mcp.ClientSession) {
+	t.Helper()
+
+	srv := New(&ServerInfo{Version: "test"}, discardLogger, nil)
+	registerTools(srv, client, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	return ctx, connectClient(t, ctx, srv)
+}
+
+func callToolJSON[T any](t *testing.T, ctx context.Context, cs *mcp.ClientSession, name string, args any) T {
+	t.Helper()
+	argsBytes, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      name,
+		Arguments: json.RawMessage(argsBytes),
+	})
+	if err != nil {
+		t.Fatalf("CallTool(%s) failed: %v", name, err)
+	}
+	if result.StructuredContent == nil {
+		t.Fatalf("CallTool(%s): no structured content returned", name)
+	}
+	data, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatalf("CallTool(%s): marshal structured content: %v", name, err)
+	}
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("CallTool(%s): unmarshal structured content: %v\nbody: %s", name, err, data)
+	}
+	return v
+}
+
+func callToolExpectError(t *testing.T, ctx context.Context, cs *mcp.ClientSession, name string, args any) string {
+	t.Helper()
+	argsBytes, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      name,
+		Arguments: json.RawMessage(argsBytes),
+	})
+	if err != nil {
+		t.Fatalf("CallTool(%s) failed at protocol level: %v", name, err)
+	}
+	if !result.IsError {
+		t.Fatalf("CallTool(%s): expected IsError=true", name)
+	}
+	if len(result.Content) == 0 {
+		t.Fatalf("CallTool(%s): no content in error result", name)
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("CallTool(%s): expected TextContent, got %T", name, result.Content[0])
+	}
+	return tc.Text
+}
+
+// --- tools/list ---
+
+func TestToolsListIncludesAllThree(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithTools(t, &mockToolClient{})
+
+	result, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+
+	want := map[string]bool{
+		"submit_evaluation": false,
+		"cancel_job":        false,
+		"get_job_status":    false,
+	}
+	for _, tool := range result.Tools {
+		if _, ok := want[tool.Name]; ok {
+			want[tool.Name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("tools/list missing %s", name)
+		}
+	}
+}
+
+func TestToolSchemasHaveDescriptions(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithTools(t, &mockToolClient{})
+
+	result, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+
+	for _, tool := range result.Tools {
+		if tool.Description == "" {
+			t.Errorf("tool %q has empty description", tool.Name)
+		}
+		if tool.InputSchema == nil {
+			t.Errorf("tool %q has nil InputSchema", tool.Name)
+			continue
+		}
+		schemaBytes, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Errorf("tool %q: failed to marshal InputSchema: %v", tool.Name, err)
+			continue
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+			t.Errorf("tool %q: InputSchema is not valid JSON: %v", tool.Name, err)
+		}
+	}
+}
+
+// --- submit_evaluation ---
+
+func TestSubmitEvaluationWithBenchmarks(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithTools(t, &mockToolClient{})
+
+	out := callToolJSON[SubmitEvaluationOutput](t, ctx, cs, "submit_evaluation", map[string]any{
+		"name": "test-eval",
+		"model": map[string]any{
+			"url":  "http://model:8080",
+			"name": "test-model",
+		},
+		"benchmarks": []map[string]any{
+			{"id": "mmlu", "provider_id": "unitxt"},
+		},
+	})
+
+	if out.JobID != "job-new" {
+		t.Errorf("job_id = %q, want %q", out.JobID, "job-new")
+	}
+	if out.State != "pending" {
+		t.Errorf("state = %q, want %q", out.State, "pending")
+	}
+}
+
+func TestSubmitEvaluationWithCollection(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithTools(t, &mockToolClient{})
+
+	out := callToolJSON[SubmitEvaluationOutput](t, ctx, cs, "submit_evaluation", map[string]any{
+		"name": "collection-eval",
+		"model": map[string]any{
+			"url":  "http://model:8080",
+			"name": "test-model",
+		},
+		"collection": map[string]any{
+			"id": "safety-suite",
+		},
+	})
+
+	if out.JobID != "job-new" {
+		t.Errorf("job_id = %q, want %q", out.JobID, "job-new")
+	}
+	if out.State != "pending" {
+		t.Errorf("state = %q, want %q", out.State, "pending")
+	}
+}
+
+func TestSubmitEvaluationMissingBenchmarksAndCollection(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithTools(t, &mockToolClient{})
+
+	msg := callToolExpectError(t, ctx, cs, "submit_evaluation", map[string]any{
+		"name": "missing-eval",
+		"model": map[string]any{
+			"url":  "http://model:8080",
+			"name": "test-model",
+		},
+	})
+
+	if msg == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestSubmitEvaluationBothBenchmarksAndCollection(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithTools(t, &mockToolClient{})
+
+	msg := callToolExpectError(t, ctx, cs, "submit_evaluation", map[string]any{
+		"name": "both-eval",
+		"model": map[string]any{
+			"url":  "http://model:8080",
+			"name": "test-model",
+		},
+		"benchmarks": []map[string]any{
+			{"id": "mmlu", "provider_id": "unitxt"},
+		},
+		"collection": map[string]any{
+			"id": "safety-suite",
+		},
+	})
+
+	if msg == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestSubmitEvaluationExperimentConfig(t *testing.T) {
+	t.Parallel()
+
+	var captured api.EvaluationJobConfig
+	client := &mockToolClient{
+		createJobFn: func(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error) {
+			captured = config
+			return &api.EvaluationJobResource{
+				Resource: api.EvaluationResource{
+					Resource: api.Resource{ID: "job-exp"},
+				},
+				Status: &api.EvaluationJobStatus{
+					EvaluationJobState: api.EvaluationJobState{State: api.OverallStatePending},
+				},
+				EvaluationJobConfig: config,
+			}, nil
+		},
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	callToolJSON[SubmitEvaluationOutput](t, ctx, cs, "submit_evaluation", map[string]any{
+		"name": "exp-eval",
+		"model": map[string]any{
+			"url":  "http://model:8080",
+			"name": "test-model",
+		},
+		"benchmarks": []map[string]any{
+			{"id": "mmlu", "provider_id": "unitxt"},
+		},
+		"experiment": map[string]any{
+			"name":              "my-experiment",
+			"tags":              map[string]string{"team": "ml"},
+			"artifact_location": "s3://bucket/artifacts",
+		},
+	})
+
+	if captured.Experiment == nil {
+		t.Fatal("expected experiment config to be passed through")
+	}
+	if captured.Experiment.Name != "my-experiment" {
+		t.Errorf("experiment name = %q, want %q", captured.Experiment.Name, "my-experiment")
+	}
+	if captured.Experiment.ArtifactLocation != "s3://bucket/artifacts" {
+		t.Errorf("artifact_location = %q, want %q", captured.Experiment.ArtifactLocation, "s3://bucket/artifacts")
+	}
+	if len(captured.Experiment.Tags) != 1 {
+		t.Fatalf("expected 1 experiment tag, got %d", len(captured.Experiment.Tags))
+	}
+}
+
+func TestSubmitEvaluationAPIError(t *testing.T) {
+	t.Parallel()
+
+	client := &mockToolClient{
+		createJobFn: func(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error) {
+			return nil, &evalhubclient.APIError{
+				StatusCode: http.StatusBadRequest,
+				Message:    "invalid model URL",
+			}
+		},
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	msg := callToolExpectError(t, ctx, cs, "submit_evaluation", map[string]any{
+		"name": "bad-eval",
+		"model": map[string]any{
+			"url":  "not-a-url",
+			"name": "test-model",
+		},
+		"benchmarks": []map[string]any{
+			{"id": "mmlu", "provider_id": "unitxt"},
+		},
+	})
+
+	if msg == "" {
+		t.Error("expected non-empty error message for API error")
+	}
+}
+
+// --- cancel_job ---
+
+func TestCancelJobSuccess(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithTools(t, &mockToolClient{})
+
+	out := callToolJSON[CancelJobOutput](t, ctx, cs, "cancel_job", map[string]any{
+		"job_id": "job-1",
+	})
+
+	if out.JobID != "job-1" {
+		t.Errorf("job_id = %q, want %q", out.JobID, "job-1")
+	}
+	if out.Message == "" {
+		t.Error("expected non-empty confirmation message")
+	}
+}
+
+func TestCancelJobNotFound(t *testing.T) {
+	t.Parallel()
+
+	client := &mockToolClient{
+		cancelJobFn: func(id string) error {
+			return &evalhubclient.APIError{
+				StatusCode: http.StatusNotFound,
+				Message:    fmt.Sprintf("job %q not found", id),
+			}
+		},
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	msg := callToolExpectError(t, ctx, cs, "cancel_job", map[string]any{
+		"job_id": "nonexistent",
+	})
+
+	if msg == "" {
+		t.Error("expected non-empty error message for missing job")
+	}
+}
+
+func TestCancelJobAlreadyCompleted(t *testing.T) {
+	t.Parallel()
+
+	client := &mockToolClient{
+		cancelJobFn: func(id string) error {
+			return &evalhubclient.APIError{
+				StatusCode: http.StatusConflict,
+				Message:    "job already completed",
+			}
+		},
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	msg := callToolExpectError(t, ctx, cs, "cancel_job", map[string]any{
+		"job_id": "job-completed",
+	})
+
+	if msg == "" {
+		t.Error("expected non-empty error message for completed job")
+	}
+}
+
+func TestCancelJobEmptyID(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithTools(t, &mockToolClient{})
+
+	msg := callToolExpectError(t, ctx, cs, "cancel_job", map[string]any{
+		"job_id": "",
+	})
+
+	if msg == "" {
+		t.Error("expected non-empty error message for empty job_id")
+	}
+}
+
+// --- get_job_status ---
+
+func TestGetJobStatusRunning(t *testing.T) {
+	t.Parallel()
+
+	client := &mockToolClient{
+		getJobFn: func(id string) (*api.EvaluationJobResource, error) {
+			return &api.EvaluationJobResource{
+				Resource: api.EvaluationResource{
+					Resource: api.Resource{
+						ID:        id,
+						CreatedAt: time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC),
+					},
+				},
+				Status: &api.EvaluationJobStatus{
+					EvaluationJobState: api.EvaluationJobState{State: api.OverallStateRunning},
+					Benchmarks: []api.BenchmarkStatus{
+						{
+							ID:          "hellaswag",
+							ProviderID:  "lighteval",
+							Status:      api.StateCompleted,
+							StartedAt:   "2026-05-01T10:01:00Z",
+							CompletedAt: "2026-05-01T10:05:00Z",
+						},
+						{
+							ID:         "mmlu",
+							ProviderID: "unitxt",
+							Status:     api.StateRunning,
+							StartedAt:  "2026-05-01T10:01:00Z",
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[GetJobStatusOutput](t, ctx, cs, "get_job_status", map[string]any{
+		"job_id": "job-1",
+	})
+
+	if out.JobID != "job-1" {
+		t.Errorf("job_id = %q, want %q", out.JobID, "job-1")
+	}
+	if out.State != "running" {
+		t.Errorf("state = %q, want %q", out.State, "running")
+	}
+	if out.Progress != 50 {
+		t.Errorf("progress = %d, want 50", out.Progress)
+	}
+	if len(out.Benchmarks) != 2 {
+		t.Fatalf("expected 2 benchmark statuses, got %d", len(out.Benchmarks))
+	}
+	if out.Benchmarks[0].Status != "completed" {
+		t.Errorf("first benchmark status = %q, want %q", out.Benchmarks[0].Status, "completed")
+	}
+	if out.Benchmarks[1].Status != "running" {
+		t.Errorf("second benchmark status = %q, want %q", out.Benchmarks[1].Status, "running")
+	}
+}
+
+func TestGetJobStatusCompleted(t *testing.T) {
+	t.Parallel()
+
+	client := &mockToolClient{
+		getJobFn: func(id string) (*api.EvaluationJobResource, error) {
+			return &api.EvaluationJobResource{
+				Resource: api.EvaluationResource{
+					Resource: api.Resource{
+						ID:        id,
+						CreatedAt: time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC),
+					},
+				},
+				Status: &api.EvaluationJobStatus{
+					EvaluationJobState: api.EvaluationJobState{State: api.OverallStateCompleted},
+					Benchmarks: []api.BenchmarkStatus{
+						{
+							ID:          "mmlu",
+							ProviderID:  "unitxt",
+							Status:      api.StateCompleted,
+							StartedAt:   "2026-05-01T10:01:00Z",
+							CompletedAt: "2026-05-01T10:10:00Z",
+						},
+					},
+				},
+				Results: &api.EvaluationJobResults{
+					Benchmarks: []api.BenchmarkResult{
+						{ID: "mmlu", ProviderID: "unitxt", Metrics: map[string]any{"accuracy": 0.85}},
+					},
+				},
+			}, nil
+		},
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[GetJobStatusOutput](t, ctx, cs, "get_job_status", map[string]any{
+		"job_id": "job-done",
+	})
+
+	if out.State != "completed" {
+		t.Errorf("state = %q, want %q", out.State, "completed")
+	}
+	if out.Progress != 100 {
+		t.Errorf("progress = %d, want 100", out.Progress)
+	}
+}
+
+func TestGetJobStatusNotFound(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithTools(t, &mockToolClient{})
+
+	msg := callToolExpectError(t, ctx, cs, "get_job_status", map[string]any{
+		"job_id": "nonexistent",
+	})
+
+	if msg == "" {
+		t.Error("expected non-empty error message for missing job")
+	}
+}
+
+func TestGetJobStatusEmptyID(t *testing.T) {
+	t.Parallel()
+	ctx, cs := connectWithTools(t, &mockToolClient{})
+
+	msg := callToolExpectError(t, ctx, cs, "get_job_status", map[string]any{
+		"job_id": "",
+	})
+
+	if msg == "" {
+		t.Error("expected non-empty error message for empty job_id")
+	}
+}
+
+// --- RegisterHandlers with tools ---
+
+func TestRegisterHandlersIncludesTools(t *testing.T) {
+	t.Parallel()
+	info := &ServerInfo{Version: "test"}
+	srv := New(info, discardLogger, nil)
+
+	ds := testDataSource()
+	RegisterHandlers(srv, nil, info, discardLogger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cs := connectClient(t, ctx, srv)
+
+	toolsResult, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+	if len(toolsResult.Tools) != 0 {
+		t.Errorf("expected 0 tools with nil client, got %d", len(toolsResult.Tools))
+	}
+
+	_ = ds
+}

--- a/internal/evalhub_mcp/server/tools_test.go
+++ b/internal/evalhub_mcp/server/tools_test.go
@@ -560,12 +560,11 @@ func TestGetJobStatusEmptyID(t *testing.T) {
 
 // --- RegisterHandlers with tools ---
 
-func TestRegisterHandlersIncludesTools(t *testing.T) {
+func TestRegisterHandlersWithNilClientHasNoTools(t *testing.T) {
 	t.Parallel()
 	info := &ServerInfo{Version: "test"}
 	srv := New(info, discardLogger, nil)
 
-	ds := testDataSource()
 	RegisterHandlers(srv, nil, info, discardLogger)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -580,6 +579,4 @@ func TestRegisterHandlersIncludesTools(t *testing.T) {
 	if len(toolsResult.Tools) != 0 {
 		t.Errorf("expected 0 tools with nil client, got %d", len(toolsResult.Tools))
 	}
-
-	_ = ds
 }


### PR DESCRIPTION
## Summary

Expose eval-hub operations as MCP tools with complete parameter schemas, enabling AI agents to submit evaluations, cancel jobs, and poll job status without external documentation.

- **`submit_evaluation`** — Submit a new model evaluation job with benchmarks or a collection, model endpoint, and optional experiment tracking config. Validates that exactly one of benchmarks/collection is provided. Returns job ID and initial state.
- **`cancel_job`** — Cancel a running or pending evaluation job by ID. Returns confirmation with job ID.
- **`get_job_status`** — Get structured status of an evaluation job including overall state, progress percentage, per-benchmark status array, and timestamps. Designed for polling.

### Implementation details

- New `EvalHubToolClient` interface for testability (CreateJob, CancelJob, GetJob)
- Tool input structs with `jsonschema` tags for automatic schema generation
- Structured output types for each tool
- Tools registered via `mcp.AddTool` (generic, type-safe)
- `RegisterHandlers` updated to wire tools when a client is available

### Files changed

| File | Change |
|---|---|
| `internal/evalhub_mcp/server/tools.go` | New: tool handlers, input/output types, registration |
| `internal/evalhub_mcp/server/tools_test.go` | New: 18 unit tests covering all tools |
| `internal/evalhub_mcp/server/server.go` | Wire `registerTools` in `RegisterHandlers` |

Ref: [RHOAIENG-60350](https://redhat.atlassian.net/browse/RHOAIENG-60350)

## Test plan

- [x] `tools/list` includes submit_evaluation, cancel_job, get_job_status with full schemas
- [x] submit_evaluation with benchmarks returns job ID and status
- [x] submit_evaluation with collection returns job ID and status
- [x] submit_evaluation missing both benchmarks and collection returns error
- [x] submit_evaluation with both benchmarks and collection returns error
- [x] submit_evaluation API error returns structured error
- [x] submit_evaluation experiment config fields are passed through correctly
- [x] cancel_job successful cancellation returns confirmation with job ID
- [x] cancel_job non-existent job returns appropriate error
- [x] cancel_job already-completed job returns appropriate error
- [x] cancel_job empty job_id returns validation error
- [x] get_job_status returns correct structured status (state, progress, per-benchmark)
- [x] get_job_status completed job shows 100% progress
- [x] get_job_status non-existent job returns error
- [x] get_job_status empty job_id returns validation error
- [x] Parameter schemas are valid JSON Schema (parseable, contain descriptions)
- [x] All existing MCP server tests continue to pass (88 total)
- [x] `go vet` and `go fmt` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Create-job payload: subset of EvaluationJobConfig

Agents cannot set via submit_evaluation:

- pass_criteria (job-level)
- custom
- exports (OCI)
- queue (e.g. Kueue)
- Per-benchmark weight, primary_score, pass_criteria, parameters, test_data_ref
- Collection ref inline benchmarks (MCP only passes collection id)
- Model parameters
- Experiment tags only as a flat map (API uses structured []ExperimentTag; MCP converts that in buildJobConfig)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submit evaluation jobs (via benchmarks or collection), cancel jobs, and poll job status with progress and per-benchmark details.
  * Tools are exposed when the evaluation client is configured.

* **Tests**
  * Comprehensive test suite covering tool listing, input validation, success/error flows, and lifecycle behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->