### PR TITLE
chore: improve MCP transport documentation

### DIFF
--- a/.claude/rules/evalhub-mcp-service.md
+++ b/.claude/rules/evalhub-mcp-service.md
@@ -15,7 +15,7 @@ paths:
 - Lint: `make lint`
 - Formatting: `make fmt vet`
 
-**CLI flags:** `--transport stdio|http`, `--host`, `--port`, `--config`, `--insecure`, `--version`
+**CLI flags:** `--transport stdio|http|http-sse` (`http` = Streamable HTTP; `http-sse` = legacy only), `--host`, `--port`, `--config`, `--insecure`, `--version`
 
 **Configuration precedence:** CLI flags > YAML config (`~/.evalhub/config.yaml`) > env vars (`EVALHUB_BASE_URL`, `EVALHUB_TOKEN`, `EVALHUB_TENANT`, `EVALHUB_INSECURE`)
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   # Ruff linting and formatting (replaces black)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.13
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -33,7 +33,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.13.10
+    rev: v4.16.2
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ The MCP (Model Context Protocol) server exposes eval-hub functionality to AI age
 ```bash
 # Run directly
 go run cmd/evalhub_mcp/main.go                          # stdio transport (default)
-go run cmd/evalhub_mcp/main.go --transport http          # HTTP/SSE on localhost:3001
+go run cmd/evalhub_mcp/main.go --transport http          # Streamable HTTP on localhost:3001
 go run cmd/evalhub_mcp/main.go --transport http --port 4000 --host 0.0.0.0
 
 # Build and run
@@ -165,7 +165,7 @@ make build-mcp
 go test -v ./cmd/evalhub_mcp/ ./internal/evalhub_mcp/...
 ```
 
-**CLI flags:** `--transport stdio|http`, `--host`, `--port`, `--config`, `--insecure`, `--version`
+**CLI flags:** `--transport stdio|http|http-sse` (`http` = Streamable HTTP, default for remote; `http-sse` = legacy HTTP+SSE only), `--host`, `--port`, `--config`, `--insecure`, `--version`
 
 **Configuration precedence:** CLI flags > env vars (`EVALHUB_BASE_URL`, `EVALHUB_TOKEN`, `EVALHUB_TENANT`, `EVALHUB_INSECURE`, `EVALHUB_LIST_PAGE_LIMIT`) > YAML config (`~/.evalhub/config.yaml`)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-mcp build-all-platforms cross-compile-mcp build-all-platforms-mcp start-service stop-service start-sidecar stop-sidecar lint test test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet update-deps generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components fvt-report docker-image-local docker-mcp-version test-mcp-build-all test-mcp-binary-info test-mcp-binary-naming test-mcp-version test-mcp-no-runtime-deps test-mcp-container-build test-mcp-container-http test-mcp-checksums test-mcp-formula-syntax test-mcp-native-smoke test-mcp-brew-install test-mcp-brew-test test-mcp-brew-uninstall test-mcp-cross-platform test-mcp-e2e
+.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-mcp build-all-platforms cross-compile-mcp build-all-platforms-mcp start-service stop-service start-sidecar stop-sidecar lint test test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet update-deps generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components fvt-report docker-image-local docker-mcp-version test-mcp-build-all test-mcp-binary-info test-mcp-binary-naming test-mcp-version test-mcp-no-runtime-deps test-mcp-container-build test-mcp-container-http test-mcp-checksums test-mcp-formula-syntax test-mcp-native-smoke test-mcp-brew-install test-mcp-brew-test test-mcp-brew-uninstall test-mcp-cross-platform test-mcp-e2e test-mcp
 
 GOPATH := $(shell go env GOPATH)
 GOBIN := $(shell go env GOPATH)/bin
@@ -680,3 +680,5 @@ test-mcp-e2e: start-service ## Run end-to-end MCP tests
 	echo "End-to-end MCP tests complete"; \
 	$(MAKE) stop-service; \
 	exit $$status
+
+test-mcp: test-mcp-cross-platform test-mcp-e2e

