### PR TITLE
feat(handlers): enhance JSON response logging

### DIFF
--- a/internal/eval_hub/handlers/collections.go
+++ b/internal/eval_hub/handlers/collections.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -91,6 +92,9 @@ func (h *Handlers) HandleListCollections(ctx *executioncontext.ExecutionContext,
 		return
 	}
 
+	var count int
+	var totalCount int
+
 	_ = h.withSpan(
 		ctx,
 		func(runtimeCtx context.Context) error {
@@ -111,11 +115,15 @@ func (h *Handlers) HandleListCollections(ctx *executioncontext.ExecutionContext,
 				Items: collections.Items,
 			}
 
-			w.WriteJSON(result, 200)
+			count = len(collections.Items)
+			totalCount = collections.TotalCount
+			w.WriteJSON(result, 200, "count", strconv.Itoa(count), "total_count", strconv.Itoa(totalCount))
 			return nil
 		},
 		"storage",
 		"list-collections",
+		"count", strconv.Itoa(count),
+		"total_count", strconv.Itoa(totalCount),
 	)
 }
 

--- a/internal/eval_hub/handlers/evaluations.go
+++ b/internal/eval_hub/handlers/evaluations.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -357,6 +358,9 @@ func (h *Handlers) HandleListEvaluations(ctx *executioncontext.ExecutionContext,
 		return
 	}
 
+	var count int
+	var totalCount int
+
 	_ = h.withSpan(
 		ctx,
 		func(runtimeCtx context.Context) error {
@@ -375,11 +379,15 @@ func (h *Handlers) HandleListEvaluations(ctx *executioncontext.ExecutionContext,
 				Items:  res.Items,
 				Errors: res.Errors,
 			}
-			w.WriteJSON(result, 200)
+			count = len(res.Items)
+			totalCount = res.TotalCount
+			w.WriteJSON(result, 200, "count", count, "total_count", totalCount)
 			return nil
 		},
 		"storage",
 		"list-evaluation-jobs",
+		"count", strconv.Itoa(count),
+		"total_count", strconv.Itoa(totalCount),
 	)
 }
 

--- a/internal/eval_hub/handlers/evaluations_test.go
+++ b/internal/eval_hub/handlers/evaluations_test.go
@@ -1,7 +1,9 @@
 package handlers_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -12,6 +14,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/server"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
@@ -841,5 +844,63 @@ func TestHandleCreateEvaluationRejectsEmptyExperimentName(t *testing.T) {
 	body := recorder.Body.String()
 	if !strings.Contains(body, "request_validation_failed") {
 		t.Fatalf("expected request_validation_failed in body, got %q", body)
+	}
+}
+
+func TestHandleListEvaluations_WriteJSON_logsExtraArgs(t *testing.T) {
+	t.Parallel()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	storage := &listEvaluationsStorage{
+		fakeStorage: &fakeStorage{},
+		jobs: []api.EvaluationJobResource{
+			{Resource: api.EvaluationResource{Resource: api.Resource{ID: "job-1"}}},
+			{Resource: api.EvaluationResource{Resource: api.Resource{ID: "job-2"}}},
+		},
+	}
+	validate := validation.NewValidator()
+	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
+
+	req := &listEvaluationsRequest{
+		MockRequest: createMockRequest("GET", "/api/v1/evaluations/jobs"),
+		queryValues: map[string][]string{},
+		pathValues:  map[string]string{},
+	}
+	recorder := httptest.NewRecorder()
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-writejson-extra", logger, "test-user", "test-tenant")
+	resp := server.NewRespWrapper(recorder, ctx)
+
+	h.HandleListEvaluations(ctx, req, resp)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body %s", recorder.Code, recorder.Body.String())
+	}
+
+	var successRecord map[string]any
+	for _, line := range strings.Split(logBuf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Fatalf("log line is not JSON: %v\n%s", err, line)
+		}
+		if obj["msg"] == "Request successful" {
+			successRecord = obj
+			break
+		}
+	}
+	if successRecord == nil {
+		t.Fatalf("expected a Request successful log record, got:\n%s", logBuf.String())
+	}
+	nItems := float64(len(storage.jobs))
+	if successRecord["count"] != nItems {
+		t.Fatalf("log count: got %v want %v", successRecord["count"], nItems)
+	}
+	if successRecord["total_count"] != nItems {
+		t.Fatalf("log total_count: got %v want %v", successRecord["total_count"], nItems)
 	}
 }

--- a/internal/eval_hub/handlers/handlers_test.go
+++ b/internal/eval_hub/handlers/handlers_test.go
@@ -114,7 +114,7 @@ func (w MockResponseWrapper) ErrorWithMessageCode(requestId string, messageCode 
 	w.WriteJSON(api.Error{Message: messages.GetErrorMessage(messageCode, messageParams...), MessageCode: messageCode.GetCode(), Trace: requestId}, messageCode.GetStatusCode())
 }
 
