### PR TITLE
fix(ci): restore automatic validate-wheels on push events

### DIFF
--- a/.github/workflows/publish-python-server.yml
+++ b/.github/workflows/publish-python-server.yml
@@ -152,7 +152,7 @@ jobs:
   validate-wheels:
     name: Validate wheel (${{ matrix.os }})
     needs: build-wheels
-    if: inputs.validate-wheels != false
+    if: github.event_name != 'workflow_dispatch' || inputs.validate-wheels != false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION


## What and why

I might have regressed this in last PR.  On PR merge it was not running validate_wheels step. This PR fixes.

Changes:
The `inputs.validate-wheels != false` condition skips validation on push events because the undefined input coerces to false. Gate the input check on workflow_dispatch so push triggers always validate.

Closes # NA

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

should work now for manual - enable and disable also
<img width="822" height="462" alt="Screenshot 2026-05-29 at 2 44 20 PM" src="https://github.com/user-attachments/assets/28663013-b9d4-4bcb-9f74-2961926136c3" />
<img width="1087" height="475" alt="Screenshot 2026-05-29 at 2 54 54 PM" src="https://github.com/user-attachments/assets/83a6dd75-0623-4c2a-91f0-cd054788b306" />




## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow execution condition for wheel validation to correctly handle both manual and automated trigger events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->