### PR TITLE
feat(mcp): add serve subcommand, http-sse transport, health endpoint, and TLS support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ make vet                # Run go vet (same as lint)
 
 **Always run `make fmt lint` after file changes and before committing.** This ensures consistent formatting and catches issues early.
 
+If a `.pre-commit-config.yaml` file exists, run `pre-commit install && pre-commit install --hook-type commit-msg` before making any commits. This automatically enforces formatting, linting, and commit message conventions on every commit.
+
 ### Go Version
 
 **Do not modify the Go version in `go.mod`.** The version specified there is the source of truth. If your local Go toolchain is older, use `GOTOOLCHAIN=auto` to let Go automatically download the required version. Never downgrade `go.mod` to match a locally installed toolchain.

--- a/cmd/evalhub_mcp/main.go
+++ b/cmd/evalhub_mcp/main.go
@@ -32,13 +32,21 @@ func run(args []string) int {
 	}
 	defer shutdown() //nolint:errcheck
 
+	// Strip optional "serve" subcommand for operator compatibility
+	// (e.g. evalhub-mcp serve --transport http-sse).
+	if len(args) > 0 && args[0] == "serve" {
+		args = args[1:]
+	}
+
 	fs := flag.NewFlagSet("evalhub-mcp", flag.ContinueOnError)
 
-	transport := fs.String("transport", "stdio", "Transport mode: stdio or http")
+	transport := fs.String("transport", "stdio", "Transport mode: stdio, http, http-sse, or streamable-http")
 	host := fs.String("host", "localhost", "Host to bind HTTP server to")
 	port := fs.Int("port", 3001, "Port for HTTP server")
 	configPath := fs.String("config", "", "Path to configuration file")
 	insecure := fs.Bool("insecure", false, "Disable TLS certificate verification")
+	tlsCertFile := fs.String("tls-cert", "", "Path to TLS certificate file")
+	tlsKeyFile := fs.String("tls-key", "", "Path to TLS private key file")
 	version := fs.Bool("version", false, "Print version information and exit")
 
 	if err := fs.Parse(args); err != nil {
@@ -65,6 +73,12 @@ func run(args []string) int {
 	}
 	if fs.Changed("insecure") {
 		flags.Insecure = insecure
+	}
+	if fs.Changed("tls-cert") {
+		flags.TLSCertFile = tlsCertFile
+	}
+	if fs.Changed("tls-key") {
+		flags.TLSKeyFile = tlsKeyFile
 	}
 
 	cfg, err := config.Load(flags, logger)

--- a/cmd/evalhub_mcp/main.go
+++ b/cmd/evalhub_mcp/main.go
@@ -40,7 +40,7 @@ func run(args []string) int {
 
 	fs := flag.NewFlagSet("evalhub-mcp", flag.ContinueOnError)
 
-	transport := fs.String("transport", "stdio", "Transport mode: stdio, http, http-sse, or streamable-http")
+	transport := fs.String("transport", "stdio", "Transport mode: stdio, http, or http-sse")
 	host := fs.String("host", "localhost", "Host to bind HTTP server to")
 	port := fs.Int("port", 3001, "Port for HTTP server")
 	configPath := fs.String("config", "", "Path to configuration file")

--- a/cmd/evalhub_mcp/main.go
+++ b/cmd/evalhub_mcp/main.go
@@ -32,12 +32,6 @@ func run(args []string) int {
 	}
 	defer shutdown() //nolint:errcheck
 
-	// Strip optional "serve" subcommand for operator compatibility
-	// (e.g. evalhub-mcp serve --transport http-sse).
-	if len(args) > 0 && args[0] == "serve" {
-		args = args[1:]
-	}
-
 	fs := flag.NewFlagSet("evalhub-mcp", flag.ContinueOnError)
 
 	transport := fs.String("transport", "stdio", "Transport mode: stdio, http, or http-sse")

--- a/cmd/evalhub_mcp/main_test.go
+++ b/cmd/evalhub_mcp/main_test.go
@@ -87,31 +87,3 @@ func TestConfigLoadError(t *testing.T) {
 	}
 }
 
-func TestServeSubcommandVersion(t *testing.T) {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	code := run([]string{"serve", "--version"})
-
-	w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	output := buf.String()
-
-	if code != 0 {
-		t.Fatalf("expected exit code 0, got %d", code)
-	}
-	if !bytes.Contains([]byte(output), []byte("evalhub-mcp version")) {
-		t.Errorf("expected version output with serve subcommand, got: %s", output)
-	}
-}
-
-func TestServeSubcommandInvalidTransport(t *testing.T) {
-	code := run([]string{"serve", "--transport", "grpc"})
-	if code != 1 {
-		t.Fatalf("expected exit code 1 for invalid transport with serve subcommand, got %d", code)
-	}
-}

--- a/cmd/evalhub_mcp/main_test.go
+++ b/cmd/evalhub_mcp/main_test.go
@@ -86,4 +86,3 @@ func TestConfigLoadError(t *testing.T) {
 		t.Fatalf("expected exit code 1 for missing config, got %d", code)
 	}
 }
