### PR TITLE
chore(tests): enhance FVT tagging and add local job scenarios

### DIFF
--- a/.claude/rules/evalhub-service.md
+++ b/.claude/rules/evalhub-service.md
@@ -160,8 +160,9 @@ BDD-style tests using godog in `tests/features/`:
 
 #### FVT Tags
 
-- `@cluster` — tests that require a Kubernetes cluster
-- `@local` — tests that only run locally (excluded from CI)
+- `@cluster` — tests that require a Kubernetes cluster (excluded from default FVT via `~@cluster`)
+- `@local_runtime` — scenarios that require a fully functional local evaluation runtime (`--local` / FVT embedded server local mode; local job execution). **Excluded** from default `make test-fvt` / CI FVT via `~@local_runtime`; override `FVT_TAGS` or `GODOG_TAGS` to run them
+- `@local` — still appears on some evaluation scenarios; prefer `@local_runtime` for new tests that need full local job/runtime behavior
 - `@mlflow` — tests requiring MLflow integration
 - `@negative` — negative/error-path tests
 - `@gha-wheel-sanity` — subset run during GHA wheel validation (`scripts/gha_wheel_sanity_test.sh`); the script starts the wheel-installed binary, waits for health, then runs `make test-fvt` with this tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ go test -v ./internal/eval_hub/handlers -run TestHandleName
 go test -v ./tests/features -run TestFeatureName
 ```
 
+FVT scenarios use godog tags (for example `@local_runtime` for a full local job runtime, `@cluster` for Kubernetes-only). Default `make test-fvt` excludes `@local_runtime`, `@cluster`, and `@mlflow` via `FVT_TAGS`; see **tests/features/README.md**.
+
 ### Code Quality
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,7 @@ func (h *Handlers) HandleCreateEvaluation(
 ### Test Categories
 
 - **Unit Tests**: Test individual functions and packages (in `internal/`)
-- **FVT (Functional Verification Tests)**: BDD-style tests using godog (in `tests/features/`). Scenarios are tagged (`@local`, `@cluster`, `@mlflow`, `@negative`, `@gha-wheel-sanity`) to control which run in each context. The `@gha-wheel-sanity` tag marks scenarios executed during GHA wheel validation via `scripts/gha_wheel_sanity_test.sh`.
+- **FVT (Functional Verification Tests)**: BDD-style tests using godog (in `tests/features/`). Scenarios are tagged (`@local_runtime`, `@local`, `@cluster`, `@mlflow`, `@negative`, `@gha-wheel-sanity`) to control which run in each context. The `@local_runtime` tag marks scenarios that need a fully functional local evaluation runtime (local mode / job execution, not Kubernetes); those scenarios are **skipped in the default FVT run** (`~@local_runtime` in `FVT_TAGS`). Opt in by overriding `FVT_TAGS` / `GODOG_TAGS` as documented in `tests/features/README.md`. The `@gha-wheel-sanity` tag marks scenarios executed during GHA wheel validation via `scripts/gha_wheel_sanity_test.sh` (that job passes its own `FVT_TAGS`, so it is unaffected by the default `~@local_runtime`). See `tests/features/README.md` for all tags and examples.
 - **Integration Tests**: Test component interactions
 
 ### Running Tests

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ SERVER_URL ?= http://localhost:8080
 
 FVT_TESTS ?= ./tests/features/...
 FVT_OUTPUT ?= --godog.format=junit:${PWD}/$(BIN_DIR)/junit-fvt-report.xml,pretty
-FVT_TAGS ?= --godog.tags=~@ignore && ~@mlflow && ~@cluster
+FVT_TAGS ?= --godog.tags=~@ignore && ~@mlflow && ~@cluster && ~@local_runtime
 FVT_CONCURRENCY ?= 1
 
 .PHONY: test-setup

--- a/tests/features/README.md
+++ b/tests/features/README.md
@@ -78,8 +78,9 @@ When running in local server mode, the tests will:
 | @collections | Used to run just the collections tests |
 | @evaluations | Used to run just the evaluations tests |
 | @providers | Used to run just the providers tests |
-| @cluster | Tests that only work when run on a cluster or with a working runtime |
-| @local | Tests that only work when running locally (so without a working runtime) |
+| @cluster | Tests that require the Kubernetes cluster runtime (default `make test-fvt` excludes them via `~@cluster` in `FVT_TAGS`) |
+| @local_runtime | Scenarios that require a **fully functional local evaluation runtime**—eval-hub in local mode (embedded FVT server with `LocalMode`, or a binary started with `--local`). Use for flows such as local evaluation jobs that run to completion. Distinct from `@cluster`. **Excluded by default** (`~@local_runtime` in `FVT_TAGS` / `suite_test.go` defaults), same idea as `@cluster` and `@mlflow`. |
+| @local | Still used on some evaluation scenarios in `evaluations.feature` for local (non-cluster) job flows; prefer `@local_runtime` for new scenarios that depend on full local job/runtime execution. |
 | @negative | Used to mark this as a negative test |
 | @mlflow | Tests that only work when running with a configured mlflow service |
 | @ignore | Can be used to ignore a test |
@@ -91,6 +92,14 @@ such as `@focus` and then set the environment variable `GODOG_TAGS`:
 export GODOG_TAGS=@focus
 make clean test-fvt-server
 ```
