### PR TITLE
fix(ci): use username/password auth for pypi-cleanup TestPyPI cleanup

### DIFF
--- a/.github/workflows/publish-python-server.yml
+++ b/.github/workflows/publish-python-server.yml
@@ -250,7 +250,8 @@ jobs:
     steps:
       - name: Cleanup old TestPyPI dev releases
         env:
-          PYPI_CLEANUP_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          PYPI_CLEANUP_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+          PYPI_CLEANUP_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
         run: |
           KEEP=20
           REGEX=$(python3 -c "
@@ -271,13 +272,13 @@ jobs:
               sys.exit(0)
           to_delete = sorted(dev, key=lambda v: dev[v])[:-keep]
           print(f'Deleting {len(to_delete)} old dev releases, keeping {keep}', file=sys.stderr)
-          print('|'.join(re.escape(v) for v in to_delete))
+          print('|'.join(re.escape(v) + '$' for v in to_delete))
           ")
           if [ -n "$REGEX" ]; then
             pip install pypi-cleanup==0.1.10
             pypi-cleanup \
               --host https://test.pypi.org/ \
-              --username __token__ \
+              --username "$PYPI_CLEANUP_USERNAME" \
               --package eval-hub-server \
               --version-regex "$REGEX" \
               --do-it \


### PR DESCRIPTION
pypi-cleanup authenticates via the PyPI web login form, not the upload API, so API token auth (`__token__` + token) cannot work. Switch to dedicated username/password secrets passed safely through env vars.

Also anchor version-match regex with `$` to prevent unintended prefix matches when using `re.match()`.

## What and why

test.pypi pipeline clean up issue
Closes # NA

Assisted-by: Claude
## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TestPyPI release cleanup process with improved authentication handling and refined version matching logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->