### PR TITLE
test(fvt): enable collection override tests and fix expected error codes

### DIFF
--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1020,8 +1020,6 @@ Feature: Evaluation Jobs
     And the response should contain the value "resource_not_found" at path "$.message_code"
 
   @negative
-  @ignore
-  #https://redhat.atlassian.net/browse/RHOAIENG-62529
   Scenario: Cannot override OOB collection benchmark with invalid provider_id
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
@@ -1047,7 +1045,7 @@ Feature: Evaluation Jobs
       }
       """
     Then the response code should be 400
-    And the response should contain the value "request_validation_failed" at path "$.message_code"
+    And the response should contain the value "resource_does_not_exist" at path "$.message_code"
 
   @negative
   Scenario: Cannot override OOB collection benchmark with empty benchmark_id
@@ -1106,8 +1104,6 @@ Feature: Evaluation Jobs
     And the response should contain the value "request_validation_failed" at path "$.message_code"
 
   @negative
-  @ignore
-  #https://redhat.atlassian.net/browse/RHOAIENG-62531
   Scenario: Cannot override OOB collection benchmark with incorrect benchmark_id
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
@@ -1133,7 +1129,7 @@ Feature: Evaluation Jobs
       }
       """
     Then the response code should be 400
-    And the response should contain the value "request_validation_failed" at path "$.message_code"
+    And the response should contain the value "resource_does_not_exist" at path "$.message_code"
 
   @kueue
   Scenario: Create evaluation job with Kueue queue


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Remove `@ignore` tags from two OOB collection override scenarios that were blocked by RHOAIENG-62529 and RHOAIENG-62531. 

Update expected error codes from `request_validation_failed` to `resource_does_not_exist` to match actual API validation behavior.

Closes #

Assisted-by: <!-- Cursor, Claude etc -->

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Activated evaluation job override validation tests previously marked as ignored.
  * Updated error classification expectations for invalid or incorrect collection benchmark references to properly reflect `resource_does_not_exist` error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->