### PR TITLE
feat: add GPU resource declaration for custom EvalHub adapters

### DIFF
--- a/internal/eval_hub/constants/message_codes.go
+++ b/internal/eval_hub/constants/message_codes.go
@@ -6,4 +6,8 @@ const (
 	MESSAGE_CODE_EVALUATION_JOB_CANCELLED = "evaluation_job_cancelled"
 	MESSAGE_CODE_EVALUATION_JOB_FAILED    = "evaluation_job_failed"
 	MESSAGE_CODE_EVALUATION_JOB_UPDATED   = "evaluation_job_updated"
+
+	// MESSAGE_CODE_GPU_UNAVAILABLE is set when an evaluation job's Kueue workload is inadmissible
+	// because the requested queue does not have sufficient GPU capacity.
+	MESSAGE_CODE_GPU_UNAVAILABLE = "gpu_unavailable"
 )

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -82,7 +82,7 @@ const (
 	annotationJobIDKey               = "eval-hub.github.io/job_id"
 	annotationProviderIDKey          = "eval-hub.github.io/provider_id"
 	annotationBenchmarkIDKey         = "eval-hub.github.io/benchmark_id"
-	labelKueueQueueNameKey           = "kueue.x-k8s.io/queue-name"
+	labelKueueQueueNameKey = "kueue.x-k8s.io/queue-name"
 )
 
 var (
@@ -273,6 +273,7 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
+					NodeSelector:       cfg.nodeSelector,
 					InitContainers:     initContainers,
 					Containers:         containers,
 					Volumes:            jobVolumes,
@@ -755,6 +756,15 @@ func buildResources(cfg *jobConfig) (corev1.ResourceRequirements, error) {
 			return corev1.ResourceRequirements{}, fmt.Errorf("parse memory limit: %w", err)
 		}
 		resources.Limits[corev1.ResourceMemory] = quantity
+	}
+	if cfg.gpuCount > 0 && cfg.gpuResource != "" {
+		gpuQty, err := resource.ParseQuantity(fmt.Sprintf("%d", cfg.gpuCount))
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("parse gpu count: %w", err)
+		}
+		// Kubernetes requires requests == limits for GPU extended resources.
+		resources.Requests[corev1.ResourceName(cfg.gpuResource)] = gpuQty
+		resources.Limits[corev1.ResourceName(cfg.gpuResource)] = gpuQty
 	}
 	if len(resources.Requests) == 0 {
 		resources.Requests = nil

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -694,3 +694,146 @@ func TestContainerCommandTrimsEmptyItems(t *testing.T) {
 		t.Fatalf("unexpected command: %v", command)
 	}
 }
