### PR TITLE
fix(deps): update Go from 1.25.9 to 1.26.2 to address stdlib CVEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Eval Hub is an API REST server that serves as a routing and orchestration layer 
 
 **Required for All Development:**
 
-- Go 1.25.0+
+- Go 1.26.0+
 - [Make](https://www.gnu.org/software/make/) for build automation
 - Git
 - [uv](https://docs.astral.sh/uv/) for Python virtual environment management (required by `make test-fvt`, `make start-service`, and pre-commit hooks)
@@ -202,7 +202,7 @@ pre-commit run --all-files
 
 ### Go Standards
 
-- **Go Version**: Support 1.25.0+
+- **Go Version**: Support 1.26.0+
 - **Code Style**: Follow standard Go conventions (enforced by gofmt)
 - **Error Handling**: Always check and handle errors explicitly
 - **Documentation**: Use godoc-style comments for exported types and functions
@@ -470,7 +470,7 @@ When reporting bugs, include:
 
 **Environment**:
 - OS: [e.g. Ubuntu 22.04]
-- Go Version: [e.g. 1.25.0]
+- Go Version: [e.g. 1.26.0]
 - eval-hub Version: [e.g. 0.1.1]
 - Kubernetes Version: [e.g. 1.28]
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for the evaluation hub Go service
 # Build stage
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 ARG TARGETARCH
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The service uses Go's standard `net/http` router, structured logging with zap, P
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - Make
 - Python 3 (for `make test`; used by scripts/grcat for colored output)
 - [uv](https://docs.astral.sh/uv/) (manages the Python venv required by `make start-service` and FVT tests; run `make venv` to create it)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/eval-hub/eval-hub
 
-go 1.25.9
+go 1.26.2
 
-// toolchain go1.25.9
+// toolchain go1.26.2
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "chore-version-041",
+  "name": "eval-hub",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/tests/kubernetes/README.md
+++ b/tests/kubernetes/README.md
@@ -8,7 +8,7 @@ These tests validate Kubernetes resources created by eval-hub in a real cluster.
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - A running eval-hub service that is configured with Kubernetes runtime
 - Access to the Kubernetes cluster where resources are created (read-only is sufficient)
 


### PR DESCRIPTION
## Summary

- Updates Go from 1.25.9 to 1.26.2 to address 8 known standard library CVEs (all fixed in go1.25.10)
- Updates Containerfile to use `go-toolset:1.26` (verified available in `registry.access.redhat.com/ubi9/go-toolset`)
- Updates Go version references in README.md, CONTRIBUTING.md, and tests/kubernetes/README.md

### CVEs addressed

| CVE ID | Package | Severity | Description |
|--------|---------|----------|-------------|
| GO-2026-4986 | net/mail | - | Quadratic string concatenation in consumeComment |
| GO-2026-4982 | html/template | - | Bypass of meta content URL escaping causes XSS |
| GO-2026-4981 | net | - | Crash when handling long CNAME response |
| GO-2026-4980 | html/template | - | Escaper bypass leads to XSS |
| GO-2026-4977 | net/mail | - | Quadratic string concatenation in consumePhrase |
| GO-2026-4976 | net/http/httputil | - | ReverseProxy forwards queries with excess params |
| GO-2026-4971 | net | - | Panic in Dial/LookupPort handling NUL byte |
| GO-2026-4918 | net/http | - | Infinite loop in HTTP/2 transport with bad SETTINGS_MAX_FRAME_SIZE |

### Why go1.26.2 instead of go1.25.10?

go1.25.10 (which fixes all 8 CVEs) is **not yet available** in `registry.access.redhat.com/ubi9/go-toolset`. The latest 1.25.x tag in go-toolset is `1.25.9`. Per project guidelines, go.mod must not reference a version absent from go-toolset. go1.26.2 is the latest supported version in go-toolset (`go-toolset:1.26`) and includes all security fixes.

### Other dependencies scanned

- **Go third-party modules**: `govulncheck` found 0 module-level vulnerabilities
- **npm**: `npm audit` reports 0 vulnerabilities; all overrides (postcss@8.5.14, fast-xml-parser@5.7.3, lodash@4.18.1, dompurify@3.4.5, etc.) are at or above their respective CVE fix versions

## Test plan

- [x] `make build` — all 4 binaries compile successfully
- [x] `make fmt lint` — no formatting or lint issues
- [x] `make test` — all unit tests pass
- [x] Verified go-toolset:1.26 tag exists in registry.access.redhat.com/ubi9/go-toolset
- [ ] CI pipeline validates build and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go version requirement from 1.25+ to 1.26+ in development prerequisites, build configurations, and project documentation including contribution guides, README files, and Kubernetes test prerequisites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->