### PR TITLE
feat(evalhub-mcp): configurable default list page size for eval-hub APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,7 @@ go test -v ./cmd/evalhub_mcp/ ./internal/evalhub_mcp/...
 
 **CLI flags:** `--transport stdio|http`, `--host`, `--port`, `--config`, `--insecure`, `--version`
 
-**Configuration precedence:** CLI flags > YAML config (`~/.evalhub/config.yaml`) > env vars (`EVALHUB_BASE_URL`, `EVALHUB_TOKEN`, `EVALHUB_TENANT`, `EVALHUB_INSECURE`)
+**Configuration precedence:** CLI flags > YAML config (`~/.evalhub/config.yaml`) > env vars (`EVALHUB_BASE_URL`, `EVALHUB_TOKEN`, `EVALHUB_TENANT`, `EVALHUB_INSECURE`, `EVALHUB_LIST_PAGE_LIMIT`)
 
 **Architecture:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,7 @@ go test -v ./cmd/evalhub_mcp/ ./internal/evalhub_mcp/...
 
 **CLI flags:** `--transport stdio|http`, `--host`, `--port`, `--config`, `--insecure`, `--version`
 
-**Configuration precedence:** CLI flags > YAML config (`~/.evalhub/config.yaml`) > env vars (`EVALHUB_BASE_URL`, `EVALHUB_TOKEN`, `EVALHUB_TENANT`, `EVALHUB_INSECURE`, `EVALHUB_LIST_PAGE_LIMIT`)
+**Configuration precedence:** CLI flags > env vars (`EVALHUB_BASE_URL`, `EVALHUB_TOKEN`, `EVALHUB_TENANT`, `EVALHUB_INSECURE`, `EVALHUB_LIST_PAGE_LIMIT`) > YAML config (`~/.evalhub/config.yaml`)
 
 **Architecture:**
 

