### PR TITLE
fix: use distinct evaluation_job_* message codes for terminal job states

### DIFF
--- a/internal/eval_hub/constants/message_codes.go
+++ b/internal/eval_hub/constants/message_codes.go
@@ -1,9 +1,11 @@
 package constants
 
 const (
-	MESSAGE_CODE_EVALUATION_JOB_CREATED   = "evaluation_job_created"
-	MESSAGE_CODE_EVALUATION_JOB_RETRIEVED = "evaluation_job_retrieved"
-	MESSAGE_CODE_EVALUATION_JOB_CANCELLED = "evaluation_job_cancelled"
-	MESSAGE_CODE_EVALUATION_JOB_FAILED    = "evaluation_job_failed"
-	MESSAGE_CODE_EVALUATION_JOB_UPDATED   = "evaluation_job_updated"
+	MESSAGE_CODE_EVALUATION_JOB_CREATED          = "evaluation_job_created"
+	MESSAGE_CODE_EVALUATION_JOB_RETRIEVED        = "evaluation_job_retrieved"
+	MESSAGE_CODE_EVALUATION_JOB_CANCELLED        = "evaluation_job_cancelled"
+	MESSAGE_CODE_EVALUATION_JOB_FAILED           = "evaluation_job_failed"
+	MESSAGE_CODE_EVALUATION_JOB_COMPLETED        = "evaluation_job_completed"
+	MESSAGE_CODE_EVALUATION_JOB_PARTIALLY_FAILED = "evaluation_job_partially_failed"
+	MESSAGE_CODE_EVALUATION_JOB_UPDATED          = "evaluation_job_updated"
 )

--- a/internal/eval_hub/storage/sql/evaluations.go
+++ b/internal/eval_hub/storage/sql/evaluations.go
@@ -254,6 +254,23 @@ func (s *sqlStorage) validateBenchmarkExists(job *api.EvaluationJobResource, run
 	return nil
 }
 
+// messageCodeForOverallState maps aggregate job state to a stable API message_code.
+// Non-terminal states (pending, running) use evaluation_job_updated.
+func messageCodeForOverallState(state api.OverallState) string {
+	switch state {
+	case api.OverallStateFailed:
+		return constants.MESSAGE_CODE_EVALUATION_JOB_FAILED
+	case api.OverallStatePartiallyFailed:
+		return constants.MESSAGE_CODE_EVALUATION_JOB_PARTIALLY_FAILED
+	case api.OverallStateCompleted:
+		return constants.MESSAGE_CODE_EVALUATION_JOB_COMPLETED
+	case api.OverallStateCancelled:
+		return constants.MESSAGE_CODE_EVALUATION_JOB_CANCELLED
+	default:
+		return constants.MESSAGE_CODE_EVALUATION_JOB_UPDATED
+	}
+}
+
 // GetOverallJobStatus returns overall state and message. getCollection is used to resolve job benchmark count when job has only a collection reference.
 func (s *sqlStorage) getOverallJobStatus(txn *sql.Tx, job *api.EvaluationJobResource) (api.OverallState, *api.MessageInfo, error) {
 	// to be safe - do an initial check to see if the job is finished
@@ -317,7 +334,7 @@ func (s *sqlStorage) getOverallJobStatus(txn *sql.Tx, job *api.EvaluationJobReso
 
 	return overallState, &api.MessageInfo{
 		Message:     stateMessage,
-		MessageCode: constants.MESSAGE_CODE_EVALUATION_JOB_UPDATED,
+		MessageCode: messageCodeForOverallState(overallState),
 	}, nil
 }
 

--- a/internal/eval_hub/storage/sql/message_code_for_overall_state_test.go
+++ b/internal/eval_hub/storage/sql/message_code_for_overall_state_test.go
@@ -1,0 +1,32 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/constants"
+	"github.com/eval-hub/eval-hub/pkg/api"
+)
+
+func TestMessageCodeForOverallState(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		state api.OverallState
+		want  string
+	}{
+		{api.OverallStateFailed, constants.MESSAGE_CODE_EVALUATION_JOB_FAILED},
+		{api.OverallStatePartiallyFailed, constants.MESSAGE_CODE_EVALUATION_JOB_PARTIALLY_FAILED},
+		{api.OverallStateCompleted, constants.MESSAGE_CODE_EVALUATION_JOB_COMPLETED},
+		{api.OverallStateCancelled, constants.MESSAGE_CODE_EVALUATION_JOB_CANCELLED},
+		{api.OverallStatePending, constants.MESSAGE_CODE_EVALUATION_JOB_UPDATED},
+		{api.OverallStateRunning, constants.MESSAGE_CODE_EVALUATION_JOB_UPDATED},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.state), func(t *testing.T) {
+			t.Parallel()
+			if got := messageCodeForOverallState(tc.state); got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/features/evaluations.feature
+++ b/tests/features/evaluations.feature
@@ -395,7 +395,7 @@ Feature: Evaluations Endpoint
     And the response should contain the value "can not be cancelled because" at path "$.message"
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
     Then the response code should be 200
-    And the response should contain the value "evaluation_job_updated" at path "$.status.message.message_code"
+    And the response should contain the value "evaluation_job_completed" at path "$.status.message.message_code"
     And the response should contain the value "completed" at path "$.status.benchmarks[0].status"
     And the response should contain the value "arc_easy" at path "$.status.benchmarks[0].id"
     And the response should contain the value "arc_easy" at path "$.results.benchmarks[0].id"


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes # https://redhat.atlassian.net/browse/RHOAIENG-62190

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually


Failing scenario:
```
{
  "resource": {
    "id": "a20edbc7-f4ed-4719-803d-f6160c3ba701",
    "tenant": "dataplane",
    "created_at": "2026-05-12T10:32:31.109267Z",
    "updated_at": "2026-05-12T10:32:47.777067Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "failed",
    "message": {
      "message": "Evaluation job is failed. \nBenchmark arc_easy failed with message: Evaluation failed: redhataigranite-31-8b-instruct is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a token having permission to this repo either by logging in with `huggingface-cli login` or by passing `token=[redacted]\n",
      "message_code": "evaluation_job_failed" <<< before, this was evaluation_job_updated
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "failed",
        "error_message": {
          "message": "Evaluation failed: redhataigranite-31-8b-instruct is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a token having permission to this repo either by logging in with `huggingface-cli login` or by passing `token=[redacted]",
          "message_code": "evaluation_failed"
        }
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0
      }
    ]
  },
  "name": "model api key/cert test",
  "model": {
    "url": "https://redhataigranite-31-8b-instruct-team-a.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "redhataigranite-31-8b-instruct"
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 1000
      }
    }
  ]
}
```
## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed evaluation job status messages to accurately display the actual job state (completed, partially failed, failed, or cancelled) instead of showing a generic update message.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/567)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->