### PR TITLE
feat(tests): add disconnected state handling in jsonnet tests

### DIFF
--- a/tests/features/gpu_step_definitions_test.go
+++ b/tests/features/gpu_step_definitions_test.go
@@ -936,7 +936,7 @@ func (tc *scenarioConfig) iWaitForSchedulingError(duration string) error {
 		case <-ticker.C:
 			// Check pod events for scheduling errors
 			cmd := exec.Command("oc", "get", "events", "-n", namespace,
-				"--field-selector", fmt.Sprintf("involvedObject.kind=Pod,reason=FailedScheduling"),
+				"--field-selector", "involvedObject.kind=Pod,reason=FailedScheduling",
 				"-o", "jsonpath={.items[*].message}")
 			output, err := cmd.CombinedOutput()
 			if err == nil && strings.Contains(string(output), "gpu") {

--- a/tests/features/jsonnet_test.go
+++ b/tests/features/jsonnet_test.go
@@ -440,8 +440,8 @@ func TestEvaluateEvaluationJobJsonnetDisconnected(t *testing.T) {
 		t.Fatalf("benchmarks = %#v, want one benchmark", job.Benchmarks)
 	}
 	b := job.Benchmarks[0]
-	if b.ID != "blimp" {
-		t.Errorf("benchmark id = %q, want blimp", b.ID)
+	if b.ID != "arc_easy" {
+		t.Errorf("benchmark id = %q, want arc_easy", b.ID)
 	}
 	if b.Parameters["tokenizer"] != "/test_data/tokenizer" {
 		t.Errorf("tokenizer = %v, want /test_data/tokenizer", b.Parameters["tokenizer"])

--- a/tests/features/jsonnet_test.go
+++ b/tests/features/jsonnet_test.go
@@ -15,6 +15,7 @@ type jsonnetHarness struct {
 	Env           map[string]string `json:"env"`
 	Values        map[string]string `json:"values"`
 	MlflowEnabled bool              `json:"mlflow_enabled"`
+	Disconnected  bool              `json:"disconnected"`
 }
 
 // jsonnetSiblingName returns the test-data filename with a .jsonnet extension for the
@@ -69,10 +70,12 @@ func (tc *scenarioConfig) jsonnetHarnessJSON() (string, error) {
 	if tc.jsonnetMlflowEnabled != nil {
 		mlflowEnabled = *tc.jsonnetMlflowEnabled
 	}
+	disconnected := strings.Contains(strings.ToLower(env["ENVIRONMENT_ID"]), "disconnected")
 	harness := jsonnetHarness{
 		Env:           env,
 		Values:        values,
 		MlflowEnabled: mlflowEnabled,
+		Disconnected:  disconnected,
 	}
 	encoded, err := json.Marshal(harness)
 	if err != nil {
@@ -399,6 +402,52 @@ test.collection()
 	}
 	if got["collection"]["id"] != "col-123" {
 		t.Errorf("collection.id = %q, want col-123", got["collection"]["id"])
+	}
+}
+
+func TestEvaluateEvaluationJobJsonnetDisconnected(t *testing.T) {
+	tc := &scenarioConfig{
+		values: map[string]string{},
+		jsonnetHarnessEnv: map[string]string{
+			"ENVIRONMENT_ID": "disconnected",
+		},
+	}
+	path, err := filepath.Abs(filepath.Join(testDataRoot(), "evaluation_job.jsonnet"))
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	out, err := tc.evaluateJsonnetFile(path)
+	if err != nil {
+		t.Fatalf("evaluateJsonnetFile: %v", err)
+	}
+	var job struct {
+		Benchmarks []struct {
+			ID          string         `json:"id"`
+			Parameters  map[string]any `json:"parameters"`
+			TestDataRef struct {
+				S3 struct {
+					Bucket    string `json:"bucket"`
+					Key       string `json:"key"`
+					SecretRef string `json:"secret_ref"`
+				} `json:"s3"`
+			} `json:"test_data_ref"`
+		} `json:"benchmarks"`
+	}
+	if err := json.Unmarshal([]byte(out), &job); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(job.Benchmarks) != 1 {
+		t.Fatalf("benchmarks = %#v, want one benchmark", job.Benchmarks)
+	}
+	b := job.Benchmarks[0]
+	if b.ID != "blimp" {
+		t.Errorf("benchmark id = %q, want blimp", b.ID)
+	}
+	if b.Parameters["tokenizer"] != "/test_data/tokenizer" {
+		t.Errorf("tokenizer = %v, want /test_data/tokenizer", b.Parameters["tokenizer"])
+	}
+	if b.TestDataRef.S3.Bucket != "mlpipeline" || b.TestDataRef.S3.Key != "offline" || b.TestDataRef.S3.SecretRef != "minio-test" {
+		t.Errorf("test_data_ref.s3 = %+v, want mlpipeline/offline/minio-test", b.TestDataRef.S3)
 	}
 }
 

--- a/tests/features/test_data/evaluation_job.jsonnet
+++ b/tests/features/test_data/evaluation_job.jsonnet
@@ -7,18 +7,7 @@ test.mergeOptional(
       model: test.model(),
       name: 'test-evaluation-job',
     } + if collectionId == '' then {
-      benchmarks: [
-        {
-          id: 'arc_easy',
-          provider_id: 'lm_evaluation_harness',
-          parameters: {
-            num_examples: 10,
-            num_fewshot: 3,
-            limit: 5,
-            tokenizer: 'google/flan-t5-small',
-          },
-        },
-      ],
+      benchmarks: [test.defaultBenchmark()],
       tags: ['environment'],
     } else {},
     if collectionId != '' then test.collection() else null,

--- a/tests/features/test_data/jsonnet/test.libsonnet
+++ b/tests/features/test_data/jsonnet/test.libsonnet
@@ -25,6 +25,35 @@ local harness = std.parseJson(std.extVar('harness'));
   mlflow(name)::
     if harness.mlflow_enabled then name else '',
 
+  // Default benchmark for evaluation_job.jsonnet (disconnected vs connected FVT).
+  defaultBenchmark()::
+    if harness.disconnected then {
+      id: 'arc_easy',
+      provider_id: 'lm_evaluation_harness',
+      parameters: {
+        num_examples: 10,
+        num_fewshot: 3,
+        limit: 5,
+        tokenizer: '/test_data/tokenizer',
+      },
+      test_data_ref: {
+        s3: {
+          bucket: $.env('TEST_DATA_S3_BUCKET', 'mlpipeline'),
+          key: $.env('TEST_DATA_S3_KEY', 'offline'),
+          secret_ref: $.env('TEST_DATA_S3_SECRET_REF', 'minio-test'),
+        },
+      },
+    } else {
+      id: 'arc_easy',
+      provider_id: 'lm_evaluation_harness',
+      parameters: {
+        num_examples: 10,
+        num_fewshot: 3,
+        limit: 5,
+        tokenizer: 'google/flan-t5-small',
+      },
+    },
+
   // Default evaluation job model block used across many scenarios.
   model()::
     local secretRef = $.env('MODEL_AUTH_SECRET_REF', '');


### PR DESCRIPTION
## What and why

- Introduced a new field `Disconnected` in the `jsonnetHarness` struct to track the disconnected state.
- Updated the `jsonnetHarnessJSON` method to set the `Disconnected` field based on the `ENVIRONMENT_ID`.
- Added a new test `TestEvaluateEvaluationJobJsonnetDisconnected` to validate behavior when the environment is set to disconnected.
- Modified `evaluation_job.jsonnet` to use a default benchmark based on the disconnected state.
- Enhanced `test.libsonnet` to define a default benchmark for disconnected scenarios.


Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced GPU scheduling error detection validation
  * Added support for testing disconnected environment scenarios
  * Improved test configuration structure and reusability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->