### PR TITLE
fix: Reject pass_criteria without threshold on providers

### DIFF
--- a/pkg/api/providers.go
+++ b/pkg/api/providers.go
@@ -11,7 +11,7 @@ type BenchmarkResource struct {
 	DatasetSize  int           `mapstructure:"dataset_size" yaml:"dataset_size" json:"dataset_size"`
 	Tags         []string      `mapstructure:"tags" yaml:"tags" json:"tags,omitempty"`
 	PrimaryScore *PrimaryScore `mapstructure:"primary_score" yaml:"primary_score" json:"primary_score,omitempty"`
-	PassCriteria *PassCriteria `mapstructure:"pass_criteria" yaml:"pass_criteria" json:"pass_criteria,omitempty"`
+	PassCriteria *PassCriteria `mapstructure:"pass_criteria" yaml:"pass_criteria" json:"pass_criteria,omitempty" validate:"omitempty"`
 }
 
 type ProviderConfig struct {
@@ -19,7 +19,7 @@ type ProviderConfig struct {
 	Description string              `mapstructure:"description" yaml:"description" json:"description,omitempty" validate:"omitempty,max=1024,min=1"`
 	Title       string              `mapstructure:"title" yaml:"title" json:"title"`
 	Tags        []string            `mapstructure:"tags" yaml:"tags" json:"tags,omitempty" validate:"omitempty,dive,tagname"`
-	Benchmarks  []BenchmarkResource `mapstructure:"benchmarks" yaml:"benchmarks" json:"benchmarks"`
+	Benchmarks  []BenchmarkResource `mapstructure:"benchmarks" yaml:"benchmarks" json:"benchmarks" validate:"dive"`
 	Runtime     *Runtime            `mapstructure:"runtime" yaml:"runtime" json:"runtime,omitempty"`
 }
 


### PR DESCRIPTION

## What and why
The swagger states that `threshold` is required when `pass_criteria` is provided. However, submitting "pass_criteria": {} without a threshold was silently accepted and stored, causing the API to return {"threshold": null} in responses breaking SDK clients that correctly treat threshold as required.
Root cause: 
Two missing validation tags in providers.go:
```
ProviderConfig.Benchmarks had no validate:"dive" — so the validator never recursed into individual BenchmarkResource items
BenchmarkResource.PassCriteria had no validate:"omitempty" — so even if the validator reached it, it wouldn't check the nested PassCriteria struct
```

<!-- What does this PR do and why? Link to related issues. -->
https://redhat.atlassian.net/browse/RHOAIENG-64962 and https://github.com/eval-hub/eval-hub/issues/575

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

Provider creation with `"pass_criteria": {}` result in the below error 
```
{
  "message_code": "request_validation_failed",
  "message": "The request validation failed: 'Key: 'ProviderConfig.benchmarks[2].pass_criteria.threshold' Error:Field validation for 'threshold' failed on the 'required' tag'. Please check the request and try again.",
  "trace": "f34369e4-a2f6-4475-a28f-a04cd3766482"
}
```
## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal validation configuration for improved data consistency and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->