--- a/internal/evalhub_mcp/config/config.go
+++ b/internal/evalhub_mcp/config/config.go
@@ -7,18 +7,20 @@ import (
 	"path/filepath"
 
 	"github.com/eval-hub/eval-hub/internal/logging"
+	"github.com/eval-hub/eval-hub/pkg/evalhubclient"
 	"github.com/go-playground/validator/v10"
 	"github.com/spf13/viper"
 )
 
 type Config struct {
-	BaseURL   string `mapstructure:"base_url,omitempty" validate:"omitempty,url"`
-	Token     string `mapstructure:"token"`
-	Tenant    string `mapstructure:"tenant"`
-	Insecure  bool   `mapstructure:"insecure"`
-	Transport string `mapstructure:"transport" validate:"required,oneof=stdio http"`
-	Host      string `mapstructure:"host"      validate:"required"`
-	Port      int    `mapstructure:"port,omitempty" validate:"omitempty,min=1,max=65535"`
+	BaseURL       string `mapstructure:"base_url,omitempty" validate:"omitempty,url"`
+	Token         string `mapstructure:"token"`
+	Tenant        string `mapstructure:"tenant"`
+	Insecure      bool   `mapstructure:"insecure"`
+	Transport     string `mapstructure:"transport" validate:"required,oneof=stdio http"`
+	Host          string `mapstructure:"host"      validate:"required"`
+	Port          int    `mapstructure:"port,omitempty" validate:"omitempty,min=1,max=65535"`
+	ListPageLimit int    `mapstructure:"list_page_limit,omitempty" validate:"omitempty,min=1,max=2000"`
 }
 
 type Flags struct {
@@ -31,9 +33,10 @@ type Flags struct {
 
 func DefaultConfig() *Config {
 	return &Config{
-		Transport: "stdio",
-		Host:      "localhost",
-		Port:      3001,
+		Transport:     "stdio",
+		Host:          "localhost",
+		Port:          3001,
+		ListPageLimit: evalhubclient.DefaultListPageLimit,
 	}
 }
 
@@ -55,6 +58,8 @@ func Load(flags *Flags, logger *slog.Logger) (*Config, error) {
 		applyFlags(conf, flags)
 	}
 
+	normalizeListPageLimit(conf)
+
 	if logger != nil {
 		logger.Info("Loaded configuration", "config", logging.AsPrettyJson(conf, "token"), "config_path", configPath)
 	}
@@ -62,8 +67,18 @@ func Load(flags *Flags, logger *slog.Logger) (*Config, error) {
 	return conf, nil
 }
 
+func normalizeListPageLimit(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	if cfg.ListPageLimit == 0 {
+		cfg.ListPageLimit = evalhubclient.DefaultListPageLimit
+	}
+}
+
 // Validate checks the Config using go-playground/validator struct tags.
 func Validate(cfg *Config) error {
+	normalizeListPageLimit(cfg)
 	validate := validator.New(validator.WithRequiredStructEnabled())
 
 	if err := validate.Struct(cfg); err != nil {
@@ -98,6 +113,7 @@ func applyYAMLConfig(cfg *Config, path string) (*Config, error) {
 		"transport", "EVALHUB_TRANSPORT",
 		"host", "EVALHUB_HOST",
 		"port", "EVALHUB_PORT",
+		"list_page_limit", "EVALHUB_LIST_PAGE_LIMIT",
 	)
 	if err != nil {
 		return nil, err
@@ -111,6 +127,7 @@ func applyYAMLConfig(cfg *Config, path string) (*Config, error) {
 		v.SetDefault("transport", cfg.Transport)
 		v.SetDefault("host", cfg.Host)
 		v.SetDefault("port", cfg.Port)
+		v.SetDefault("list_page_limit", cfg.ListPageLimit)
 	}
 
 	if path == "" {

--- a/internal/evalhub_mcp/config/config_test.go
+++ b/internal/evalhub_mcp/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/eval-hub/eval-hub/pkg/evalhubclient"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -31,6 +33,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Insecure {
 		t.Error("expected default insecure to be false")
 	}
+	if cfg.ListPageLimit != evalhubclient.DefaultListPageLimit {
+		t.Errorf("expected default list_page_limit %d, got %d", evalhubclient.DefaultListPageLimit, cfg.ListPageLimit)
+	}
 }
 
 func TestLoadNoConfig(t *testing.T) {
@@ -43,6 +48,9 @@ func TestLoadNoConfig(t *testing.T) {
 	}
 	if cfg.Transport != "stdio" {
 		t.Errorf("expected transport \"stdio\", got %q", cfg.Transport)
+	}
+	if cfg.ListPageLimit != evalhubclient.DefaultListPageLimit {
+		t.Errorf("expected list_page_limit %d, got %d", evalhubclient.DefaultListPageLimit, cfg.ListPageLimit)
 	}
 }
 
@@ -71,6 +79,20 @@ func TestLoadEnvVars(t *testing.T) {
 	}
 	if !cfg.Insecure {
 		t.Error("expected insecure=true from env")
+	}
+}
+
+func TestLoadEnvListPageLimit(t *testing.T) {
+	clearEnv(t)
+	defer clearEnv(t)
+	t.Setenv("EVALHUB_LIST_PAGE_LIMIT", "99")
+
+	cfg, err := Load(nil, nil)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ListPageLimit != 99 {
+		t.Errorf("ListPageLimit = %d, want 99", cfg.ListPageLimit)
 	}
 }
 
@@ -275,6 +297,31 @@ func TestValidateStdioIgnoresPort(t *testing.T) {
 	}
 }
 
+func TestValidateListPageLimit(t *testing.T) {
+	t.Parallel()
+	t.Run("too large fails", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{Transport: "stdio", Host: "localhost", ListPageLimit: 5000}
+		if err := Validate(cfg); err == nil {
+			t.Fatal("expected validation error for list_page_limit > 2000")
+		}
+	})
+	t.Run("negative fails", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{Transport: "stdio", Host: "localhost", ListPageLimit: -1}
+		if err := Validate(cfg); err == nil {
+			t.Fatal("expected validation error for negative list_page_limit")
+		}
+	})
+	t.Run("valid custom passes", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{Transport: "stdio", Host: "localhost", ListPageLimit: 400}
+		if err := Validate(cfg); err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+	})
+}
+
 func TestValidateBaseURL(t *testing.T) {
 	t.Parallel()
 	t.Run("valid URL passes", func(t *testing.T) {
@@ -432,7 +479,7 @@ func TestLoadConfigFile(t *testing.T) {
 
 func clearEnv(t *testing.T) {
 	t.Helper()
-	for _, key := range []string{"EVALHUB_BASE_URL", "EVALHUB_TOKEN", "EVALHUB_TENANT", "EVALHUB_INSECURE"} {
+	for _, key := range []string{"EVALHUB_BASE_URL", "EVALHUB_TOKEN", "EVALHUB_TENANT", "EVALHUB_INSECURE", "EVALHUB_LIST_PAGE_LIMIT"} {
 		t.Setenv(key, "")
 	}
 }

--- a/internal/evalhub_mcp/server/completions.go
+++ b/internal/evalhub_mcp/server/completions.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/eval-hub/eval-hub/pkg/evalhubclient"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -62,16 +63,18 @@ func (c *completionCache) set(key string, values []string) {
 }
 
 type completionProvider struct {
-	ds     EvalHubDiscovery
-	cache  *completionCache
-	logger *slog.Logger
+	ds            EvalHubDiscovery
+	cache         *completionCache
+	logger        *slog.Logger
+	listPageLimit int
 }
 
-func newCompletionProvider(ds EvalHubDiscovery, logger *slog.Logger) *completionProvider {
+func newCompletionProvider(ds EvalHubDiscovery, logger *slog.Logger, listPageLimit int) *completionProvider {
 	return &completionProvider{
-		ds:     ds,
-		cache:  newCompletionCache(defaultCacheTTL),
-		logger: logger,
+		ds:            ds,
+		cache:         newCompletionCache(defaultCacheTTL),
+		logger:        logger,
+		listPageLimit: listPageLimit,
 	}
 }
 
@@ -131,7 +134,7 @@ func (cp *completionProvider) cachedFetch(key string, fetch func() []string) []s
 }
 
 func (cp *completionProvider) fetchProviderIDs() []string {
-	list, err := cp.ds.ListProviders()
+	list, err := cp.ds.ListProviders(evalhubclient.WithLimit(cp.listPageLimit))
 	if err != nil {
 		cp.logger.Warn("completion: failed to list providers", "error", err)
 		return nil
@@ -157,7 +160,7 @@ func (cp *completionProvider) fetchBenchmarkIDs() []string {
 }
 
 func (cp *completionProvider) fetchCollectionIDs() []string {
-	list, err := cp.ds.ListCollections()
+	list, err := cp.ds.ListCollections(evalhubclient.WithLimit(cp.listPageLimit))
 	if err != nil {
 		cp.logger.Warn("completion: failed to list collections", "error", err)
 		return nil
@@ -170,7 +173,7 @@ func (cp *completionProvider) fetchCollectionIDs() []string {
 }
 
 func (cp *completionProvider) fetchJobIDs() []string {
-	list, err := cp.ds.ListJobs()
+	list, err := cp.ds.ListJobs(evalhubclient.WithLimit(cp.listPageLimit))
 	if err != nil {
 		cp.logger.Warn("completion: failed to list jobs", "error", err)
 		return nil

--- a/internal/evalhub_mcp/server/completions_test.go
+++ b/internal/evalhub_mcp/server/completions_test.go
@@ -17,8 +17,8 @@ import (
 func connectWithCompletions(t *testing.T, ds EvalHubDiscovery) (context.Context, *mcp.ClientSession) {
 	t.Helper()
 
-	srv := New(&ServerInfo{Version: "test"}, discardLogger, CompletionHandlerOption(ds, discardLogger))
-	registerResources(srv, ds, discardLogger)
+	srv := New(&ServerInfo{Version: "test"}, discardLogger, CompletionHandlerOption(ds, discardLogger, evalhubclient.DefaultListPageLimit))
+	registerResources(srv, ds, discardLogger, evalhubclient.DefaultListPageLimit)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
@@ -278,7 +278,7 @@ func TestCompletionCacheExpiry(t *testing.T) {
 	t.Parallel()
 
 	ds := &callCountDataSource{inner: testDataSource()}
-	cp := newCompletionProvider(ds, discardLogger)
+	cp := newCompletionProvider(ds, discardLogger, evalhubclient.DefaultListPageLimit)
 
 	now := time.Now()
 	cp.cache.now = func() time.Time { return now }
@@ -352,7 +352,7 @@ func TestCompletionAPIErrorNotCached(t *testing.T) {
 			}, nil
 		},
 	}
-	cp := newCompletionProvider(ds, discardLogger)
+	cp := newCompletionProvider(ds, discardLogger, evalhubclient.DefaultListPageLimit)
 
 	got := cp.resolveValues("evalhub://providers/{id}", "id")
 	if len(got) != 0 {

--- a/internal/evalhub_mcp/server/prompts_test.go
+++ b/internal/evalhub_mcp/server/prompts_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eval-hub/eval-hub/pkg/evalhubclient"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -459,7 +460,7 @@ func TestRegisterHandlersIncludesPromptsWithoutBackend(t *testing.T) {
 	info := &ServerInfo{Version: "test"}
 	srv := New(info, discardLogger, nil)
 
-	if err := RegisterHandlers(srv, nil, info, discardLogger); err != nil {
+	if err := RegisterHandlers(srv, nil, info, discardLogger, evalhubclient.DefaultListPageLimit); err != nil {
 		t.Fatalf("RegisterHandlers: %v", err)
 	}
 
@@ -483,7 +484,7 @@ func TestRegisterHandlersPromptsUnavailableWithoutBackend(t *testing.T) {
 	info := &ServerInfo{Version: "test"}
 	srv := New(info, discardLogger, nil)
 
-	if err := RegisterHandlers(srv, nil, info, discardLogger); err != nil {
+	if err := RegisterHandlers(srv, nil, info, discardLogger, evalhubclient.DefaultListPageLimit); err != nil {
 		t.Fatalf("RegisterHandlers: %v", err)
 	}
 

--- a/internal/evalhub_mcp/server/resource_uri_helpers_test.go
+++ b/internal/evalhub_mcp/server/resource_uri_helpers_test.go
@@ -193,6 +193,46 @@ func TestExtractPagination(t *testing.T) {
 	}
 }
 
+func TestListOptsFromResourceURI(t *testing.T) {
+	t.Parallel()
+	t.Run("uses default when limit absent", func(t *testing.T) {
+		t.Parallel()
+		opts, err := listOptsFromResourceURI("evalhub://collections", 42)
+		if err != nil {
+			t.Fatalf("listOptsFromResourceURI: %v", err)
+		}
+		v := collectPaginationParams(opts)
+		if g, w := v.Get("limit"), "42"; g != w {
+			t.Fatalf("limit = %q, want %q", g, w)
+		}
+	})
+	t.Run("keeps uri limit", func(t *testing.T) {
+		t.Parallel()
+		opts, err := listOptsFromResourceURI("evalhub://collections?limit=9", 42)
+		if err != nil {
+			t.Fatalf("listOptsFromResourceURI: %v", err)
+		}
+		v := collectPaginationParams(opts)
+		if g, w := v.Get("limit"), "9"; g != w {
+			t.Fatalf("limit = %q, want %q", g, w)
+		}
+	})
+	t.Run("default with offset", func(t *testing.T) {
+		t.Parallel()
+		opts, err := listOptsFromResourceURI("evalhub://jobs?offset=3", 100)
+		if err != nil {
+			t.Fatalf("listOptsFromResourceURI: %v", err)
+		}
+		v := collectPaginationParams(opts)
+		if g, w := v.Get("limit"), "100"; g != w {
+			t.Fatalf("limit = %q, want %q", g, w)
+		}
+		if g, w := v.Get("offset"), "3"; g != w {
+			t.Fatalf("offset = %q, want %q", g, w)
+		}
+	})
+}
+
 func TestEmptyResult(t *testing.T) {
 	t.Parallel()
 	r := emptyResult()

--- a/internal/evalhub_mcp/server/resources.go
+++ b/internal/evalhub_mcp/server/resources.go
@@ -31,7 +31,7 @@ type EvalHubDiscovery interface {
 	ListJobsByStatus(status api.OverallState, opts ...evalhubclient.ListOption) (*api.EvaluationJobResourceList, error)
 }
 
-func registerResources(srv *mcp.Server, ds EvalHubDiscovery, logger *slog.Logger) {
+func registerResources(srv *mcp.Server, ds EvalHubDiscovery, logger *slog.Logger, listPageLimit int) {
 	benchmarksHandler := listBenchmarksHandler(ds, logger)
 
 	srv.AddResource(&mcp.Resource{
@@ -39,7 +39,7 @@ func registerResources(srv *mcp.Server, ds EvalHubDiscovery, logger *slog.Logger
 		Description: "List all evaluation providers",
 		MIMEType:    "application/json",
 		URI:         "evalhub://providers",
-	}, listProvidersHandler(ds, logger))
+	}, listProvidersHandler(ds, logger, listPageLimit))
 
 	srv.AddResourceTemplate(&mcp.ResourceTemplate{
 		Name:        "provider",
@@ -74,7 +74,7 @@ func registerResources(srv *mcp.Server, ds EvalHubDiscovery, logger *slog.Logger
 		Description: "List all benchmark collections",
 		MIMEType:    "application/json",
 		URI:         "evalhub://collections",
-	}, listCollectionsHandler(ds, logger))
+	}, listCollectionsHandler(ds, logger, listPageLimit))
 
 	srv.AddResourceTemplate(&mcp.ResourceTemplate{
 		Name:        "collection",
@@ -83,7 +83,7 @@ func registerResources(srv *mcp.Server, ds EvalHubDiscovery, logger *slog.Logger
 		URITemplate: "evalhub://collections/{id}",
 	}, getCollectionHandler(ds, logger))
 
-	jobsHandler := listJobsHandler(ds, logger)
+	jobsHandler := listJobsHandler(ds, logger, listPageLimit)
 
 	srv.AddResource(&mcp.Resource{
 		Name:        "jobs",
@@ -107,10 +107,10 @@ func registerResources(srv *mcp.Server, ds EvalHubDiscovery, logger *slog.Logger
 	}, getJobHandler(ds, logger))
 }
 
-func listProvidersHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceHandler {
+func listProvidersHandler(ds EvalHubDiscovery, logger *slog.Logger, defaultLimit int) mcp.ResourceHandler {
 	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		logger.Debug("reading resource", "uri", req.Params.URI)
-		list, err := ds.ListProviders()
+		list, err := ds.ListProviders(evalhubclient.WithLimit(defaultLimit))
 		if err != nil {
 			return nil, fmt.Errorf("listing providers: %w", err)
 		}
@@ -174,10 +174,10 @@ func getBenchmarkHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceH
 	}
 }
 
-func listCollectionsHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceHandler {
+func listCollectionsHandler(ds EvalHubDiscovery, logger *slog.Logger, defaultLimit int) mcp.ResourceHandler {
 	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		logger.Debug("reading resource", "uri", req.Params.URI)
-		opts, err := extractPagination(req.Params.URI)
+		opts, err := listOptsFromResourceURI(req.Params.URI, defaultLimit)
 		if err != nil {
 			return nil, err
 		}
@@ -208,14 +208,14 @@ func getCollectionHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.Resource
 	}
 }
 
-func listJobsHandler(ds EvalHubDiscovery, logger *slog.Logger) mcp.ResourceHandler {
+func listJobsHandler(ds EvalHubDiscovery, logger *slog.Logger, defaultLimit int) mcp.ResourceHandler {
 	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		logger.Debug("reading resource", "uri", req.Params.URI)
 		status, hasStatus, err := extractStatus(req.Params.URI)
 		if err != nil {
 			return nil, err
 		}
-		opts, pErr := extractPagination(req.Params.URI)
+		opts, pErr := listOptsFromResourceURI(req.Params.URI, defaultLimit)
 		if pErr != nil {
 			return nil, pErr
 		}
@@ -317,6 +317,27 @@ func extractPagination(rawURI string) ([]evalhubclient.ListOption, error) {
 		}
 	}
 	return opts, nil
+}
+
+// listOptsFromResourceURI returns list options from the resource URI, applying
+// defaultLimit when the URI does not set an explicit "limit" query parameter.
+func listOptsFromResourceURI(rawURI string, defaultLimit int) ([]evalhubclient.ListOption, error) {
+	opts, err := extractPagination(rawURI)
+	if err != nil {
+		return nil, err
+	}
+	if uriQueryHasLimit(rawURI) {
+		return opts, nil
+	}
+	return append([]evalhubclient.ListOption{evalhubclient.WithLimit(defaultLimit)}, opts...), nil
+}
+
+func uriQueryHasLimit(rawURI string) bool {
+	u, err := url.Parse(rawURI)
+	if err != nil {
+		return false
+	}
+	return u.Query().Get("limit") != ""
 }
 
 func toMCPError(uri string, err error) error {

--- a/internal/evalhub_mcp/server/resources_test.go
+++ b/internal/evalhub_mcp/server/resources_test.go
@@ -232,7 +232,7 @@ func connectWithResources(t *testing.T, ds EvalHubDiscovery) (context.Context, *
 	t.Helper()
 
 	srv := New(&ServerInfo{Version: "test"}, discardLogger, nil)
-	registerResources(srv, ds, discardLogger)
+	registerResources(srv, ds, discardLogger, evalhubclient.DefaultListPageLimit)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
@@ -694,7 +694,7 @@ func TestRegisterHandlersNilClient(t *testing.T) {
 	t.Parallel()
 	info := &ServerInfo{Version: "test"}
 	srv := New(info, discardLogger, nil)
-	if err := RegisterHandlers(srv, nil, info, discardLogger); err != nil {
+	if err := RegisterHandlers(srv, nil, info, discardLogger, evalhubclient.DefaultListPageLimit); err != nil {
 		t.Fatalf("RegisterHandlers: %v", err)
 	}
 

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -74,7 +74,7 @@ func NewEvalHubClient(cfg *config.Config, logger *slog.Logger) *evalhubclient.Cl
 	if cfg.BaseURL == "" {
 		return nil
 	}
-	client := evalhubclient.NewClient(cfg.BaseURL).WithLogger(logger)
+	client := evalhubclient.NewClient(cfg.BaseURL).WithListPageLimit(cfg.ListPageLimit).WithLogger(logger)
 	if cfg.Token != "" {
 		client = client.WithToken(cfg.Token)
 	}
@@ -89,17 +89,17 @@ func NewEvalHubClient(cfg *config.Config, logger *slog.Logger) *evalhubclient.Cl
 }
 
 // RegisterHandlers wires tool, resource, and prompt handlers into the MCP
-// server. The server version resource is always registered. The EvalHub client
-// is captured by handler closures so that every handler has access to the API
-// without global state.
-func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, info *ServerInfo, logger *slog.Logger) error {
+// server. listPageLimit is the default maximum number of items requested from
+// eval-hub list endpoints (providers, collections, jobs, and completion caches);
+// resource URIs may still set an explicit "limit" query parameter for collections and jobs.
+func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, info *ServerInfo, logger *slog.Logger, listPageLimit int) error {
 	registerVersionResource(srv, info, logger)
 	// should we error if no client is provided?
 	if client != nil {
 		if err := registerPrompts(srv, logger); err != nil {
 			return err
 		}
-		registerResources(srv, client, logger)
+		registerResources(srv, client, logger, listPageLimit)
 		registerTools(srv, client, logger)
 	}
 	return nil
@@ -107,11 +107,11 @@ func RegisterHandlers(srv *mcp.Server, client *evalhubclient.Client, info *Serve
 
 // CompletionHandlerOption returns a ServerOption that installs a completion handler
 // backed by the given data source. Returns nil when ds is nil.
-func CompletionHandlerOption(ds EvalHubDiscovery, logger *slog.Logger) *ServerOption {
+func CompletionHandlerOption(ds EvalHubDiscovery, logger *slog.Logger, listPageLimit int) *ServerOption {
 	if ds == nil {
 		return nil
 	}
-	cp := newCompletionProvider(ds, logger)
+	cp := newCompletionProvider(ds, logger, listPageLimit)
 	return &ServerOption{applyFn: func(opts *mcp.ServerOptions) {
 		opts.CompletionHandler = cp.handle
 	}}
@@ -119,8 +119,8 @@ func CompletionHandlerOption(ds EvalHubDiscovery, logger *slog.Logger) *ServerOp
 
 func Run(ctx context.Context, cfg *config.Config, info *ServerInfo, logger *slog.Logger) error {
 	client := NewEvalHubClient(cfg, logger)
-	srv := New(info, logger, CompletionHandlerOption(client, logger))
-	if err := RegisterHandlers(srv, client, info, logger); err != nil {
+	srv := New(info, logger, CompletionHandlerOption(client, logger, cfg.ListPageLimit))
+	if err := RegisterHandlers(srv, client, info, logger, cfg.ListPageLimit); err != nil {
 		return err
 	}
 

--- a/internal/evalhub_mcp/server/tools_test.go
+++ b/internal/evalhub_mcp/server/tools_test.go
@@ -565,7 +565,7 @@ func TestRegisterHandlersWithNilClientHasNoTools(t *testing.T) {
 	info := &ServerInfo{Version: "test"}
 	srv := New(info, discardLogger, nil)
 
-	if err := RegisterHandlers(srv, nil, info, discardLogger); err != nil {
+	if err := RegisterHandlers(srv, nil, info, discardLogger, evalhubclient.DefaultListPageLimit); err != nil {
 		t.Fatalf("RegisterHandlers: %v", err)
 	}
 

--- a/internal/evalhub_mcp/server/version_resource_test.go
+++ b/internal/evalhub_mcp/server/version_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eval-hub/eval-hub/pkg/evalhubclient"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -130,7 +131,7 @@ func TestVersionResourceAvailableWithoutBackend(t *testing.T) {
 
 	info := &ServerInfo{Version: "0.1.0"}
 	srv := New(info, discardLogger, nil)
-	if err := RegisterHandlers(srv, nil, info, discardLogger); err != nil {
+	if err := RegisterHandlers(srv, nil, info, discardLogger, evalhubclient.DefaultListPageLimit); err != nil {
 		t.Fatalf("RegisterHandlers: %v", err)
 	}
 

--- a/pkg/evalhubclient/client.go
+++ b/pkg/evalhubclient/client.go
@@ -26,6 +26,10 @@ const (
 
 	// maxLoggedBodyBytes caps JSON logged for request/response bodies (aligned with eval-hub handler visibility).
 	maxLoggedBodyBytes = 8192
+
+	// DefaultListPageLimit is the page size used for eval-hub list APIs when the caller
+	// does not set an explicit limit. evalhub-mcp applies this (configurable via list_page_limit).
+	DefaultListPageLimit = 200
 )
 
 // APIError represents a typed error returned by the eval-hub API.
@@ -63,6 +67,9 @@ type Client struct {
 	logger     *slog.Logger
 	maxRetries int
 	retryDelay time.Duration
+	// listPageLimit is the page size for provider listing when aggregating benchmarks
+	// (see allProviders). Zero means use DefaultListPageLimit.
+	listPageLimit int
 }
 
 // NewClient creates a new eval-hub API client. Trailing slashes in baseURL are stripped.
@@ -84,14 +91,15 @@ func NewClient(baseURL string) *Client {
 // a compile-time update here rather than silently inheriting a zero value.
 func (c *Client) clone() *Client {
 	return &Client{
-		ctx:        c.ctx,
-		baseURL:    c.baseURL,
-		token:      c.token,
-		tenant:     c.tenant,
-		httpClient: c.httpClient,
-		logger:     c.logger,
-		maxRetries: c.maxRetries,
-		retryDelay: c.retryDelay,
+		ctx:           c.ctx,
+		baseURL:       c.baseURL,
+		token:         c.token,
+		tenant:        c.tenant,
+		httpClient:    c.httpClient,
+		logger:        c.logger,
+		maxRetries:    c.maxRetries,
+		retryDelay:    c.retryDelay,
+		listPageLimit: c.listPageLimit,
 	}
 }
 
@@ -176,6 +184,25 @@ func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
 	cp := c.clone()
 	cp.httpClient = httpClient
 	return cp
+}
+
+// WithListPageLimit returns a copy of the client that uses n as the page size when listing
+// providers for benchmark discovery (allProviders). When n < 1, DefaultListPageLimit is used.
+func (c *Client) WithListPageLimit(n int) *Client {
+	cp := c.clone()
+	if n < 1 {
+		cp.listPageLimit = DefaultListPageLimit
+	} else {
+		cp.listPageLimit = n
+	}
+	return cp
+}
+
+func (c *Client) effectiveListPageLimit() int {
+	if c.listPageLimit > 0 {
+		return c.listPageLimit
+	}
+	return DefaultListPageLimit
 }
 
 func truncateBodyForLog(b []byte) string {
@@ -417,7 +444,7 @@ func (c *Client) ListBenchmarksByLabel(labels []string) ([]api.BenchmarkResource
 
 // allProviders fetches every provider page and returns the combined slice.
 func (c *Client) allProviders() ([]api.ProviderResource, error) {
-	const pageSize = 100
+	pageSize := c.effectiveListPageLimit()
 	var all []api.ProviderResource
 	for offset := 0; ; offset += pageSize {
 		list, err := c.ListProviders(WithLimit(pageSize), WithOffset(offset))

--- a/pkg/evalhubclient/client.go
+++ b/pkg/evalhubclient/client.go
@@ -375,6 +375,19 @@ func decode[T any](body []byte) (*T, error) {
 	return &result, nil
 }
 
+func (c *Client) logTruncatedListPage(endpoint string, page api.Page) {
+	if page.Limit <= 0 {
+		return
+	}
+	if page.TotalCount > page.Limit {
+		c.logger.Error("eval-hub list response has more items than returned on this page (total_count > limit); fetch additional pages with offset if needed",
+			"endpoint", endpoint,
+			"total_count", page.TotalCount,
+			"limit", page.Limit,
+		)
+	}
+}
+
 // ─── Health ──────────────────────────────────────────────────────────────────
 
 // GetHealth returns the current health status of the eval-hub service.
@@ -390,11 +403,22 @@ func (c *Client) GetHealth() (*api.HealthResponse, error) {
 
 // ListProviders returns all registered evaluation providers. Use WithLimit/WithOffset for pagination.
 func (c *Client) ListProviders(opts ...ListOption) (*api.ProviderResourceList, error) {
+	return c.fetchProviderList(opts, true)
+}
+
+func (c *Client) fetchProviderList(opts []ListOption, logTruncation bool) (*api.ProviderResourceList, error) {
 	body, _, err := c.doRequest(http.MethodGet, apiBasePath+"/providers", nil, applyListOptions(opts))
 	if err != nil {
 		return nil, err
 	}
-	return decode[api.ProviderResourceList](body)
+	list, err := decode[api.ProviderResourceList](body)
+	if err != nil {
+		return nil, err
+	}
+	if logTruncation {
+		c.logTruncatedListPage(apiBasePath+"/providers", list.Page)
+	}
+	return list, nil
 }
 
 // GetProvider returns the provider with the given ID.
@@ -447,7 +471,7 @@ func (c *Client) allProviders() ([]api.ProviderResource, error) {
 	pageSize := c.effectiveListPageLimit()
 	var all []api.ProviderResource
 	for offset := 0; ; offset += pageSize {
-		list, err := c.ListProviders(WithLimit(pageSize), WithOffset(offset))
+		list, err := c.fetchProviderList([]ListOption{WithLimit(pageSize), WithOffset(offset)}, false)
 		if err != nil {
 			return nil, err
 		}
@@ -500,7 +524,12 @@ func (c *Client) ListCollections(opts ...ListOption) (*api.CollectionResourceLis
 	if err != nil {
 		return nil, err
 	}
-	return decode[api.CollectionResourceList](body)
+	list, err := decode[api.CollectionResourceList](body)
+	if err != nil {
+		return nil, err
+	}
+	c.logTruncatedListPage(apiBasePath+"/collections", list.Page)
+	return list, nil
 }
 
 // GetCollection returns the collection with the given ID.
@@ -520,7 +549,12 @@ func (c *Client) ListJobs(opts ...ListOption) (*api.EvaluationJobResourceList, e
 	if err != nil {
 		return nil, err
 	}
-	return decode[api.EvaluationJobResourceList](body)
+	list, err := decode[api.EvaluationJobResourceList](body)
+	if err != nil {
+		return nil, err
+	}
+	c.logTruncatedListPage(apiBasePath+"/jobs", list.Page)
+	return list, nil
 }
 
 // GetJob returns the evaluation job with the given ID.

--- a/pkg/evalhubclient/client_test.go
+++ b/pkg/evalhubclient/client_test.go
@@ -324,6 +324,81 @@ func TestListBenchmarksUsesListPageLimitForProviderPages(t *testing.T) {
 	}
 }
 
+func TestListProvidersLogsErrorWhenTotalCountExceedsLimit(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	resp := api.ProviderResourceList{
+		Page:  api.Page{TotalCount: 500, Limit: 100},
+		Items: []api.ProviderResource{},
+	}
+	srv, _ := newCapturingServer(t, http.StatusOK, mustMarshal(t, resp))
+
+	_, err := NewClient(srv.URL).WithLogger(logger).ListProviders(WithLimit(100))
+	if err != nil {
+		t.Fatalf("ListProviders: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "total_count") || !strings.Contains(out, "500") || !strings.Contains(out, "100") {
+		t.Fatalf("expected truncation error log with total_count and limit, got: %q", out)
+	}
+}
+
+func TestListProvidersDoesNotLogWhenTotalWithinLimit(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	resp := api.ProviderResourceList{
+		Page:  api.Page{TotalCount: 10, Limit: 200},
+		Items: []api.ProviderResource{},
+	}
+	srv, _ := newCapturingServer(t, http.StatusOK, mustMarshal(t, resp))
+
+	_, err := NewClient(srv.URL).WithLogger(logger).ListProviders(WithLimit(200))
+	if err != nil {
+		t.Fatalf("ListProviders: %v", err)
+	}
+	if strings.TrimSpace(buf.String()) != "" {
+		t.Fatalf("expected no error logs, got %q", buf.String())
+	}
+}
+
+func TestListBenchmarksDoesNotLogTruncationDuringAggregatingPagination(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var body []byte
+		if r.URL.Query().Get("offset") == "" || r.URL.Query().Get("offset") == "0" {
+			body = mustMarshal(t, api.ProviderResourceList{
+				Page:  api.Page{TotalCount: 150, Limit: 100},
+				Items: make([]api.ProviderResource, 100),
+			})
+		} else {
+			body = mustMarshal(t, api.ProviderResourceList{
+				Page:  api.Page{TotalCount: 150, Limit: 100},
+				Items: make([]api.ProviderResource, 50),
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL).WithLogger(logger).WithListPageLimit(100).ListBenchmarks()
+	if err != nil {
+		t.Fatalf("ListBenchmarks: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 provider list calls, got %d", calls)
+	}
+	if strings.TrimSpace(buf.String()) != "" {
+		t.Fatalf("expected no truncation error logs during client pagination, got %q", buf.String())
+	}
+}
+
 func TestGetProvider(t *testing.T) {
 	want := api.ProviderResource{ProviderConfig: api.ProviderConfig{Name: "ragas"}}
 	srv, capture := newCapturingServer(t, http.StatusOK, mustMarshal(t, want))

--- a/pkg/evalhubclient/client_test.go
+++ b/pkg/evalhubclient/client_test.go
@@ -308,6 +308,22 @@ func TestListProvidersPagination(t *testing.T) {
 	}
 }
 
+func TestListBenchmarksUsesListPageLimitForProviderPages(t *testing.T) {
+	resp := api.ProviderResourceList{
+		Page:  api.Page{TotalCount: 1, Limit: 2},
+		Items: []api.ProviderResource{{ProviderConfig: api.ProviderConfig{Name: "p1", Benchmarks: []api.BenchmarkResource{{ID: "b1"}}}}},
+	}
+	srv, capture := newCapturingServer(t, http.StatusOK, mustMarshal(t, resp))
+
+	_, err := newTestClient(srv).WithListPageLimit(2).ListBenchmarks()
+	if err != nil {
+		t.Fatalf("ListBenchmarks: %v", err)
+	}
+	if !strings.Contains(capture.query, "limit=2") {
+		t.Errorf("query %q should include limit=2 for provider paging", capture.query)
+	}
+}
+
 func TestGetProvider(t *testing.T) {
 	want := api.ProviderResource{ProviderConfig: api.ProviderConfig{Name: "ragas"}}
 	srv, capture := newCapturingServer(t, http.StatusOK, mustMarshal(t, want))


### PR DESCRIPTION
## Summary

Adds a default page size of **200** for eval-hub list calls from the MCP server (resources and completions), replacing reliance on the API default (50).

## Changes

- **`pkg/evalhubclient`**: `DefaultListPageLimit` constant (200), `WithListPageLimit` on the client, and provider paging in `allProviders()` uses the configured limit (so benchmark aggregation aligns with MCP settings).
- **MCP config**: `list_page_limit` in YAML and `EVALHUB_LIST_PAGE_LIMIT` in the environment; validated between 1 and 2000. Zero/unset normalizes to the default before validation.
- **MCP server**: `listProvidersHandler` passes `WithLimit`; collections and jobs use `listOptsFromResourceURI` so an explicit `?limit=` on the resource URI still wins. Completions pass the same limit for provider, collection, and job ID lists.
- **Tests**: URI helper tests for default vs explicit limit; client test for benchmark listing query; config tests for default, env override, and validation.

## Notes

- `RegisterHandlers` and `CompletionHandlerOption` now take `listPageLimit` (from `cfg.ListPageLimit` after load/validate).

Assisted-by: Cursor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable list page limit used across API client and server pagination; can be set via CLI flags, EVALHUB_LIST_PAGE_LIMIT, or YAML (with CLI > env > YAML precedence).

* **Documentation**
  * Updated configuration docs to reflect the new pagination setting and the revised precedence order.

* **Tests**
  * Added and updated tests to cover loading, validation, server wiring, and pagination/truncation behaviors for the new setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/571)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->