+
+func TestBuildResourcesGPURequest(t *testing.T) {
+	cfg := &jobConfig{
+		cpuRequest:    "250m",
+		memoryRequest: "512Mi",
+		cpuLimit:      "1",
+		memoryLimit:   "2Gi",
+		gpuResource:   "nvidia.com/gpu",
+		gpuCount:      2,
+	}
+	resources, err := buildResources(cfg)
+	if err != nil {
+		t.Fatalf("buildResources returned error: %v", err)
+	}
+	gpu, ok := resources.Requests[corev1.ResourceName("nvidia.com/gpu")]
+	if !ok {
+		t.Fatalf("expected GPU resource %q in requests", "nvidia.com/gpu")
+	}
+	if gpu.Value() != 2 {
+		t.Fatalf("expected GPU request 2, got %v", gpu.Value())
+	}
+	gpuLimit, ok := resources.Limits[corev1.ResourceName("nvidia.com/gpu")]
+	if !ok {
+		t.Fatalf("expected GPU resource %q in limits", "nvidia.com/gpu")
+	}
+	if gpuLimit.Value() != 2 {
+		t.Fatalf("expected GPU limit 2 (must equal request), got %v", gpuLimit.Value())
+	}
+}
+
+func TestBuildResourcesAMDGPURequest(t *testing.T) {
+	cfg := &jobConfig{
+		cpuRequest:    "250m",
+		memoryRequest: "512Mi",
+		cpuLimit:      "1",
+		memoryLimit:   "2Gi",
+		gpuResource:   "amd.com/gpu",
+		gpuCount:      1,
+	}
+	resources, err := buildResources(cfg)
+	if err != nil {
+		t.Fatalf("buildResources returned error: %v", err)
+	}
+	if _, ok := resources.Requests[corev1.ResourceName("amd.com/gpu")]; !ok {
+		t.Fatalf("expected amd.com/gpu in requests")
+	}
+	if _, ok := resources.Requests[corev1.ResourceName("nvidia.com/gpu")]; ok {
+		t.Fatalf("expected no nvidia.com/gpu when amd.com/gpu specified")
+	}
+}
+
+func TestBuildResourcesNoGPURequest(t *testing.T) {
+	cfg := &jobConfig{
+		cpuRequest:    "250m",
+		memoryRequest: "512Mi",
+		cpuLimit:      "1",
+		memoryLimit:   "2Gi",
+		gpuResource:   "",
+		gpuCount:      0,
+	}
+	resources, err := buildResources(cfg)
+	if err != nil {
+		t.Fatalf("buildResources returned error: %v", err)
+	}
+	for name := range resources.Requests {
+		if strings.HasSuffix(string(name), "/gpu") || strings.HasSuffix(string(name), ".gpu") {
+			t.Fatalf("expected no GPU resource in requests, found %q", name)
+		}
+	}
+}
+
+func TestBuildJobGPUResourcesPropagated(t *testing.T) {
+	cfg := &jobConfig{
+		jobID:          "gpu-job",
+		resourceGUID:   "guid-gpu",
+		benchmarkIndex: 0,
+		namespace:      "default",
+		providerID:     "gpu-provider",
+		benchmarkID:    "bench-gpu",
+		adapterImage:   "adapter:latest",
+		defaultEnv:     []api.EnvVar{},
+		gpuResource:    "nvidia.com/gpu",
+		gpuCount:       1,
+	}
+	job, err := buildJob(cfg)
+	if err != nil {
+		t.Fatalf("buildJob: %v", err)
+	}
+	adapter := findContainer(job.Spec.Template.Spec.Containers, adapterContainerName)
+	if adapter == nil {
+		t.Fatalf("adapter container not found")
+	}
+	if _, ok := adapter.Resources.Requests[corev1.ResourceName("nvidia.com/gpu")]; !ok {
+		t.Fatalf("expected nvidia.com/gpu in adapter container requests")
+	}
+	if _, ok := adapter.Resources.Limits[corev1.ResourceName("nvidia.com/gpu")]; !ok {
+		t.Fatalf("expected nvidia.com/gpu in adapter container limits")
+	}
+}
+
+func TestBuildJobNodeSelector(t *testing.T) {
+	sel := map[string]string{"nvidia.com/gpu.product": "NVIDIA-H100-SXM5-80GB"}
+	cfg := &jobConfig{
+		jobID:          "ns-job",
+		resourceGUID:   "guid-ns",
+		benchmarkIndex: 0,
+		namespace:      "default",
+		providerID:     "p",
+		benchmarkID:    "b",
+		adapterImage:   "adapter:latest",
+		defaultEnv:     []api.EnvVar{},
+		gpuResource:    "nvidia.com/gpu",
+		gpuCount:       1,
+		nodeSelector:   sel,
+	}
+	job, err := buildJob(cfg)
+	if err != nil {
+		t.Fatalf("buildJob: %v", err)
+	}
+	if job.Spec.Template.Spec.NodeSelector["nvidia.com/gpu.product"] != "NVIDIA-H100-SXM5-80GB" {
+		t.Errorf("pod NodeSelector = %v, want H100 label", job.Spec.Template.Spec.NodeSelector)
+	}
+}
+
+func TestBuildJobNoNodeSelectorWhenAbsent(t *testing.T) {
+	cfg := &jobConfig{
+		jobID:          "no-ns-job",
+		resourceGUID:   "guid-no-ns",
+		benchmarkIndex: 0,
+		namespace:      "default",
+		providerID:     "p",
+		benchmarkID:    "b",
+		adapterImage:   "adapter:latest",
+		defaultEnv:     []api.EnvVar{},
+	}
+	job, err := buildJob(cfg)
+	if err != nil {
+		t.Fatalf("buildJob: %v", err)
+	}
+	if len(job.Spec.Template.Spec.NodeSelector) != 0 {
+		t.Errorf("expected empty NodeSelector, got %v", job.Spec.Template.Spec.NodeSelector)
+	}
+}

