### PR TITLE
chore(config): add `intents` benchmark to non-kfp garak provider

### DIFF
--- a/config/providers/garak.yaml
+++ b/config/providers/garak.yaml
@@ -25,11 +25,11 @@ benchmarks:
     description: Risk assessment with a context-aware custom intent typology and probes of increasing complexity.
     category: security
     metrics:
-    - attack_success_rate
+      - attack_success_rate
     tags:
-    - security
-    - intents
-    - red_team
+      - security
+      - intents
+      - red_team
     primary_score:
       metric: attack_success_rate
       lower_is_better: true

--- a/config/providers/garak.yaml
+++ b/config/providers/garak.yaml
@@ -20,6 +20,21 @@ runtime:
     # used for local mode tests (FVT)
     command: python tests/features/test_data/runtime/main.py
 benchmarks:
+  - id: intents
+    name: Context-aware vulnerability scan
+    description: Risk assessment with a context-aware custom intent typology and probes of increasing complexity.
+    category: security
+    metrics:
+    - attack_success_rate
+    tags:
+    - security
+    - intents
+    - red_team
+    primary_score:
+      metric: attack_success_rate
+      lower_is_better: true
+    pass_criteria:
+      threshold: 0.3
   - id: owasp_llm_top10
     name: OWASP LLM top 10 risk scan
     description: Tests against the top 10 security risks specific to LLM applications.


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->
With https://github.com/trustyai-explainability/llama-stack-provider-trustyai-garak/pull/163 and https://github.com/trustyai-explainability/trustyai-service-operator/pull/736 we enable `intents` scan for non-kfp mode. 

This PR adds and syncs the `intents` benchmark for garak config.

Closes [RHOAIENG-63138](https://redhat.atlassian.net/browse/RHOAIENG-63138)

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark configuration with customizable performance metrics and configurable pass criteria thresholds, enabling enhanced testing evaluation capabilities and more granular assessment options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->