### PR TITLE
fix(tests): enhance error logging for job status timeout in evaluation tests

### DIFF
--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -513,7 +513,7 @@ func (tc *scenarioConfig) iWaitForEvaluationJobStatus(expectedStatus string) err
 	if lastErr != nil {
 		return tc.logError(lastErr)
 	}
-	return tc.logError(fmt.Errorf("timed out waiting for status %q, last status: %q", expectedStatus, lastStatus))
+	return tc.logError(fmt.Errorf("timed out after %v waiting for status %q, last status: %q", tc.waitDeadline, expectedStatus, lastStatus))
 }
 
 var errTestFileNotFound = errors.New("test file not found")


### PR DESCRIPTION
## What and why

- Updated the error message in the iWaitForEvaluationJobStatus function to include the wait deadline, providing clearer context when a timeout occurs.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced timeout error messages for evaluation jobs to display wait deadline and last observed job status, providing more detailed information for troubleshooting timeout issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->