--- a/cmd/evalhub_mcp/main.go
+++ b/cmd/evalhub_mcp/main.go
@@ -34,7 +34,8 @@ func run(args []string) int {
 
 	fs := flag.NewFlagSet("evalhub-mcp", flag.ContinueOnError)
 
-	transport := fs.String("transport", "stdio", "Transport mode: stdio, http, or http-sse")
+	transport := fs.String("transport", config.TransportStdio,
+		"Transport: stdio (default), http (Streamable HTTP), or http-sse (legacy HTTP+SSE for older MCP clients only)")
 	host := fs.String("host", "localhost", "Host to bind HTTP server to")
 	port := fs.Int("port", 3001, "Port for HTTP server")
 	configPath := fs.String("config", "", "Path to configuration file")

--- a/config/mcp_local.yaml
+++ b/config/mcp_local.yaml
@@ -2,6 +2,7 @@ base_url: http://localhost:8080
 token: token
 tenant: tenant
 insecure: false
+# Streamable HTTP (default for remote); use http-sse only for legacy MCP clients.
 transport: http
 host: localhost
 port: 3001

--- a/internal/evalhub_mcp/config/config.go
+++ b/internal/evalhub_mcp/config/config.go
@@ -12,12 +12,20 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Transport mode names. Use TransportHTTP for remote clients; TransportHTTPSSE is
+// legacy HTTP+SSE (MCP 2024-11-05) and should only be enabled for older clients.
+const (
+	TransportStdio   = "stdio"
+	TransportHTTP    = "http"
+	TransportHTTPSSE = "http-sse"
+)
+
 type Config struct {
 	BaseURL       string `mapstructure:"base_url,omitempty" validate:"omitempty,url"`
 	Token         string `mapstructure:"token"`
 	Tenant        string `mapstructure:"tenant"`
 	Insecure      bool   `mapstructure:"insecure"`
-	Transport     string `mapstructure:"transport" validate:"required,oneof=stdio http http-sse"`
+	Transport     string `mapstructure:"transport" validate:"required,oneof=stdio http http-sse"` // default stdio; use http for remote
 	Host          string `mapstructure:"host"      validate:"required"`
 	Port          int    `mapstructure:"port,omitempty" validate:"omitempty,min=1,max=65535"`
 	ListPageLimit int    `mapstructure:"list_page_limit,omitempty" validate:"omitempty,min=1,max=2000"`
@@ -37,7 +45,7 @@ type Flags struct {
 
 func DefaultConfig() *Config {
 	return &Config{
-		Transport:     "stdio",
+		Transport:     TransportStdio,
 		Host:          "localhost",
 		Port:          3001,
 		ListPageLimit: evalhubclient.DefaultListPageLimit,
@@ -87,7 +95,12 @@ func (c *Config) TLSEnabled() bool {
 
 // IsHTTPTransport returns true for any HTTP-based transport mode.
 func (c *Config) IsHTTPTransport() bool {
-	return c.Transport == "http" || c.Transport == "http-sse"
+	return c.Transport == TransportHTTP || c.Transport == TransportHTTPSSE
+}
+
+// IsLegacyHTTPTransport returns true for the deprecated HTTP+SSE transport (MCP 2024-11-05).
+func (c *Config) IsLegacyHTTPTransport() bool {
+	return c.Transport == TransportHTTPSSE
 }
 
 // Validate checks the Config using go-playground/validator struct tags.

--- a/internal/evalhub_mcp/config/config_test.go
+++ b/internal/evalhub_mcp/config/config_test.go
@@ -528,6 +528,27 @@ func TestTLSEnabled(t *testing.T) {
 	})
 }
 
+func TestIsLegacyHTTPTransport(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		transport string
+		want      bool
+	}{
+		{"stdio", false},
+		{"http", false},
+		{"http-sse", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.transport, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{Transport: tt.transport}
+			if got := cfg.IsLegacyHTTPTransport(); got != tt.want {
+				t.Errorf("IsLegacyHTTPTransport(%q) = %v, want %v", tt.transport, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsHTTPTransport(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -134,12 +134,15 @@ func Run(ctx context.Context, cfg *config.Config, info *ServerInfo, logger *slog
 	)
 
 	switch cfg.Transport {
-	case "stdio":
+	case config.TransportStdio:
 		return runStdio(ctx, srv)
-	case "http":
+	case config.TransportHTTP:
 		return runHTTP(ctx, srv, cfg, logger)
-	case "http-sse":
-		return runHTTPSSE(ctx, srv, cfg, logger)
+	case config.TransportHTTPSSE:
+		logger.Warn("transport http-sse is deprecated; use http (Streamable HTTP) unless connecting to legacy MCP clients",
+			"transport", cfg.Transport,
+		)
+		return runLegacyHTTPSSE(ctx, srv, cfg, logger)
 	default:
 		return fmt.Errorf("unsupported transport: %s", cfg.Transport)
 	}
@@ -157,7 +160,8 @@ func runHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *s
 	return serveHTTP(ctx, handler, cfg, logger)
 }
 
-func runHTTPSSE(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *slog.Logger) error {
+// runLegacyHTTPSSE serves the deprecated HTTP+SSE transport (MCP 2024-11-05) for older clients.
+func runLegacyHTTPSSE(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *slog.Logger) error {
 	handler := mcp.NewSSEHandler(
 		func(r *http.Request) *mcp.Server { return srv },
 		nil,

--- a/internal/evalhub_mcp/server/server_test.go
+++ b/internal/evalhub_mcp/server/server_test.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -162,7 +164,7 @@ func TestRunHTTPStartsAndStops(t *testing.T) {
 	port := freePort(t)
 
 	cfg := &config.Config{
-		Transport: "http",
+		Transport: config.TransportHTTP,
 		Host:      "127.0.0.1",
 		Port:      port,
 	}
@@ -189,12 +191,12 @@ func TestRunHTTPStartsAndStops(t *testing.T) {
 	}
 }
 
-func TestRunHTTPSSEStartsAndStops(t *testing.T) {
+func TestRunLegacyHTTPSSEStartsAndStops(t *testing.T) {
 	t.Parallel()
 	port := freePort(t)
 
 	cfg := &config.Config{
-		Transport: "http-sse",
+		Transport: config.TransportHTTPSSE,
 		Host:      "127.0.0.1",
 		Port:      port,
 	}
@@ -202,12 +204,19 @@ func TestRunHTTPSSEStartsAndStops(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- Run(ctx, cfg, info, discardLogger)
+		errCh <- Run(ctx, cfg, info, logger)
 	}()
 
 	waitForPort(t, cfg.Host, port, 3*time.Second)
+
+	if !strings.Contains(logBuf.String(), "deprecated") {
+		t.Errorf("expected deprecation warning in logs, got: %s", logBuf.String())
+	}
 
 	cancel()
 
@@ -253,12 +262,12 @@ func TestHealthEndpoint(t *testing.T) {
 	}
 }
 
-func TestHealthEndpointHTTPSSE(t *testing.T) {
+func TestHealthEndpointLegacyHTTPSSE(t *testing.T) {
 	t.Parallel()
 	port := freePort(t)
 
 	cfg := &config.Config{
-		Transport: "http-sse",
+		Transport: config.TransportHTTPSSE,
 		Host:      "127.0.0.1",
 		Port:      port,
 	}

--- a/internal/evalhub_mcp/server/server_test.go
+++ b/internal/evalhub_mcp/server/server_test.go
@@ -214,10 +214,6 @@ func TestRunLegacyHTTPSSEStartsAndStops(t *testing.T) {
 
 	waitForPort(t, cfg.Host, port, 3*time.Second)
 
-	if !strings.Contains(logBuf.String(), "deprecated") {
-		t.Errorf("expected deprecation warning in logs, got: %s", logBuf.String())
-	}
-
 	cancel()
 
 	select {
@@ -227,6 +223,11 @@ func TestRunLegacyHTTPSSEStartsAndStops(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("server did not shut down within 5 seconds")
+	}
+
+	// Read logBuf only after Run returns; slog writes to the buffer from the server goroutine.
+	if !strings.Contains(logBuf.String(), "deprecated") {
+		t.Errorf("expected deprecation warning in logs, got: %s", logBuf.String())
 	}
 }
 

--- a/tests/mcp/CLAUDE_CODE_INTEGRATION.md
+++ b/tests/mcp/CLAUDE_CODE_INTEGRATION.md
@@ -152,7 +152,7 @@ In a Claude Code conversation, type a partial resource URI and verify that autoc
 
 ---
 
-## Part 2: HTTP/SSE Transport Integration
+## Part 2: Streamable HTTP Transport Integration
 
 ### Step 7 — Start the evalhub-mcp Server in HTTP Mode
 

--- a/tests/mcp/scripts/part2_http_transport.sh
+++ b/tests/mcp/scripts/part2_http_transport.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Part 2: HTTP/SSE Transport Integration Tests
+# Part 2: Streamable HTTP Transport Integration Tests
 # Tests Steps 7-10 from CLAUDE_CODE_INTEGRATION.md
 # JIRA: RHOAIENG-60353
 set -euo pipefail
@@ -382,7 +382,7 @@ fi
 ###############################################################################
 # Summary
 ###############################################################################
-header "Part 2 Summary: HTTP/SSE Transport"
+header "Part 2 Summary: Streamable HTTP Transport"
 TOTAL=$((PASS + FAIL + SKIP))
 echo -e "  ${GREEN}Passed:  ${PASS}${NC}"
 echo -e "  ${RED}Failed:  ${FAIL}${NC}"


### PR DESCRIPTION
## What and why

- Update evalhub-mcp transport documentation to clarify the use of 'http' as Streamable HTTP and 'http-sse' as legacy.
- Refactor CLI flags and configuration to reflect the new transport options.
- Add tests for legacy HTTP transport handling.
- Bump ruff pre-commit hook version from v0.15.12 to v0.15.13.
- Upgrade commitizen version from v4.13.10 to v4.16.2.

This commit enhances the clarity of transport options and ensures the latest versions of dependencies are used.

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [x] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified HTTP transport uses streamable HTTP on localhost:3001; deprecated HTTP-SSE as legacy transport for older MCP clients.

* **Chores**
  * Updated pre-commit hooks to latest versions (Ruff, Commitizen).
  * Added unified MCP test target to build system.

* **Tests**
  * Added test coverage for legacy HTTP-SSE transport deprecation warning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/579)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->