-func (w MockResponseWrapper) WriteJSON(v any, code int) {
+func (w MockResponseWrapper) WriteJSON(v any, code int, _ ...any) {
 	w.recorder.Code = code
 	if code != 204 {
 		w.recorder.Header().Set("Content-Type", "application/json")

--- a/internal/eval_hub/handlers/providers.go
+++ b/internal/eval_hub/handlers/providers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 
@@ -149,6 +150,9 @@ func (h *Handlers) HandleListProviders(ctx *executioncontext.ExecutionContext, r
 		return
 	}
 
+	var count int
+	var totalCount int
+
 	_ = h.withSpan(
 		ctx,
 		func(runtimeCtx context.Context) error {
@@ -175,11 +179,15 @@ func (h *Handlers) HandleListProviders(ctx *executioncontext.ExecutionContext, r
 				Items: providers.Items,
 			}
 
-			w.WriteJSON(result, 200)
+			count = len(providers.Items)
+			totalCount = providers.TotalCount
+			w.WriteJSON(result, 200, "count", strconv.Itoa(count), "total_count", strconv.Itoa(totalCount))
 			return nil
 		},
 		"storage",
 		"list-providers",
+		"count", strconv.Itoa(count),
+		"total_count", strconv.Itoa(totalCount),
 	)
 }
 

--- a/internal/eval_hub/http_wrappers/defs.go
+++ b/internal/eval_hub/http_wrappers/defs.go
@@ -22,5 +22,5 @@ type ResponseWrapper interface {
 	DeleteHeader(key string)
 	SetStatusCode(code int)
 	Write(buf []byte) (n int, err error)
-	WriteJSON(v any, code int)
+	WriteJSON(v any, code int, arguments ...any)
 }

--- a/internal/eval_hub/server/execution_context.go
+++ b/internal/eval_hub/server/execution_context.go
@@ -149,7 +149,7 @@ func (r RespWrapper) Write(buf []byte) (int, error) {
 	return r.Response.Write(buf)
 }
 
-func (r RespWrapper) WriteJSON(v any, code int) {
+func (r RespWrapper) WriteJSON(v any, code int, arguments ...any) {
 	r.SetHeader("Content-Type", "application/json")
 	if r.ctx.RequestID != "" {
 		r.SetHeader(TRANSACTION_ID_HEADER, r.ctx.RequestID)
@@ -163,7 +163,9 @@ func (r RespWrapper) WriteJSON(v any, code int) {
 			return
 		}
 	}
-	logging.LogRequestSuccess(r.ctx, code, v)
+	// Copy variadic args before re-expansion so key/value pairs are not dropped when
+	// forwarding ...any into LogRequestSuccess (see handlers TestHandleListEvaluations_WriteJSON_logsExtraArgs).
+	logging.LogRequestSuccess(r.ctx, code, v, append([]any(nil), arguments...)...)
 }
 
 func (r RespWrapper) SetStatusCode(code int) {

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -123,8 +123,8 @@ func LogRequestFailed(ctx *executioncontext.ExecutionContext, code int, errorMes
 	LogWithCallerSkip(ctx.Ctx, ctx.Logger, slog.LevelInfo, skipCount, "Request failed", "error", errorMessage, "code", code, "duration", time.Since(ctx.StartedAt))
 }
 
-func LogRequestSuccess(ctx *executioncontext.ExecutionContext, code int, response any) {
-	LogWithCallerSkip(ctx.Ctx, ctx.Logger, slog.LevelInfo, 3, "Request successful", "code", code, "duration", time.Since(ctx.StartedAt))
+func LogRequestSuccess(ctx *executioncontext.ExecutionContext, code int, response any, arguments ...any) {
+	LogWithCallerSkip(ctx.Ctx, ctx.Logger, slog.LevelInfo, 3, "Request successful", append([]any{"code", code, "duration", time.Since(ctx.StartedAt)}, arguments...)...)
 }
 
 func AsPrettyJson(s any, mask ...string) string {

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -123,7 +123,7 @@ func LogRequestFailed(ctx *executioncontext.ExecutionContext, code int, errorMes
 	LogWithCallerSkip(ctx.Ctx, ctx.Logger, slog.LevelInfo, skipCount, "Request failed", "error", errorMessage, "code", code, "duration", time.Since(ctx.StartedAt))
 }
 
-func LogRequestSuccess(ctx *executioncontext.ExecutionContext, code int, response any, arguments ...any) {
+func LogRequestSuccess(ctx *executioncontext.ExecutionContext, code int, _ any, arguments ...any) {
 	LogWithCallerSkip(ctx.Ctx, ctx.Logger, slog.LevelInfo, 3, "Request successful", append([]any{"code", code, "duration", time.Since(ctx.StartedAt)}, arguments...)...)
 }
 

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,10 +1,16 @@
 package logging
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
 )
 
 func TestAsPrettyJson_noMask(t *testing.T) {
@@ -118,5 +124,41 @@ func TestAsPrettyJson_marshalError_fallsBackToString(t *testing.T) {
 	want := fmt.Sprintf("%v", ch)
 	if out != want {
 		t.Fatalf("marshal failure should fall back to %%v: got %q want %q", out, want)
+	}
+}
+
+func TestLogRequestSuccess_additionalArgsInOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	ctx := &executioncontext.ExecutionContext{
+		Ctx:       context.Background(),
+		RequestID: "req-extra-args",
+		Logger:    logger,
+		StartedAt: time.Now().Add(-50 * time.Millisecond),
+	}
+
+	LogRequestSuccess(ctx, 201, map[string]string{"ignored": "response is not logged"}, "extra_key", "extra_value", "count", 42)
+
+	var payload map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("log output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if payload["msg"] != "Request successful" {
+		t.Fatalf("msg: got %v want Request successful", payload["msg"])
+	}
+	if code, ok := payload["code"].(float64); !ok || code != 201 {
+		t.Fatalf("code: got %v want 201", payload["code"])
+	}
+	if payload["extra_key"] != "extra_value" {
+		t.Fatalf("extra_key: got %v want extra_value", payload["extra_key"])
+	}
+	if n, ok := payload["count"].(float64); !ok || n != 42 {
+		t.Fatalf("count: got %v want 42", payload["count"])
+	}
+	if _, ok := payload["duration"]; !ok {
+		t.Fatalf("expected duration field in log output: %v", payload)
 	}
 }

--- a/pkg/evalhubclient/client.go
+++ b/pkg/evalhubclient/client.go
@@ -23,6 +23,9 @@ const (
 
 	apiBasePath = "/api/v1/evaluations"
 	healthPath  = "/api/v1/health"
+
+	// maxLoggedBodyBytes caps JSON logged for request/response bodies (aligned with eval-hub handler visibility).
+	maxLoggedBodyBytes = 8192
 )
 
 // APIError represents a typed error returned by the eval-hub API.
@@ -175,6 +178,48 @@ func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
 	return cp
 }
 
+func truncateBodyForLog(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	if len(b) <= maxLoggedBodyBytes {
+		return string(b)
+	}
+	return string(b[:maxLoggedBodyBytes]) + "… (truncated)"
+}
+
+// shouldLogBody returns true if the body should be logged based on the logger level (DEBUG level) and the body length (greater than zero).
+func (c *Client) shouldLogBody(b []byte) bool {
+	return c.logger.Enabled(c.ctx, slog.LevelDebug) && (len(b) > 0)
+}
+
+func (c *Client) logEvalHubRequestStarted(method, fullURL string, bodyBytes []byte) {
+	args := []any{"method", method, "uri", fullURL}
+	if c.tenant != "" {
+		args = append(args, "tenant", c.tenant)
+	}
+	if c.shouldLogBody(bodyBytes) {
+		args = append(args, "request", truncateBodyForLog(bodyBytes))
+	}
+	c.logger.Info("Request started", args...)
+}
+
+func (c *Client) logEvalHubRequestFailed(start time.Time, code int, errMsg string, respBody []byte) {
+	args := []any{"error", errMsg, "code", code, "duration", time.Since(start)}
+	if c.shouldLogBody(respBody) {
+		args = append(args, "response", truncateBodyForLog(respBody))
+	}
+	c.logger.Info("Request failed", args...)
+}
+
+func (c *Client) logEvalHubRequestSuccessful(start time.Time, code int, respBody []byte) {
+	args := []any{"code", code, "duration", time.Since(start)}
+	if c.shouldLogBody(respBody) {
+		args = append(args, "response", truncateBodyForLog(respBody))
+	}
+	c.logger.Info("Request successful", args...)
+}
+
 func (c *Client) setHeaders(req *http.Request) {
 	if req.Body != nil {
 		req.Header.Set("Content-Type", "application/json")
@@ -207,6 +252,9 @@ func (c *Client) doRequest(method, path string, body any, queryParams url.Values
 		}
 	}
 
+	start := time.Now()
+	c.logEvalHubRequestStarted(method, fullURL, bodyBytes)
+
 	var (
 		respBody   []byte
 		statusCode int
@@ -225,11 +273,11 @@ func (c *Client) doRequest(method, path string, body any, queryParams url.Values
 
 		req, err := http.NewRequestWithContext(c.ctx, method, fullURL, reqBody)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to create request: %w", err)
+			wrapped := fmt.Errorf("failed to create request: %w", err)
+			c.logEvalHubRequestFailed(start, 0, wrapped.Error(), nil)
+			return nil, 0, wrapped
 		}
 		c.setHeaders(req)
-
-		c.logger.Debug("eval-hub request", "method", method, "path", path, "attempt", attempt+1)
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
@@ -238,6 +286,7 @@ func (c *Client) doRequest(method, path string, body any, queryParams url.Values
 				c.logger.Warn("eval-hub request failed, retrying", "method", method, "path", path, "attempt", attempt+1, "error", err)
 				continue
 			}
+			c.logEvalHubRequestFailed(start, 0, lastErr.Error(), nil)
 			return nil, 0, lastErr
 		}
 
@@ -245,7 +294,9 @@ func (c *Client) doRequest(method, path string, body any, queryParams url.Values
 		respBody, err = io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
-			return nil, statusCode, fmt.Errorf("failed to read response body: %w", err)
+			wrapped := fmt.Errorf("failed to read response body: %w", err)
+			c.logEvalHubRequestFailed(start, statusCode, wrapped.Error(), nil)
+			return nil, statusCode, wrapped
 		}
 
 		// Retry server errors; propagate client errors immediately.
@@ -260,13 +311,16 @@ func (c *Client) doRequest(method, path string, body any, queryParams url.Values
 	}
 
 	if lastErr != nil {
+		c.logEvalHubRequestFailed(start, statusCode, lastErr.Error(), respBody)
 		return nil, statusCode, lastErr
 	}
 	if statusCode < 200 || statusCode >= 300 {
-		return nil, statusCode, c.parseAPIError(statusCode, respBody)
+		apiErr := c.parseAPIError(statusCode, respBody)
+		c.logEvalHubRequestFailed(start, statusCode, apiErr.Error(), respBody)
+		return nil, statusCode, apiErr
 	}
 
-	c.logger.Debug("eval-hub request succeeded", "method", method, "path", path, "status", statusCode)
+	c.logEvalHubRequestSuccessful(start, statusCode, respBody)
 	return respBody, statusCode, nil
 }
 

--- a/pkg/evalhubclient/client_test.go
+++ b/pkg/evalhubclient/client_test.go
@@ -1,9 +1,11 @@
 package evalhubclient
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -739,6 +741,59 @@ func TestAPIErrorHelpers(t *testing.T) {
 		if e.IsForbidden() != tc.forbidden {
 			t.Errorf("IsForbidden() for %d = %v, want %v", tc.status, e.IsForbidden(), tc.forbidden)
 		}
+	}
+}
+
+// ─── Request / response logging (MCP and other callers use WithLogger) ─────────
+
+func TestClient_logsRequestLifecycle_success(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	srv, _ := newCapturingServer(t, http.StatusOK, mustMarshal(t, api.HealthResponse{Status: "ok"}))
+
+	_, err := NewClient(srv.URL).WithLogger(logger).WithTenant("ns1").GetHealth()
+	if err != nil {
+		t.Fatalf("GetHealth: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"msg":"Request started"`) {
+		t.Fatalf("expected Request started in logs:\n%s", out)
+	}
+	if !strings.Contains(out, `"msg":"Request successful"`) {
+		t.Fatalf("expected Request successful in logs:\n%s", out)
+	}
+	if !strings.Contains(out, `"tenant":"ns1"`) {
+		t.Fatalf("expected tenant in logs:\n%s", out)
+	}
+	if !strings.Contains(out, `"method":"GET"`) {
+		t.Fatalf("expected method in logs:\n%s", out)
+	}
+}
+
+func TestClient_logsRequestLifecycle_apiError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	errBody := mustMarshal(t, api.Error{Message: "nope", MessageCode: "test.bad"})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(errBody)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL).WithLogger(logger).WithMaxRetries(0).GetHealth()
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"msg":"Request started"`) {
+		t.Fatalf("expected Request started in logs:\n%s", out)
+	}
+	if !strings.Contains(out, `"msg":"Request failed"`) {
+		t.Fatalf("expected Request failed in logs:\n%s", out)
+	}
+	if !strings.Contains(out, `"code":400`) {
+		t.Fatalf("expected HTTP 400 in logs:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## What and why

- Added logs for all requests from the MCP server to the evalhub server.
- Updated the HandleListCollections, HandleListEvaluations, and HandleListProviders methods to include additional fields in the JSON response: "count" and "total_count". This change improves the logging of response details, allowing for better tracking of the number of items returned and the total available count. 
- Modified the WriteJSON method in the MockResponseWrapper to accept variadic arguments for logging purposes. Updated related tests to verify the correct logging of these new fields.
- Refactored logging functions to support additional arguments, ensuring that request success logs include relevant metrics for better observability.

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * List collections, evaluations, and providers endpoints now include pagination count information in responses.
  * Added enhanced logging for client API requests and responses, including request initiation, success, and failure events with relevant metadata.

* **Tests**
  * Added test coverage for new pagination count fields and request/response logging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->