### PR TITLE
chore(examples): update lighteval example to use stable PyPI release

### DIFF
--- a/examples/local-lighteval/pyproject.toml
+++ b/examples/local-lighteval/pyproject.toml
@@ -3,7 +3,7 @@ name = "local-lighteval"
 version = "0.0.1"
 requires-python = ">=3.12"
 dependencies = [
-    "eval-hub-server>=0.4.0.dev363",
+    "eval-hub-server>=0.4.0",
 ]
 
 [project.optional-dependencies]
@@ -15,11 +15,3 @@ demo = [
     "oras>=0.2.41",
     "eval-hub-sdk[client]>=0.1.7",
 ]
-
-[tool.uv.sources]
-eval-hub-server = { index = "testpypi" }
-
-[[tool.uv.index]]
-name = "testpypi"
-url = "https://test.pypi.org/simple/"
-explicit = true


### PR DESCRIPTION
Switch eval-hub-server dependency from dev pre-release on TestPyPI to the stable release on PyPI. Remove testpypi index configuration.

Generated with: Claude Code

## What and why


Closes #

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [x] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated eval-hub-server dependency to stable release version in the local-lighteval example
  * Removed test package index configuration, streamlining project setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->