### PR TITLE
fix(ci): use WINDIR for Windows detection in wheel sanity test

### DIFF
--- a/scripts/gha_wheel_sanity_test.sh
+++ b/scripts/gha_wheel_sanity_test.sh
@@ -17,13 +17,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Windows GHA runners lack /tmp; the Go binary resolves it to \tmp on the
-# current drive (e.g. D:\tmp) which differs from Git Bash's MSYS2 /tmp
-if [[ "$OSTYPE" == msys* ]]; then
-    echo "Windows detected (OSTYPE=${OSTYPE}): creating \\tmp via cmd"
+if [[ -n "${WINDIR:-}" ]]; then
+    echo "Windows detected: creating \\tmp via cmd"
     cmd //c "mkdir \\tmp 2>nul" || true
 else
-    echo "Unix detected (OSTYPE=${OSTYPE}): ensuring /tmp exists"
+    echo "Unix detected: ensuring /tmp exists"
     mkdir -p /tmp
 fi
 


### PR DESCRIPTION


## What and why

The windows-latest GHA runner image changed from MSYS2 to Cygwin, causing $OSTYPE to report "cygwin" instead of "msys". This broke the /tmp directory creation, as the script took the Unix path and Go resolved /tmp to \tmp on the native drive which didn't exist.

Use $WINDIR instead, which is set by Windows itself regardless of shell flavor.

Fix for: the CI failure
<img width="1138" height="362" alt="Screenshot 2026-05-11 at 4 08 07 PM" src="https://github.com/user-attachments/assets/81dfef7e-6c92-4ffe-b482-6065d1975e0d" />


Closes # NA

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OS detection logic in wheel testing script to use environment variable-based Windows detection instead of shell type checking, improving compatibility with GitHub Actions Windows runners.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/559)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->