### PR TITLE
fix(ci): disable attestations for TestPyPI publish

### DIFF
--- a/.github/workflows/publish-python-server.yml
+++ b/.github/workflows/publish-python-server.yml
@@ -263,3 +263,4 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
+          attestations: false


### PR DESCRIPTION
TestPyPI rejects uploads with 400 Bad Request when attestations are enabled because the trusted publisher registry is separate from production PyPI. Disable attestations for the TestPyPI publish step.


Generated with: Claude Code

## What and why

Candidate fix for test.pypi push https://github.com/eval-hub/eval-hub/actions/runs/25677247920

Closes NA

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python server publishing workflow configuration for TestPyPI publishing step.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/562)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->