### PR TITLE
fix(deps): update postcss override to 8.5.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2534,9 +2534,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "overrides": {
     "semver": "7.7.4",
-    "postcss": "8.5.13",
+    "postcss": "8.5.14",
     "uuid": "14.0.0",
     "fast-xml-parser": "5.7.3"
   },


### PR DESCRIPTION
## Summary

- Updates the `postcss` npm override from `8.5.13` to `8.5.14` (latest available)
- Regenerated `package-lock.json` via `npm install` — `npm audit` confirms 0 vulnerabilities
- Verified documentation build with `make documentation` — no docs changes from this update

## Security Audit Results

Comprehensive dependency audit performed across both Go and npm ecosystems:

**Go dependencies (155 modules, go1.25.9):**
- `govulncheck`: **0 vulnerabilities** found
- Manual cross-check of key packages (golang.org/x/crypto@0.50.0, golang.org/x/net@0.53.0, google.golang.org/grpc@1.81.0, github.com/jackc/pgx/v5@5.9.2) against GitHub Security Advisory DB confirms all at patched versions
- Go 1.25.9 is the latest available 1.25.x release

**npm dependencies (308 packages):**
- `npm audit`: **0 vulnerabilities** found
- All overrides confirmed at latest patched versions:
  - `semver@7.7.4` — latest available
  - `postcss@8.5.14` — updated from 8.5.13 (latest available)
  - `uuid@14.0.0` — latest available
  - `fast-xml-parser@5.7.3` — latest available
- Manual cross-check of commonly-CVE'd transitive packages (undici@6.24.0, nanoid@3.3.11, handlebars@4.7.9, dompurify@3.4.2, lodash@4.18.1, ws@7.5.10, etc.) confirms all at patched versions

**No other open PRs** exist for CVE fixes in this repository.

## Test plan

- [x] `npm audit` reports 0 vulnerabilities after update
- [x] `make documentation` builds successfully with no changed output files
- [x] `postcss@8.5.14` resolves correctly in `package-lock.json`
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a build tool dependency to the latest patch version for improved performance and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->