### PR TITLE
fix(deps): pin protobufjs@7.5.9 to address GHSA-jggg-4jg4-v7c6 DoS CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -635,14 +635,13 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -653,9 +652,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -2548,9 +2547,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
+      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -2559,9 +2558,9 @@
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "fast-xml-parser": "5.7.3",
     "fast-uri": "3.1.2",
     "tmp": "0.2.6",
+    "protobufjs": "7.5.9",
     "lodash": "4.18.1",
     "dompurify": "3.4.5",
     "@cucumber/cucumber": {


### PR DESCRIPTION
## Summary

- Pins `protobufjs` to `7.5.9` in npm overrides to address [GHSA-jggg-4jg4-v7c6](https://github.com/advisories/GHSA-jggg-4jg4-v7c6) — Denial of Service via unbounded recursive JSON descriptor expansion (CVSS 5.3, moderate severity)
- The vulnerable version `protobufjs@7.5.6` was pulled in as a transitive devDependency via `cucumber-html-reporter` → `@opentelemetry/otlp-transformer` → `protobufjs`
- Regenerated `package-lock.json` via `npm install`; `npm audit` now reports 0 vulnerabilities
- Verified `make documentation` still builds successfully with no output changes

### Go standard library CVEs (not fixed in this PR)

`govulncheck` identified 7 vulnerabilities in the Go 1.26.2 standard library (GO-2026-4986, GO-2026-4982, GO-2026-4980, GO-2026-4977, GO-2026-4976, GO-2026-4971, GO-2026-4918), all fixed in Go 1.26.3. However, `registry.access.redhat.com/ubi9/go-toolset` does not yet publish a 1.26.3 tag — per repository policy, `go.mod` must not be updated until the same version exists in go-toolset. These CVEs should be addressed once go-toolset 1.26.3 becomes available.

## Test plan

- [x] `npm audit` reports 0 vulnerabilities
- [x] `make documentation` builds successfully with no output changes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->