### PR TITLE
fix(sidecar): prepend target path prefix when proxying MLflow requests

### DIFF
--- a/internal/eval_runtime_sidecar/proxy/proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/proxy.go
@@ -114,6 +114,9 @@ func NewReverseProxy(target *url.URL, client *http.Client, logger *slog.Logger, 
 		req.URL.Scheme = target.Scheme
 		req.URL.Host = target.Host
 		req.Host = target.Host
+		if target.Path != "" && target.Path != "/" {
+			req.URL.Path = strings.TrimSuffix(target.Path, "/") + req.URL.Path
+		}
 		req.RequestURI = "" // required for client requests
 		// Content-Type and X-Tenant are already on req (copied from incoming by ReverseProxy)
 		authInput, ok := AuthInputFromContext(req.Context())

--- a/internal/eval_runtime_sidecar/proxy/proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/proxy_test.go
@@ -127,6 +127,31 @@ func TestNewReverseProxy(t *testing.T) {
 	}
 }
 
+func TestNewReverseProxyWithPathPrefix(t *testing.T) {
+	logger := slog.Default()
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mlflow/api/2.0/mlflow/experiments/get-by-name" {
+			t.Errorf("backend path = %s, want /mlflow/api/2.0/mlflow/experiments/get-by-name", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	target, err := url.Parse(strings.TrimSuffix(backend.URL, "/") + "/mlflow")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	proxy := NewReverseProxy(target, backend.Client(), logger, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/2.0/mlflow/experiments/get-by-name", nil)
+	rw := httptest.NewRecorder()
+	proxy.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rw.Code)
+	}
+}
+
 func TestContextWithOriginalRequest(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Host = "client.example:8443"


### PR DESCRIPTION
## What and why

The sidecar reverse proxy's Director only copies scheme and host from the target URL, dropping the path. When MLflow runs behind a static prefix (`--static-prefix=/mlflow`, tracking URI `https://mlflow.svc:8443/mlflow`), the proxy forwards to `/api/2.0/mlflow/...` instead of `/mlflow/api/2.0/mlflow/...`, causing 404s. This breaks MLflow metric saving for all adapters.


## Type

- [x] fix

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

None. Targets without a path prefix are unaffected.