### PR TITLE
fix: test_data_ref ignored in collection benchmark overrides

### DIFF
--- a/internal/eval_hub/handlers/helpers.go
+++ b/internal/eval_hub/handlers/helpers.go
@@ -273,13 +273,24 @@ func mergeBenchmarkParameters(benchmark api.CollectionBenchmarkConfig, jobBenchm
 			parameters[key] = value
 		}
 	}
+	// pick up TestDataRef from the job override if provided
+	testDataRef := benchmark.TestDataRef
+
+	for _, jobBenchmark := range jobBenchmarks {
+		if jobBenchmark.ID == benchmark.ID && jobBenchmark.ProviderID == benchmark.ProviderID {
+			if jobBenchmark.TestDataRef != nil {
+				testDataRef = jobBenchmark.TestDataRef
+			}
+			break
+		}
+	}
 	return api.EvaluationBenchmarkConfig{
 		Ref:          benchmark.Ref,
 		ProviderID:   benchmark.ProviderID,
 		Weight:       benchmark.Weight,
 		PrimaryScore: benchmark.PrimaryScore,
 		PassCriteria: benchmark.PassCriteria,
-		TestDataRef:  benchmark.TestDataRef,
+		TestDataRef:  testDataRef,
 		Parameters:   parameters,
 	}
 }


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

When a job is submitted with a collection and benchmark-level overrides in collection.benchmarks, TestDataRef was silently dropped — only Parameters were merged from the override. This caused the init container to never be created for collection jobs, making offline evaluation impossible via collections.

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

With the fix, offline collection worked fine.
```
{
  "resource": {
    "id": "4f9f8dca-716a-4141-8419-0a79ee7e8e4b",
    "tenant": "dataplane",
    "created_at": "2026-05-11T09:33:49.783212Z",
    "updated_at": "2026-05-11T09:37:36.016563Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "completed",
    "message": {
      "message": "Evaluation job is completed",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "truthfulqa_mc1",
        "benchmark_index": 1,
        "status": "completed",
        "completed_at": "2026-05-11T09:37:36.001001+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "toxigen",
        "benchmark_index": 0,
        "status": "completed",
        "completed_at": "2026-05-11T09:35:48.213751+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "bigbench_hhh_alignment_multiple_choice",
        "benchmark_index": 2,
        "status": "completed",
        "completed_at": "2026-05-11T09:34:39.787391+00:00"
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "bigbench_hhh_alignment_multiple_choice",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 2,
        "metrics": {
          "acc": 0.4253393665158371,
          "acc_stderr": 0.03333206140201842
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0,
        "metrics": {
          "acc": 0.4074468085106383,
          "acc_norm": 0.42872340425531913,
          "acc_norm_stderr": 0.016150241325972998,
          "acc_stderr": 0.01603490291675187
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 1,
        "metrics": {
          "acc": 0.2729498164014688,
          "acc_stderr": 0.01559475363200653
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      }
    ]
  },
  "name": "model offline test using collection",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct"
  },
  "collection": {
    "id": "toxicity-and-ethical-principles",
    "benchmarks": [
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "tokenizer": "/test_data/tokenizer"
        },
        "test_data_ref": {
          "s3": {
            "bucket": "mlpipeline",
            "key": "offline_toxigen/",
            "secret_ref": "minio-test"
          }
        }
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "tokenizer": "/test_data/tokenizer"
        },
        "test_data_ref": {
          "s3": {
            "bucket": "mlpipeline",
            "key": "offline_truthful_qa/",
            "secret_ref": "minio-test"
          }
        }
      },
      {
        "id": "bigbench_hhh_alignment_multiple_choice",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "tokenizer": "/test_data/tokenizer"
        },
        "test_data_ref": {
          "s3": {
            "bucket": "mlpipeline",
            "key": "offline_bigbench/",
            "secret_ref": "minio-test"
          }
        }
      }
    ]
  }
```

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced benchmark configuration to support overriding test data references at the job level, providing greater flexibility in benchmark customization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/558)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->