### PR TITLE
fix(deps): add fast-uri override to resolve GHSA-v39h-62p7-jpjc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1469,9 +1469,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.1.tgz",
-      "integrity": "sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "semver": "7.7.4",
     "postcss": "8.5.14",
     "uuid": "14.0.0",
-    "fast-xml-parser": "5.7.3"
+    "fast-xml-parser": "5.7.3",
+    "fast-uri": "3.1.2"
   },
   "scripts": {
     "lint-openapi": "redocly lint docs/src/openapi.yaml",


### PR DESCRIPTION
## Summary

- Adds `fast-uri@3.1.2` override in `package.json` to fix **GHSA-v39h-62p7-jpjc** (high severity, CVSS 7.5) — host confusion via percent-encoded authority delimiters in `fast-uri <=3.1.1`
- Regenerated `package-lock.json` via `npm install`; `npm audit` now reports **0 vulnerabilities**
- Verified documentation build with `make documentation` — no changes to docs output

### Go stdlib CVEs (not addressed)

`govulncheck` found 7 vulnerabilities in Go stdlib (all fixed in Go 1.25.10):

| ID | Package | Description |
|---|---|---|
| GO-2026-4986 | net/mail | Quadratic string concatenation in consumeComment |
| GO-2026-4982 | html/template | Bypass of meta content URL escaping causes XSS |
| GO-2026-4980 | html/template | Escaper bypass leads to XSS |
| GO-2026-4977 | net/mail | Quadratic string concatenation in consumePhrase |
| GO-2026-4976 | net/http/httputil | ReverseProxy forwards excessive query params |
| GO-2026-4971 | net | Panic in Dial/LookupPort with NUL byte on Windows |
| GO-2026-4918 | net/http | Infinite loop in HTTP/2 transport with bad SETTINGS_MAX_FRAME_SIZE |

These require updating Go from 1.25.9 to 1.25.10, but `registry.access.redhat.com/ubi9/go-toolset` does not yet support any Go 1.25.x version (latest available is 1.21.10). Per repository policy, go.mod must not be updated until go-toolset supports the target version.

## Test plan

- [x] `npm audit` reports 0 vulnerabilities
- [x] `make documentation` succeeds with no output changes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency overrides in package configuration for improved dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->