### PR TITLE
fix(tests): enhance error logging in evaluation job status check

### DIFF
--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -469,6 +469,7 @@ func (tc *scenarioConfig) iSetWaitDeadlineTo(paramValue string) error {
 func (tc *scenarioConfig) iWaitForEvaluationJobStatus(expectedStatus string) error {
 	deadline := time.Now().Add(tc.waitDeadline)
 	var lastErr error
+	var lastStatus string
 	for time.Now().Before(deadline) {
 		if err := tc.iSendARequestImpl(http.MethodGet, "/api/v1/evaluations/jobs/{id}", "", "wait for evaluation job status"); err != nil {
 			lastErr = err
@@ -477,6 +478,9 @@ func (tc *scenarioConfig) iWaitForEvaluationJobStatus(expectedStatus string) err
 		}
 		if tc.response != nil && tc.response.StatusCode == http.StatusOK {
 			status, err := tc.getJsonPath("$.status.state")
+			if status != "" {
+				lastStatus = status
+			}
 			if err != nil {
 				lastErr = err
 			} else if status == expectedStatus {
@@ -491,7 +495,8 @@ func (tc *scenarioConfig) iWaitForEvaluationJobStatus(expectedStatus string) err
 					}
 					return tc.logError(fmt.Errorf("evaluation job reached terminal state %q (expected %q)", status, expectedStatus))
 				}
-				lastErr = fmt.Errorf("expected status %q but got %q", expectedStatus, status)
+				// we should not do this because it will be logged as an error
+				// lastErr = fmt.Errorf("expected status %q but got %q", expectedStatus, status)
 			}
 		} else if tc.response != nil {
 			lastErr = tc.logError(fmt.Errorf("unexpected response status %d", tc.response.StatusCode))
@@ -501,7 +506,7 @@ func (tc *scenarioConfig) iWaitForEvaluationJobStatus(expectedStatus string) err
 	if lastErr != nil {
 		return tc.logError(lastErr)
 	}
-	return tc.logError(fmt.Errorf("timed out waiting for status %q", expectedStatus))
+	return tc.logError(fmt.Errorf("timed out waiting for status %q, last status: %q", expectedStatus, lastStatus))
 }
 
 func (tc *scenarioConfig) findFile(fileName string) (string, error) {


### PR DESCRIPTION

## What and why

-Updated the iWaitForEvaluationJobStatus function to store the last known status of the evaluation job. Improved the error message returned when a timeout occurs, now including the last status observed. This change enhances debugging capabilities by providing more context in case of failures.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved job status monitoring in test steps to display both expected and last observed statuses in timeout error messages for better debugging visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/581)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->