### PR TITLE
fix(python-server): fall back to generic binary when platform-specific one is missing

### DIFF
--- a/python-server/evalhub_server/__init__.py
+++ b/python-server/evalhub_server/__init__.py
@@ -45,10 +45,15 @@ def get_binary_path():
     binary_path = package_dir / "binaries" / binary_name
 
     if not binary_path.exists():
-        raise FileNotFoundError(
-            f"Binary not found: {binary_path}\n"
-            f"This package may not support your platform ({system} {machine})"
-        )
+        fallback_name = "eval-hub.exe" if system == "windows" else "eval-hub"
+        fallback_path = package_dir / "binaries" / fallback_name
+        if fallback_path.exists():
+            binary_path = fallback_path
+        else:
+            raise FileNotFoundError(
+                f"Binary not found: {binary_path}\n"
+                f"This package may not support your platform ({system} {machine})"
+            )
 
     return str(binary_path)
 

--- a/python-server/evalhub_server/main.py
+++ b/python-server/evalhub_server/main.py
@@ -26,15 +26,14 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
 
-    # Get the path to the binary
     binary_path = get_binary_path()
 
     if "--version" in args or "-V" in args:
         print(f"eval-hub-server {__version__}")
         sys.exit(0)
 
-    # Pass all command-line arguments to the binary
-    result = subprocess.run([binary_path] + args)
+    # argv[0] = wrapper name so usage messages don't expose the raw binary path
+    result = subprocess.run(["eval-hub-server"] + args, executable=binary_path)
     sys.exit(result.returncode)
 
 

--- a/python-server/tests/test_get_binary_path.py
+++ b/python-server/tests/test_get_binary_path.py
@@ -1,0 +1,110 @@
+"""Tests for evalhub_server.get_binary_path binary resolution."""
+
+from unittest.mock import patch
+
+import pytest
+
+from evalhub_server import get_binary_path
+
+
+@pytest.mark.unit
+@patch("evalhub_server.platform.machine", return_value="x86_64")
+@patch("evalhub_server.platform.system", return_value="Linux")
+def test_returns_platform_specific_binary(mock_system, mock_machine, tmp_path):
+    binaries = tmp_path / "binaries"
+    binaries.mkdir()
+    specific = binaries / "eval-hub-linux-amd64"
+    specific.touch()
+
+    with patch("evalhub_server.Path") as mock_cls:
+        mock_cls.return_value.parent = tmp_path
+        result = get_binary_path()
+
+    assert result == str(specific)
+
+
+@pytest.mark.unit
+@patch("evalhub_server.platform.machine", return_value="x86_64")
+@patch("evalhub_server.platform.system", return_value="Linux")
+def test_falls_back_to_generic_on_linux(mock_system, mock_machine, tmp_path):
+    binaries = tmp_path / "binaries"
+    binaries.mkdir()
+    generic = binaries / "eval-hub"
+    generic.touch()
+
+    with patch("evalhub_server.Path") as mock_cls:
+        mock_cls.return_value.parent = tmp_path
+        result = get_binary_path()
+
+    assert result == str(generic)
+
+
+@pytest.mark.unit
+@patch("evalhub_server.platform.machine", return_value="arm64")
+@patch("evalhub_server.platform.system", return_value="Darwin")
+def test_falls_back_to_generic_on_macos(mock_system, mock_machine, tmp_path):
+    binaries = tmp_path / "binaries"
+    binaries.mkdir()
+    generic = binaries / "eval-hub"
+    generic.touch()
+
+    with patch("evalhub_server.Path") as mock_cls:
+        mock_cls.return_value.parent = tmp_path
+        result = get_binary_path()
+
+    assert result == str(generic)
+
+
+@pytest.mark.unit
+@patch("evalhub_server.platform.machine", return_value="AMD64")
+@patch("evalhub_server.platform.system", return_value="Windows")
+def test_falls_back_to_generic_exe_on_windows(mock_system, mock_machine, tmp_path):
+    binaries = tmp_path / "binaries"
+    binaries.mkdir()
+    generic = binaries / "eval-hub.exe"
+    generic.touch()
+
+    with patch("evalhub_server.Path") as mock_cls:
+        mock_cls.return_value.parent = tmp_path
+        result = get_binary_path()
+
+    assert result == str(generic)
+
+
+@pytest.mark.unit
+@patch("evalhub_server.platform.machine", return_value="x86_64")
+@patch("evalhub_server.platform.system", return_value="Linux")
+def test_prefers_platform_specific_over_generic(mock_system, mock_machine, tmp_path):
+    binaries = tmp_path / "binaries"
+    binaries.mkdir()
+    specific = binaries / "eval-hub-linux-amd64"
+    specific.touch()
+    generic = binaries / "eval-hub"
+    generic.touch()
+
+    with patch("evalhub_server.Path") as mock_cls:
+        mock_cls.return_value.parent = tmp_path
+        result = get_binary_path()
+
+    assert result == str(specific)
+
+
+@pytest.mark.unit
+@patch("evalhub_server.platform.machine", return_value="x86_64")
+@patch("evalhub_server.platform.system", return_value="Linux")
+def test_raises_when_no_binary_found(mock_system, mock_machine, tmp_path):
+    binaries = tmp_path / "binaries"
+    binaries.mkdir()
+
+    with patch("evalhub_server.Path") as mock_cls:
+        mock_cls.return_value.parent = tmp_path
+        with pytest.raises(FileNotFoundError, match="Binary not found"):
+            get_binary_path()
+
+
+@pytest.mark.unit
+@patch("evalhub_server.platform.machine", return_value="x86_64")
+@patch("evalhub_server.platform.system", return_value="FooOS")
+def test_raises_for_unsupported_platform(mock_system, mock_machine):
+    with pytest.raises(RuntimeError, match="Unsupported platform"):
+        get_binary_path()

