### PR TITLE
chore(ci): enable verbose logging for TestPyPI publish debugging

### DIFF
--- a/.github/workflows/publish-python-server.yml
+++ b/.github/workflows/publish-python-server.yml
@@ -264,3 +264,4 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
           attestations: false
+          verbose: true


### PR DESCRIPTION
The TestPyPI publish step has been failing with an unhelpful "400 Bad Request" error since run 334. Adding verbose output to surface the full HTTP response and diagnose the root cause.

## What and why

enabled verbose to get more information
Closes #

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved diagnostic output for internal publishing processes.

---

**Note:** This release contains only internal infrastructure updates with no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/564)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->