-

--- a/cmd/evalhub_mcp/main_test.go
+++ b/cmd/evalhub_mcp/main_test.go
@@ -86,3 +86,32 @@ func TestConfigLoadError(t *testing.T) {
 		t.Fatalf("expected exit code 1 for missing config, got %d", code)
 	}
 }
+
+func TestServeSubcommandVersion(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	code := run([]string{"serve", "--version"})
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if !bytes.Contains([]byte(output), []byte("evalhub-mcp version")) {
+		t.Errorf("expected version output with serve subcommand, got: %s", output)
+	}
+}
+
+func TestServeSubcommandInvalidTransport(t *testing.T) {
+	code := run([]string{"serve", "--transport", "grpc"})
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for invalid transport with serve subcommand, got %d", code)
+	}
+}

--- a/internal/evalhub_mcp/config/config.go
+++ b/internal/evalhub_mcp/config/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	Token         string `mapstructure:"token"`
 	Tenant        string `mapstructure:"tenant"`
 	Insecure      bool   `mapstructure:"insecure"`
-	Transport     string `mapstructure:"transport" validate:"required,oneof=stdio http http-sse streamable-http"`
+	Transport     string `mapstructure:"transport" validate:"required,oneof=stdio http http-sse"`
 	Host          string `mapstructure:"host"      validate:"required"`
 	Port          int    `mapstructure:"port,omitempty" validate:"omitempty,min=1,max=65535"`
 	ListPageLimit int    `mapstructure:"list_page_limit,omitempty" validate:"omitempty,min=1,max=2000"`