--- a/internal/eval_hub/runtimes/k8s/job_config.go
+++ b/internal/eval_hub/runtimes/k8s/job_config.go
@@ -30,8 +30,11 @@ const (
 	inClusterNamespaceFile      = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 	serviceAccountNameSuffix    = "-job"
 	serviceCAConfigMapSuffix    = "-service-ca"
-	defaultTestDataInitCmd      = "/app/eval-runtime-init"
-	defaultEvalHubPort          = "8443"
+	defaultTestDataInitCmd = "/app/eval-runtime-init"
+	defaultEvalHubPort     = "8443"
+	// defaultGPUResource is the Kubernetes extended resource name used when a GPUConfig omits
+	// the Resource field. Aligns with NVIDIA GPU naming used by other RHOAI workloads.
+	defaultGPUResource = "nvidia.com/gpu"
 )
 
 type jobConfig struct {
@@ -49,6 +52,9 @@ type jobConfig struct {
 	memoryRequest       string
 	cpuLimit            string
 	memoryLimit         string
+	gpuResource         string            // Kubernetes extended resource name (e.g. "nvidia.com/gpu")
+	gpuCount            int               // number of GPU units to request (0 = CPU-only)
+	nodeSelector        map[string]string // pod nodeSelector from GPU config; nil when queue is set
 	jobSpec             shared.JobSpec
 	serviceAccountName  string
 	serviceCAConfigMap  string
@@ -178,6 +184,16 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 		queueKind = strings.TrimSpace(evaluation.Queue.Kind)
 	}
 
+	// GPU resource requests/limits are always propagated to the pod spec so that Kueue can
+	// account for GPU quota. When a queue is specified, nodeSelector is omitted — Kueue's
+	// admission controller selects the appropriate ResourceFlavor (which encodes node labels)
+	// and mutates the pod at admission time.
+	gpuResource, gpuCount := resolveGPUConfig(runtime.K8s.GPU)
+	var nodeSelector map[string]string
+	if queueName == "" {
+		nodeSelector = resolveNodeSelector(runtime.K8s.GPU)
+	}
+
 	out := &jobConfig{
 		jobID:                evaluation.Resource.ID,
 		resourceGUID:         uuid.NewString(),
@@ -193,6 +209,9 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 		memoryRequest:        memoryRequest,
 		cpuLimit:             cpuLimit,
 		memoryLimit:          memoryLimit,
+		gpuResource:          gpuResource,
+		gpuCount:             gpuCount,
+		nodeSelector:         nodeSelector,
 		jobSpec:              *spec,
 		serviceAccountName:   serviceAccountName,
 		serviceCAConfigMap:   serviceCAConfigMap,
@@ -304,6 +323,32 @@ func resourceRequirementsFromConfig(cfg *config.ResourceRequirements) (corev1.Re
 		}
 	}
 	return out, nil
+}
+
+// resolveNodeSelector returns the node selector map from a GPUConfig, or nil when absent.
+func resolveNodeSelector(gpu *api.GPUConfig) map[string]string {
+	if gpu == nil || len(gpu.NodeSelector) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(gpu.NodeSelector))
+	for k, v := range gpu.NodeSelector {
+		out[k] = v
+	}
+	return out
+}
+
+// resolveGPUConfig returns the Kubernetes extended resource name and count from a GPUConfig.
+// When gpu is nil or Count is 0, both return values are zero-valued (no GPU scheduled).
+// When Resource is empty the NVIDIA default is used, aligning with other RHOAI workloads.
+func resolveGPUConfig(gpu *api.GPUConfig) (resource string, count int) {
+	if gpu == nil || gpu.Count <= 0 {
+		return "", 0
+	}
+	r := strings.TrimSpace(gpu.Resource)
+	if r == "" {
+		r = defaultGPUResource
+	}
+	return r, gpu.Count
 }
 
 func defaultIfEmpty(value string, fallback string) string {

--- a/internal/eval_hub/runtimes/k8s/job_config.go
+++ b/internal/eval_hub/runtimes/k8s/job_config.go
@@ -32,9 +32,6 @@ const (
 	serviceCAConfigMapSuffix    = "-service-ca"
 	defaultTestDataInitCmd = "/app/eval-runtime-init"
 	defaultEvalHubPort     = "8443"
-	// defaultGPUResource is the Kubernetes extended resource name used when a GPUConfig omits
-	// the Resource field. Aligns with NVIDIA GPU naming used by other RHOAI workloads.
-	defaultGPUResource = "nvidia.com/gpu"
 )
 
 type jobConfig struct {
@@ -339,16 +336,13 @@ func resolveNodeSelector(gpu *api.GPUConfig) map[string]string {
 
 // resolveGPUConfig returns the Kubernetes extended resource name and count from a GPUConfig.
 // When gpu is nil or Count is 0, both return values are zero-valued (no GPU scheduled).
-// When Resource is empty the NVIDIA default is used, aligning with other RHOAI workloads.
+// When Resource is empty it is left empty — the caller (buildResources) skips the GPU
+// resource request, leaving node selection to Kueue or cluster defaults.
 func resolveGPUConfig(gpu *api.GPUConfig) (resource string, count int) {
 	if gpu == nil || gpu.Count <= 0 {
 		return "", 0
 	}
-	r := strings.TrimSpace(gpu.Resource)
-	if r == "" {
-		r = defaultGPUResource
-	}
-	return r, gpu.Count
+	return strings.TrimSpace(gpu.Resource), gpu.Count
 }
 
 func defaultIfEmpty(value string, fallback string) string {

--- a/internal/eval_hub/runtimes/k8s/job_config_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_config_test.go
@@ -712,3 +712,190 @@ func TestBuildJobConfigBenchmarkIndexPropagated(t *testing.T) {
 func intPtr(value int) *int {
 	return &value
 }
+
+func TestResolveGPUConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		gpu         *api.GPUConfig
+		wantRes     string
+		wantCount   int
+	}{
+		{
+			name:      "nil gpu config yields no GPU",
+			gpu:       nil,
+			wantRes:   "",
+			wantCount: 0,
+		},
+		{
+			name:      "zero count yields no GPU",
+			gpu:       &api.GPUConfig{Resource: "nvidia.com/gpu", Count: 0},
+			wantRes:   "",
+			wantCount: 0,
+		},
+		{
+			name:      "nvidia gpu with explicit resource",
+			gpu:       &api.GPUConfig{Resource: "nvidia.com/gpu", Count: 2},
+			wantRes:   "nvidia.com/gpu",
+			wantCount: 2,
+		},
+		{
+			name:      "amd gpu with explicit resource",
+			gpu:       &api.GPUConfig{Resource: "amd.com/gpu", Count: 1},
+			wantRes:   "amd.com/gpu",
+			wantCount: 1,
+		},
+		{
+			name:      "empty resource defaults to nvidia.com/gpu",
+			gpu:       &api.GPUConfig{Resource: "", Count: 1},
+			wantRes:   defaultGPUResource,
+			wantCount: 1,
+		},
+		{
+			name:      "whitespace-only resource defaults to nvidia.com/gpu",
+			gpu:       &api.GPUConfig{Resource: "  ", Count: 1},
+			wantRes:   defaultGPUResource,
+			wantCount: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, count := resolveGPUConfig(tc.gpu)
+			if res != tc.wantRes {
+				t.Errorf("resource = %q, want %q", res, tc.wantRes)
+			}
+			if count != tc.wantCount {
+				t.Errorf("count = %d, want %d", count, tc.wantCount)
+			}
+		})
+	}
+}
+
+func TestBuildJobConfigGPU(t *testing.T) {
+	benchmark := api.EvaluationBenchmarkConfig{Ref: api.Ref{ID: "bench-1"}}
+	newEvaluation := func(queue *api.QueueConfig) *api.EvaluationJobResource {
+		return &api.EvaluationJobResource{
+			Resource: api.EvaluationResource{Resource: api.Resource{ID: "job-gpu"}},
+			EvaluationJobConfig: api.EvaluationJobConfig{
+				Model:      api.ModelRef{URL: "http://model", Name: "model"},
+				Benchmarks: []api.EvaluationBenchmarkConfig{benchmark},
+				Queue:      queue,
+			},
+		}
+	}
+	gpuProvider := &api.ProviderResource{
+		Resource: api.Resource{ID: "gpu-provider"},
+		ProviderConfig: api.ProviderConfig{
+			Runtime: &api.Runtime{
+				K8s: &api.K8sRuntime{
+					Image: "adapter:latest",
+					GPU: &api.GPUConfig{
+						Resource:     "nvidia.com/gpu",
+						Count:        2,
+						NodeSelector: map[string]string{"nvidia.com/gpu.product": "NVIDIA-H100-SXM5-80GB"},
+					},
+				},
+			},
+		},
+	}
+	cpuProvider := &api.ProviderResource{
+		Resource: api.Resource{ID: "cpu-provider"},
+		ProviderConfig: api.ProviderConfig{
+			Runtime: &api.Runtime{
+				K8s: &api.K8sRuntime{Image: "adapter:latest"},
+			},
+		},
+	}
+
+	t.Run("gpu config and node_selector propagated when no queue", func(t *testing.T) {
+		cfg, err := buildJobConfig(newEvaluation(nil), gpuProvider, &benchmark, 0, nil)
+		if err != nil {
+			t.Fatalf("buildJobConfig: %v", err)
+		}
+		if cfg.gpuResource != "nvidia.com/gpu" {
+			t.Errorf("gpuResource = %q, want nvidia.com/gpu", cfg.gpuResource)
+		}
+		if cfg.gpuCount != 2 {
+			t.Errorf("gpuCount = %d, want 2", cfg.gpuCount)
+		}
+		if cfg.nodeSelector["nvidia.com/gpu.product"] != "NVIDIA-H100-SXM5-80GB" {
+			t.Errorf("nodeSelector = %v, want H100 label", cfg.nodeSelector)
+		}
+	})
+
+	t.Run("node_selector suppressed when queue is set but GPU resources remain", func(t *testing.T) {
+		q := &api.QueueConfig{Kind: "kueue", Name: "gpu-queue"}
+		cfg, err := buildJobConfig(newEvaluation(q), gpuProvider, &benchmark, 0, nil)
+		if err != nil {
+			t.Fatalf("buildJobConfig: %v", err)
+		}
+		// GPU resource requests must be preserved so Kueue can account for GPU quota.
+		if cfg.gpuResource != "nvidia.com/gpu" {
+			t.Errorf("gpuResource = %q, want nvidia.com/gpu (GPU must be set even with queue)", cfg.gpuResource)
+		}
+		if cfg.gpuCount != 2 {
+			t.Errorf("gpuCount = %d, want 2 (GPU must be set even with queue)", cfg.gpuCount)
+		}
+		// nodeSelector must be suppressed — Kueue ResourceFlavors govern node selection.
+		if len(cfg.nodeSelector) != 0 {
+			t.Errorf("expected no nodeSelector when queue set, got %v", cfg.nodeSelector)
+		}
+		if cfg.queueName != "gpu-queue" {
+			t.Errorf("queueName = %q, want gpu-queue", cfg.queueName)
+		}
+	})
+
+	t.Run("nil gpu config leaves jobConfig without GPU", func(t *testing.T) {
+		cfg, err := buildJobConfig(newEvaluation(nil), cpuProvider, &benchmark, 0, nil)
+		if err != nil {
+			t.Fatalf("buildJobConfig: %v", err)
+		}
+		if cfg.gpuResource != "" || cfg.gpuCount != 0 {
+			t.Errorf("expected no GPU for CPU-only provider, got resource=%q count=%d", cfg.gpuResource, cfg.gpuCount)
+		}
+		if len(cfg.nodeSelector) != 0 {
+			t.Errorf("expected no nodeSelector for CPU-only provider, got %v", cfg.nodeSelector)
+		}
+	})
+}
+
+func TestResolveNodeSelector(t *testing.T) {
+	tests := []struct {
+		name string
+		gpu  *api.GPUConfig
+		want map[string]string
+	}{
+		{
+			name: "nil gpu returns nil",
+			gpu:  nil,
+			want: nil,
+		},
+		{
+			name: "empty node_selector returns nil",
+			gpu:  &api.GPUConfig{Count: 1},
+			want: nil,
+		},
+		{
+			name: "node_selector copied",
+			gpu:  &api.GPUConfig{Count: 1, NodeSelector: map[string]string{"nvidia.com/gpu.product": "NVIDIA-H100-SXM5-80GB"}},
+			want: map[string]string{"nvidia.com/gpu.product": "NVIDIA-H100-SXM5-80GB"},
+		},
+		{
+			name: "multiple labels copied",
+			gpu:  &api.GPUConfig{Count: 1, NodeSelector: map[string]string{"k1": "v1", "k2": "v2"}},
+			want: map[string]string{"k1": "v1", "k2": "v2"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveNodeSelector(tc.gpu)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("key %q: got %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/internal/eval_hub/runtimes/k8s/job_config_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_config_test.go
@@ -745,15 +745,15 @@ func TestResolveGPUConfig(t *testing.T) {
 			wantCount: 1,
 		},
 		{
-			name:      "empty resource defaults to nvidia.com/gpu",
+			name:      "empty resource leaves resource empty",
 			gpu:       &api.GPUConfig{Resource: "", Count: 1},
-			wantRes:   defaultGPUResource,
+			wantRes:   "",
 			wantCount: 1,
 		},
 		{
-			name:      "whitespace-only resource defaults to nvidia.com/gpu",
+			name:      "whitespace-only resource leaves resource empty",
 			gpu:       &api.GPUConfig{Resource: "  ", Count: 1},
-			wantRes:   defaultGPUResource,
+			wantRes:   "",
 			wantCount: 1,
 		},
 	}

--- a/pkg/api/providers.go
+++ b/pkg/api/providers.go
@@ -35,7 +35,8 @@ type Runtime struct {
 
 // GPUConfig declares the GPU resources required by an adapter.
 // Resource is the Kubernetes extended resource name (e.g. "nvidia.com/gpu", "amd.com/gpu").
-// When Resource is omitted it defaults to "nvidia.com/gpu".
+// When Resource is omitted, no specific GPU resource is requested in the pod spec —
+// node selection is left to Kueue ResourceFlavors or cluster defaults.
 // Count is the number of GPU units to request; must be ≥ 1 when GPU is specified.
 //
 // Kubernetes requires requests == limits for GPU extended resources, so both are set to Count.
@@ -64,7 +65,7 @@ type GPUConfig struct {
 //	  cpu_limit: "1"
 //	  memory_limit: "2Gi"
 //	  gpu:
-//	    resource: nvidia.com/gpu         # defaults to nvidia.com/gpu when omitted
+//	    resource: nvidia.com/gpu         # omit to leave GPU resource unspecified (any GPU)
 //	    count: 1
 //	    node_selector:                   # optional; ignored when a queue is specified
 //	      nvidia.com/gpu.product: NVIDIA-H100-SXM5-80GB

--- a/pkg/api/providers.go
+++ b/pkg/api/providers.go
@@ -33,6 +33,24 @@ type Runtime struct {
 	Local *LocalRuntime `mapstructure:"local" yaml:"local" json:"local,omitempty"`
 }
 
+// GPUConfig declares the GPU resources required by an adapter.
+// Resource is the Kubernetes extended resource name (e.g. "nvidia.com/gpu", "amd.com/gpu").
+// When Resource is omitted it defaults to "nvidia.com/gpu".
+// Count is the number of GPU units to request; must be ≥ 1 when GPU is specified.
+//
+// Kubernetes requires requests == limits for GPU extended resources, so both are set to Count.
+// When GPU is nil or Count is 0 the adapter is scheduled as CPU-only.
+//
+// NodeSelector is an optional map of node label key→value pairs added to the evaluation pod
+// to target a specific GPU model or node pool (e.g. {"nvidia.com/gpu.product": "NVIDIA-H100-SXM5-80GB"}).
+// NodeSelector is ignored when the evaluation job is submitted with a queue — in that case
+// Kueue's ResourceFlavors govern node selection.
+type GPUConfig struct {
+	Resource     string            `mapstructure:"resource" yaml:"resource" json:"resource,omitempty"`
+	Count        int               `mapstructure:"count" yaml:"count" json:"count"`
+	NodeSelector map[string]string `mapstructure:"node_selector" yaml:"node_selector" json:"node_selector,omitempty"`
+}
+
 // ProviderRuntime contains runtime configuration for Kubernetes jobs.
 //
 // Example YAML for provider configs:
@@ -45,17 +63,25 @@ type Runtime struct {
 //	  memory_request: "512Mi"
 //	  cpu_limit: "1"
 //	  memory_limit: "2Gi"
+//	  gpu:
+//	    resource: nvidia.com/gpu         # defaults to nvidia.com/gpu when omitted
+//	    count: 1
+//	    node_selector:                   # optional; ignored when a queue is specified
+//	      nvidia.com/gpu.product: NVIDIA-H100-SXM5-80GB
 //	  default_env:
 //	    - name: FOO
 //	      value: "bar"
 type K8sRuntime struct {
-	Image         string   `mapstructure:"image" yaml:"image"`
-	Entrypoint    []string `mapstructure:"entrypoint" yaml:"entrypoint"`
-	CPURequest    string   `mapstructure:"cpu_request" yaml:"cpu_request"`
-	MemoryRequest string   `mapstructure:"memory_request" yaml:"memory_request"`
-	CPULimit      string   `mapstructure:"cpu_limit" yaml:"cpu_limit"`
-	MemoryLimit   string   `mapstructure:"memory_limit" yaml:"memory_limit"`
-	Env           []EnvVar `mapstructure:"env" yaml:"env"`
+	Image         string     `mapstructure:"image" yaml:"image"`
+	Entrypoint    []string   `mapstructure:"entrypoint" yaml:"entrypoint"`
+	CPURequest    string     `mapstructure:"cpu_request" yaml:"cpu_request"`
+	MemoryRequest string     `mapstructure:"memory_request" yaml:"memory_request"`
+	CPULimit      string     `mapstructure:"cpu_limit" yaml:"cpu_limit"`
+	MemoryLimit   string     `mapstructure:"memory_limit" yaml:"memory_limit"`
+	// GPU declares the GPU resource requirement for this adapter. Omit entirely for CPU-only
+	// adapters — existing adapters are unaffected.
+	GPU *GPUConfig `mapstructure:"gpu" yaml:"gpu" json:"gpu,omitempty"`
+	Env []EnvVar   `mapstructure:"env" yaml:"env"`
 }
 
 type LocalRuntime struct {


### PR DESCRIPTION
Related to https://redhat.atlassian.net/browse/RHAIRFE-2171

Adapters can now declare GPU requirements in provider YAML via a new `gpu` block under `runtime.k8s`:

  gpu:
    resource: nvidia.com/gpu   # defaults to nvidia.com/gpu when omitted
    count: 1
    node_selector:             # optional; ignored when a queue is specified
      nvidia.com/gpu.product: NVIDIA-H100-SXM5-80GB

The K8s runtime propagates GPU requests/limits to evaluation pods (K8s requires requests == limits for extended resources). When a Kueue queue is specified, GPU resource requests are kept so Kueue can account for GPU quota, but nodeSelector is omitted — Kueue ResourceFlavors govern node selection at admission time.

Also adds MESSAGE_CODE_GPU_UNAVAILABLE for use by the operator-side Kueue workload reconciler when surfacing GPU quota exhaustion errors.

## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes #

Assisted-by: <!-- Cursor, Claude etc -->

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->
