### PR TITLE
fix(deps): pin tmp@0.2.6 to address path traversal CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3197,9 +3197,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "uuid": "14.0.0",
     "fast-xml-parser": "5.7.3",
     "fast-uri": "3.1.2",
+    "tmp": "0.2.6",
     "lodash": "4.18.1",
     "dompurify": "3.4.5",
     "@cucumber/cucumber": {


### PR DESCRIPTION
## Summary
- Pins `tmp` npm dependency to `0.2.6` via overrides in `package.json` to fix [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) (CWE-22: Path Traversal via unsanitized prefix/postfix)
- The vulnerable `tmp@0.2.5` was a transitive dependency of `@cucumber/cucumber`
- Regenerated `package-lock.json` and verified `npm audit` reports 0 vulnerabilities
- Verified `make documentation` builds successfully with no changed output files

### Go stdlib CVEs (informational)
7 Go stdlib CVEs (GO-2026-4986, GO-2026-4982, GO-2026-4980, GO-2026-4977, GO-2026-4976, GO-2026-4971, GO-2026-4918) are fixed in Go 1.26.3, but `registry.access.redhat.com/ubi9/go-toolset` only supports up to Go 1.26.2 currently. The Go version update will need to wait until go-toolset is updated.

## Test plan
- [x] `npm audit` returns 0 vulnerabilities
- [x] `make documentation` builds successfully
- [x] No documentation output files changed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency version override to ensure improved compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->