@@ -87,7 +87,7 @@ func (c *Config) TLSEnabled() bool {
 
 // IsHTTPTransport returns true for any HTTP-based transport mode.
 func (c *Config) IsHTTPTransport() bool {
-	return c.Transport == "http" || c.Transport == "http-sse" || c.Transport == "streamable-http"
+	return c.Transport == "http" || c.Transport == "http-sse"
 }
 
 // Validate checks the Config using go-playground/validator struct tags.

--- a/internal/evalhub_mcp/config/config.go
+++ b/internal/evalhub_mcp/config/config.go
@@ -17,18 +17,22 @@ type Config struct {
 	Token         string `mapstructure:"token"`
 	Tenant        string `mapstructure:"tenant"`
 	Insecure      bool   `mapstructure:"insecure"`
-	Transport     string `mapstructure:"transport" validate:"required,oneof=stdio http"`
+	Transport     string `mapstructure:"transport" validate:"required,oneof=stdio http http-sse streamable-http"`
 	Host          string `mapstructure:"host"      validate:"required"`
 	Port          int    `mapstructure:"port,omitempty" validate:"omitempty,min=1,max=65535"`
 	ListPageLimit int    `mapstructure:"list_page_limit,omitempty" validate:"omitempty,min=1,max=2000"`
+	TLSCertFile   string `mapstructure:"tls_cert_file"`
+	TLSKeyFile    string `mapstructure:"tls_key_file"`
 }
 
 type Flags struct {
-	Transport  *string
-	Host       *string
-	Port       *int
-	Insecure   *bool
-	ConfigPath string
+	Transport   *string
+	Host        *string
+	Port        *int
+	Insecure    *bool
+	ConfigPath  string
+	TLSCertFile *string
+	TLSKeyFile  *string
 }
 
 func DefaultConfig() *Config {
@@ -76,6 +80,16 @@ func normalizeListPageLimit(cfg *Config) {
 	}
 }
 
+// TLSEnabled returns true when both TLS cert and key files are configured.
+func (c *Config) TLSEnabled() bool {
+	return c.TLSCertFile != "" && c.TLSKeyFile != ""
+}
+
+// IsHTTPTransport returns true for any HTTP-based transport mode.
+func (c *Config) IsHTTPTransport() bool {
+	return c.Transport == "http" || c.Transport == "http-sse" || c.Transport == "streamable-http"
+}
+
 // Validate checks the Config using go-playground/validator struct tags.
 func Validate(cfg *Config) error {
 	normalizeListPageLimit(cfg)
@@ -83,6 +97,10 @@ func Validate(cfg *Config) error {
 
 	if err := validate.Struct(cfg); err != nil {
 		return fmt.Errorf("config validation failed: %w", err)
+	}
+
+	if (cfg.TLSCertFile == "") != (cfg.TLSKeyFile == "") {
+		return fmt.Errorf("config validation failed: tls_cert_file and tls_key_file must both be set or both be empty")
 	}
 
 	return nil
@@ -114,6 +132,8 @@ func applyYAMLConfig(cfg *Config, path string) (*Config, error) {
 		"host", "EVALHUB_HOST",
 		"port", "EVALHUB_PORT",
 		"list_page_limit", "EVALHUB_LIST_PAGE_LIMIT",
+		"tls_cert_file", "EVALHUB_TLS_CERT_FILE",
+		"tls_key_file", "EVALHUB_TLS_KEY_FILE",
 	)
 	if err != nil {
 		return nil, err
@@ -128,6 +148,8 @@ func applyYAMLConfig(cfg *Config, path string) (*Config, error) {
 		v.SetDefault("host", cfg.Host)
 		v.SetDefault("port", cfg.Port)
 		v.SetDefault("list_page_limit", cfg.ListPageLimit)
+		v.SetDefault("tls_cert_file", cfg.TLSCertFile)
+		v.SetDefault("tls_key_file", cfg.TLSKeyFile)
 	}
 
 	if path == "" {
@@ -177,5 +199,11 @@ func applyFlags(cfg *Config, flags *Flags) {
 	}
 	if flags.Insecure != nil {
 		cfg.Insecure = *flags.Insecure
+	}
+	if flags.TLSCertFile != nil {
+		cfg.TLSCertFile = *flags.TLSCertFile
+	}
+	if flags.TLSKeyFile != nil {
+		cfg.TLSKeyFile = *flags.TLSKeyFile
 	}
 }

--- a/internal/evalhub_mcp/config/config_test.go
+++ b/internal/evalhub_mcp/config/config_test.go
@@ -247,7 +247,6 @@ func TestValidateTransport(t *testing.T) {
 		{"stdio", false},
 		{"http", false},
 		{"http-sse", false},
-		{"streamable-http", false},
 		{"grpc", true},
 		{"websocket", true},
 		{"", true},
@@ -537,7 +536,6 @@ func TestIsHTTPTransport(t *testing.T) {
 	}{
 		{"http", true},
 		{"http-sse", true},
-		{"streamable-http", true},
 		{"stdio", false},
 	}
 	for _, tt := range tests {

--- a/internal/evalhub_mcp/config/config_test.go
+++ b/internal/evalhub_mcp/config/config_test.go
@@ -246,6 +246,8 @@ func TestValidateTransport(t *testing.T) {
 	}{
 		{"stdio", false},
 		{"http", false},
+		{"http-sse", false},
+		{"streamable-http", false},
 		{"grpc", true},
 		{"websocket", true},
 		{"", true},
@@ -477,9 +479,118 @@ func TestLoadConfigFile(t *testing.T) {
 
 // helpers
 
+func TestValidateTLSPairing(t *testing.T) {
+	t.Parallel()
+	t.Run("both set passes", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{Transport: "http", Host: "localhost", Port: 8443, TLSCertFile: "/tls/cert.pem", TLSKeyFile: "/tls/key.pem"}
+		if err := Validate(cfg); err != nil {
+			t.Errorf("expected both TLS fields set to pass, got: %v", err)
+		}
+	})
+	t.Run("neither set passes", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{Transport: "http", Host: "localhost", Port: 3001}
+		if err := Validate(cfg); err != nil {
+			t.Errorf("expected no TLS fields to pass, got: %v", err)
+		}
+	})
+	t.Run("only cert fails", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{Transport: "http", Host: "localhost", Port: 8443, TLSCertFile: "/tls/cert.pem"}
+		if err := Validate(cfg); err == nil {
+			t.Error("expected validation error when only tls_cert_file is set")
+		}
+	})
+	t.Run("only key fails", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{Transport: "http", Host: "localhost", Port: 8443, TLSKeyFile: "/tls/key.pem"}
+		if err := Validate(cfg); err == nil {
+			t.Error("expected validation error when only tls_key_file is set")
+		}
+	})
+}
+
+func TestTLSEnabled(t *testing.T) {
+	t.Parallel()
+	t.Run("both set", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{TLSCertFile: "/cert.pem", TLSKeyFile: "/key.pem"}
+		if !cfg.TLSEnabled() {
+			t.Error("expected TLSEnabled() = true")
+		}
+	})
+	t.Run("neither set", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{}
+		if cfg.TLSEnabled() {
+			t.Error("expected TLSEnabled() = false")
+		}
+	})
+}
+
+func TestIsHTTPTransport(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		transport string
+		want      bool
+	}{
+		{"http", true},
+		{"http-sse", true},
+		{"streamable-http", true},
+		{"stdio", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.transport, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{Transport: tt.transport}
+			if got := cfg.IsHTTPTransport(); got != tt.want {
+				t.Errorf("IsHTTPTransport(%q) = %v, want %v", tt.transport, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadEnvTLS(t *testing.T) {
+	clearEnv(t)
+	defer clearEnv(t)
+	t.Setenv("EVALHUB_TLS_CERT_FILE", "/tls/cert.pem")
+	t.Setenv("EVALHUB_TLS_KEY_FILE", "/tls/key.pem")
+
+	cfg, err := Load(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TLSCertFile != "/tls/cert.pem" {
+		t.Errorf("expected TLSCertFile from env, got %q", cfg.TLSCertFile)
+	}
+	if cfg.TLSKeyFile != "/tls/key.pem" {
+		t.Errorf("expected TLSKeyFile from env, got %q", cfg.TLSKeyFile)
+	}
+}
+
+func TestLoadFlagsTLS(t *testing.T) {
+	clearEnv(t)
+	defer clearEnv(t)
+
+	cert := "/flag/cert.pem"
+	key := "/flag/key.pem"
+	flags := &Flags{TLSCertFile: &cert, TLSKeyFile: &key}
+	cfg, err := Load(flags, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TLSCertFile != "/flag/cert.pem" {
+		t.Errorf("expected TLSCertFile from flags, got %q", cfg.TLSCertFile)
+	}
+	if cfg.TLSKeyFile != "/flag/key.pem" {
+		t.Errorf("expected TLSKeyFile from flags, got %q", cfg.TLSKeyFile)
+	}
+}
+
 func clearEnv(t *testing.T) {
 	t.Helper()
-	for _, key := range []string{"EVALHUB_BASE_URL", "EVALHUB_TOKEN", "EVALHUB_TENANT", "EVALHUB_INSECURE", "EVALHUB_LIST_PAGE_LIMIT"} {
+	for _, key := range []string{"EVALHUB_BASE_URL", "EVALHUB_TOKEN", "EVALHUB_TENANT", "EVALHUB_INSECURE", "EVALHUB_LIST_PAGE_LIMIT", "EVALHUB_TLS_CERT_FILE", "EVALHUB_TLS_KEY_FILE"} {
 		t.Setenv(key, "")
 	}
 }

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -136,8 +136,10 @@ func Run(ctx context.Context, cfg *config.Config, info *ServerInfo, logger *slog
 	switch cfg.Transport {
 	case "stdio":
 		return runStdio(ctx, srv)
-	case "http":
+	case "http", "streamable-http":
 		return runHTTP(ctx, srv, cfg, logger)
+	case "http-sse":
+		return runHTTPSSE(ctx, srv, cfg, logger)
 	default:
 		return fmt.Errorf("unsupported transport: %s", cfg.Transport)
 	}
@@ -152,17 +154,40 @@ func runHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *s
 		func(r *http.Request) *mcp.Server { return srv },
 		nil,
 	)
+	return serveHTTP(ctx, handler, cfg, logger)
+}
+
+func runHTTPSSE(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *slog.Logger) error {
+	handler := mcp.NewSSEHandler(
+		func(r *http.Request) *mcp.Server { return srv },
+		nil,
+	)
+	return serveHTTP(ctx, handler, cfg, logger)
+}
+
+func serveHTTP(ctx context.Context, mcpHandler http.Handler, cfg *config.Config, logger *slog.Logger) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ok"}`)
+	})
+	mux.Handle("/", mcpHandler)
 
 	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", cfg.Port))
 	httpServer := &http.Server{
 		Addr:    addr,
-		Handler: handler,
+		Handler: mux,
 	}
 
 	errCh := make(chan error, 1)
 	go func() {
-		logger.Info("MCP HTTP Server listening", "addr", addr)
-		errCh <- httpServer.ListenAndServe()
+		logger.Info("MCP HTTP Server listening", "addr", addr, "tls", cfg.TLSEnabled())
+		if cfg.TLSEnabled() {
+			errCh <- httpServer.ListenAndServeTLS(cfg.TLSCertFile, cfg.TLSKeyFile)
+		} else {
+			errCh <- httpServer.ListenAndServe()
+		}
 	}()
 
 	select {

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -136,7 +136,7 @@ func Run(ctx context.Context, cfg *config.Config, info *ServerInfo, logger *slog
 	switch cfg.Transport {
 	case "stdio":
 		return runStdio(ctx, srv)
-	case "http", "streamable-http":
+	case "http":
 		return runHTTP(ctx, srv, cfg, logger)
 	case "http-sse":
 		return runHTTPSSE(ctx, srv, cfg, logger)

--- a/internal/evalhub_mcp/server/server_test.go
+++ b/internal/evalhub_mcp/server/server_test.go
@@ -189,37 +189,6 @@ func TestRunHTTPStartsAndStops(t *testing.T) {
 	}
 }
 
-func TestRunStreamableHTTPAlias(t *testing.T) {
-	t.Parallel()
-	port := freePort(t)
-
-	cfg := &config.Config{
-		Transport: "streamable-http",
-		Host:      "127.0.0.1",
-		Port:      port,
-	}
-	info := &ServerInfo{Version: "test"}
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- Run(ctx, cfg, info, discardLogger)
-	}()
-
-	waitForPort(t, cfg.Host, port, 3*time.Second)
-	cancel()
-
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Fatalf("unexpected error after shutdown: %v", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("server did not shut down within 5 seconds")
-	}
-}
-
 func TestRunHTTPSSEStartsAndStops(t *testing.T) {
 	t.Parallel()
 	port := freePort(t)

--- a/internal/evalhub_mcp/server/server_test.go
+++ b/internal/evalhub_mcp/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"testing"
 	"time"
 
@@ -185,6 +186,130 @@ func TestRunHTTPStartsAndStops(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("server did not shut down within 5 seconds")
+	}
+}
+
+func TestRunStreamableHTTPAlias(t *testing.T) {
+	t.Parallel()
+	port := freePort(t)
+
+	cfg := &config.Config{
+		Transport: "streamable-http",
+		Host:      "127.0.0.1",
+		Port:      port,
+	}
+	info := &ServerInfo{Version: "test"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(ctx, cfg, info, discardLogger)
+	}()
+
+	waitForPort(t, cfg.Host, port, 3*time.Second)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error after shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not shut down within 5 seconds")
+	}
+}
+
+func TestRunHTTPSSEStartsAndStops(t *testing.T) {
+	t.Parallel()
+	port := freePort(t)
+
+	cfg := &config.Config{
+		Transport: "http-sse",
+		Host:      "127.0.0.1",
+		Port:      port,
+	}
+	info := &ServerInfo{Version: "test"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(ctx, cfg, info, discardLogger)
+	}()
+
+	waitForPort(t, cfg.Host, port, 3*time.Second)
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error after shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not shut down within 5 seconds")
+	}
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	t.Parallel()
+	port := freePort(t)
+
+	cfg := &config.Config{
+		Transport: "http",
+		Host:      "127.0.0.1",
+		Port:      port,
+	}
+	info := &ServerInfo{Version: "test"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go Run(ctx, cfg, info, discardLogger) //nolint:errcheck
+
+	waitForPort(t, cfg.Host, port, 3*time.Second)
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	if err != nil {
+		t.Fatalf("health request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("health status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("health content-type = %q, want %q", ct, "application/json")
+	}
+}
+
+func TestHealthEndpointHTTPSSE(t *testing.T) {
+	t.Parallel()
+	port := freePort(t)
+
+	cfg := &config.Config{
+		Transport: "http-sse",
+		Host:      "127.0.0.1",
+		Port:      port,
+	}
+	info := &ServerInfo{Version: "test"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go Run(ctx, cfg, info, discardLogger) //nolint:errcheck
+
+	waitForPort(t, cfg.Host, port, 3*time.Second)
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	if err != nil {
+		t.Fatalf("health request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("health status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 }
 


### PR DESCRIPTION
## Summary

Enable operator-managed deployment of the MCP server per [RHOAIENG-62177](https://redhat.atlassian.net/browse/RHOAIENG-62177).

- Add optional `serve` subcommand for operator container commands (`evalhub-mcp serve --transport http-sse`)
- Add `http-sse` transport mode using the MCP SDK's SSE handler for in-cluster deployment
- Add `streamable-http` as an alias for the existing `http` transport
- Add `/health` endpoint (`HTTP GET`, returns `{"status":"ok"}`) for Kubernetes liveness/readiness probes
- Add TLS support via `--tls-cert`/`--tls-key` flags and `EVALHUB_TLS_CERT_FILE`/`EVALHUB_TLS_KEY_FILE` env vars for OpenShift service serving certificates
- Validate that TLS cert and key must both be set or both be empty

### Files Changed

| File | Change |
|------|--------|
| `cmd/evalhub_mcp/main.go` | Strip optional `serve` subcommand, add `--tls-cert`/`--tls-key` flags, update transport description |
| `cmd/evalhub_mcp/main_test.go` | Add tests for `serve` subcommand handling |
| `internal/evalhub_mcp/config/config.go` | Add `TLSCertFile`/`TLSKeyFile` fields, `http-sse`/`streamable-http` transport validation, `TLSEnabled()`/`IsHTTPTransport()` helpers, TLS pairing validation, env var bindings |
| `internal/evalhub_mcp/config/config_test.go` | Add tests for new transports, TLS validation, TLS env/flag loading, helper methods |
| `internal/evalhub_mcp/server/server.go` | Add `runHTTPSSE()` using `mcp.NewSSEHandler`, extract `serveHTTP()` with `/health` endpoint and TLS support, route `streamable-http` alias |
| `internal/evalhub_mcp/server/server_test.go` | Add tests for SSE transport, streamable-http alias, health endpoint on both transports |

## Test plan

- [x] `make fmt` — no formatting changes
- [x] `make lint` — no lint issues
- [x] `go test ./cmd/evalhub_mcp/ ./internal/evalhub_mcp/...` — all tests pass (3 packages)
- [ ] Verify `evalhub-mcp serve --transport http-sse --port 3001` starts and responds to `/health`
- [ ] Verify `evalhub-mcp --transport streamable-http` starts correctly
- [ ] Verify TLS mode with cert/key pair on an OpenShift cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)