+
+To **include** `@local_runtime` scenarios while keeping other default exclusions, override the tag expression (drop `~@local_runtime`). With Make, `FVT_TAGS` is passed through to `go test` and overrides the Makefile default when set in the environment:
+
+```shell
+FVT_TAGS='--godog.tags=~@ignore && ~@mlflow && ~@cluster' make test-fvt-server
+```
+
+Or set `GODOG_TAGS` for a plain `go test ./tests/features/...` run (see `suite_test.go`; this replaces the built-in default expression entirely).
 
 ## Running Tests
 

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -480,6 +480,19 @@ Feature: Evaluation Jobs
     When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}"
     Then the response code should be 204
 
+  Scenario: Create an evaluation job and wait for completion
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_with_auth.json"
+    Then the response code should be 202
+    And I wait for the evaluation job status to be "completed"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 404
+    And the response should contain the value "resource_not_found" at path "$.message_code"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 404
+
   Scenario: Verify Evaluation Jobs Can Use OOB Collections
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -480,20 +480,6 @@ Feature: Evaluation Jobs
     When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}"
     Then the response code should be 204
 
-  @gha-wheel-sanity
-  Scenario: Create an evaluation job and wait for completion
-    Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_with_auth.json"
-    Then the response code should be 202
-    And I wait for the evaluation job status to be "completed"
-    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
-    Then the response code should be 204
-    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
-    Then the response code should be 404
-    And the response should contain the value "resource_not_found" at path "$.message_code"
-    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
-    Then the response code should be 404
-
   Scenario: Verify Evaluation Jobs Can Use OOB Collections
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:

--- a/tests/features/evaluation_local_jobs.feature
+++ b/tests/features/evaluation_local_jobs.feature
@@ -1,0 +1,25 @@
+@local_runtime
+@evaluations
+Feature: Evaluation Jobs
+  As a data scientist
+  I want to create evaluation jobs against a running cluster
+  So that I evaluate models
+
+  Background:
+    Given I set the header "X-Tenant" to "{{env:X_TENANT|test-tenant}}"
+    And I set the wait deadline to "{{env:WAIT_DEADLINE|30m}}"
+    And the model endpoint is reachable
+
+  @gha-wheel-sanity
+  Scenario: Create an evaluation job and wait for completion
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
+    Then the response code should be 202
+    And I wait for the evaluation job status to be "completed"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 404
+    And the response should contain the value "resource_not_found" at path "$.message_code"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 404

--- a/tests/features/suite_test.go
+++ b/tests/features/suite_test.go
@@ -16,7 +16,7 @@ var opts = godog.Options{
 	Output:   colors.Colored(os.Stdout),
 	Format:   "junit:bin/junit-fvt.xml",
 	Strict:   true,
-	Tags:     "~@ignore && ~@mlflow && ~@cluster && ~@local_runtime",
+	Tags:     "~@ignore",
 	Paths:    []string{"."},
 	TestingT: nil,
 }

--- a/tests/features/suite_test.go
+++ b/tests/features/suite_test.go
@@ -16,7 +16,7 @@ var opts = godog.Options{
 	Output:   colors.Colored(os.Stdout),
 	Format:   "junit:bin/junit-fvt.xml",
 	Strict:   true,
-	Tags:     "~@ignore",
+	Tags:     "~@ignore && ~@mlflow && ~@cluster && ~@local_runtime",
 	Paths:    []string{"."},
 	TestingT: nil,
 }


### PR DESCRIPTION

## What and why

- Updated FVT tags in documentation and Makefile to include `@local_runtime`, which is now used for scenarios requiring a fully functional local evaluation runtime.
- Added a new feature file for local evaluation jobs, incorporating scenarios that utilize the `@local_runtime` tag.
- Revised existing documentation to clarify the usage of FVT tags and their exclusions in default test runs.
- Removed outdated scenarios from `evaluation_jobs.feature` to streamline test coverage.

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced FVT tag documentation across contributing and test guides, introducing `@local_runtime` tag with clear guidance on default exclusion and how to override via `FVT_TAGS`/`GODOG_TAGS`

* **Tests**
  * Added new feature file for local evaluation job tests with scenarios covering job creation, completion waiting, and deletion verification
  * Updated test suite configuration to properly exclude `@local_runtime` scenarios from default runs

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/561)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->