### PR TITLE
fix(fvt): add auth secret reference to OOB collection test scenarios

### DIFF
--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -528,7 +528,10 @@ Feature: Evaluation Jobs
         },
         "model": {
           "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}"
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
         }
       }
       """
@@ -608,7 +611,10 @@ Feature: Evaluation Jobs
         },
         "model": {
           "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}"
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
         }
       }
       """
@@ -696,7 +702,10 @@ Feature: Evaluation Jobs
         },
         "model": {
           "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}"
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
         }
       }
       """


### PR DESCRIPTION
## What and why
Added model.auth.secret_ref to the three OOB collection scenarios (toxicity-and-ethical-principles, leaderboard-v2, safety-and-fairness-v1) to enable HuggingFace authentication for gated datasets.

This allows the evaluation jobs to access the vllm-api-key secret which contains the HF token needed to download gated datasets like toxigen, truthfulqa, and leaderboard benchmarks.

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated evaluation job test scenarios for toxicity-and-ethical-principles, leaderboard-v2, and safety-and-fairness-v1 collections to include model authentication configuration in POST request payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/582)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->