### PR TITLE
test(fvt): add EA1 failure notes and enable Kueue validation test

### DIFF
--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1020,6 +1020,7 @@ Feature: Evaluation Jobs
     And the response should contain the value "resource_not_found" at path "$.message_code"
 
   @negative
+  # Expected to fail on 3.5 EA1 builds - was fixed in 3.5 EA2 (RHOAIENG-62529)
   Scenario: Cannot override OOB collection benchmark with invalid provider_id
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
@@ -1104,6 +1105,7 @@ Feature: Evaluation Jobs
     And the response should contain the value "request_validation_failed" at path "$.message_code"
 
   @negative
+  # Expected to fail on 3.5 EA1 builds - was fixed in 3.5 EA2 (RHOAIENG-62531)
   Scenario: Cannot override OOB collection benchmark with incorrect benchmark_id
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
@@ -1504,8 +1506,6 @@ Feature: Evaluation Jobs
 
   @kueue
   @negative
-  @ignore
-  # https://redhat.atlassian.net/browse/RHOAIENG-61584 - will remove the ignore tag once fix is deployed on the cluster and verified
   Scenario: Queue name with special characters is rejected
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->
Add documentation to collection override scenarios noting expected failures on 3.5 EA1 clusters where validation fixes (RHOAIENG-62529, RHOAIENG-62531) are not yet deployed.

Remove `@ignore` tag from Kueue queue name validation test (RHOAIENG-61584) now that the fix is deployed on both releases.


Closes #

Assisted-by: <!-- Cursor, Claude etc -->

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated evaluation jobs test suite to reflect fixes in newer builds.
  * Enabled previously ignored test scenario for improved test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->