### PR TITLE
fix(tests): use valid default for MODEL_AUTH_SECRET_REF in FVT test data

### DIFF
--- a/tests/features/test_data/evaluation_job.json
+++ b/tests/features/test_data/evaluation_job.json
@@ -3,7 +3,7 @@
     "url": "{{env:MODEL_URL|http://test.com}}",
     "name": "{{env:MODEL_NAME|test}}",
     "auth": {
-      "secret_ref": "{{env:MODEL_AUTH_SECRET_REF| }}"
+      "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
     }
   },
   "benchmarks": [


### PR DESCRIPTION

## What and why

The previous default value (a single space) was rejected by the Python SDK's Pydantic validator which strips whitespace and rejects empty secret_ref values. This caused the local runtime's benchmark subprocess to crash on startup, leaving evaluation jobs stuck in "pending" and timing out the @gha-wheel-sanity CI tests.


Closes # https://redhat.atlassian.net/browse/RHOAIENG-61917

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture to refine default configuration values for improved test reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/557)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->