--- a/python-server/tests/test_main.py
+++ b/python-server/tests/test_main.py
@@ -28,7 +28,8 @@ def test_setuptools_entrypoint_forwards_argv(mock_exit, mock_run, mock_path):
         main()  # no args, exactly as setuptools calls it
 
     mock_run.assert_called_once_with(
-        ["/fake/eval-hub", "--local", "--configdir", "/tmp/config"]
+        ["eval-hub-server", "--local", "--configdir", "/tmp/config"],
+        executable="/fake/eval-hub",
     )
     mock_exit.assert_called_once_with(0)
 
@@ -49,7 +50,8 @@ def test_explicit_args_override_argv(mock_exit, mock_run, mock_path):
         main(["--local", "--configdir", "/tmp/config"])
 
     mock_run.assert_called_once_with(
-        ["/fake/eval-hub", "--local", "--configdir", "/tmp/config"]
+        ["eval-hub-server", "--local", "--configdir", "/tmp/config"],
+        executable="/fake/eval-hub",
     )
     mock_exit.assert_called_once_with(0)
 


### PR DESCRIPTION


## What and why
(1) AIPCC builds ship a single `eval-hub` binary instead of platform-specific names (e.g. `eval-hub-linux-amd64`), causing FileNotFoundError at startup. Add fallback logic so `get_binary_path()` checks for a generic `eval-hub` binary before raising an error. 

(2) Also set argv[0] to "eval-hub-server" so usage messages show the wrapper name instead of the raw binary path.
Earlier: shows the full path to the binary
```
╰─➤  eval-hub-server --help
Usage of /Users/gnaulak/workspace/worktrees/local-custom-provider/.venv/lib/python3.12/site-packages/evalhub_server/binaries/eval-hub-darwin-arm64:
  -configdir string
    	Directory to search for configuration files.
  -local
    	Server operates in local mode or not.
```

Now: just refers to eval-hub-server
```
╰─➤  eval-hub-server --help
Usage of eval-hub-server:
  -configdir string
    	Directory to search for configuration files.
  -local
    	Server operates in local mode or not.
```
Closes # https://redhat.atlassian.net/browse/RHOAIENG-63588

Assisted-by: Claude

## Type

- [x] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced binary resolution with automatic fallback support when platform-specific binaries are unavailable; improved error messages for missing or unsupported binaries.

* **Tests**
  * Added comprehensive test coverage for binary path resolution; updated related test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->