### PR TITLE
chore(config): relocate misplaced YAML comments in provider configs

### DIFF
--- a/config/providers/guidellm.yaml
+++ b/config/providers/guidellm.yaml
@@ -113,12 +113,12 @@ benchmarks:
       - poisson
       - realistic
       - guidellm
-  # Pre-configured benchmark suites
     primary_score:
       metric: output_tokens_per_second
       lower_is_better: false
     pass_criteria:
       threshold: 10.0
+  # Pre-configured benchmark suites
   - id: quick_perf_test
     name: Quick performance snapshot
     description: Fast sweep-based evaluation with limited samples for rapid performance assessment.

--- a/config/providers/lighteval.yaml
+++ b/config/providers/lighteval.yaml
@@ -131,12 +131,12 @@ benchmarks:
       - glue
       - lighteval
       - suite
-  # Individual benchmarks
     primary_score:
       metric: acc
       lower_is_better: false
     pass_criteria:
       threshold: 0.25
+  # Individual benchmarks
   - id: hellaswag
     name: Everyday activity completion
     description: Picks the most plausible continuation of an everyday scenario (10,042 examples).


### PR DESCRIPTION
Move section-divider comments that were incorrectly placed inside benchmark entries (between tags and primary_score) to their intended positions between benchmark sections.

## What and why


Closes # NA

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

No