### PR TITLE
feat(tests): add serialization failure handling and retry logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,9 @@ test-coverage: $(BIN_DIR) ## Run unit tests with coverage
 
 test-all: test test-fvt test-fvt-server ## Run all tests (unit + FVT)
 
+test-help:
+	@go help testflag
+
 SERVER_URL ?= http://localhost:8080
 
 ## ------------------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-mcp build-all-platforms cross-compile-mcp build-all-platforms-mcp start-service stop-service start-sidecar stop-sidecar lint test test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet update-deps generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components fvt-report docker-image-local docker-mcp-version test-mcp-build-all test-mcp-binary-info test-mcp-binary-naming test-mcp-version test-mcp-no-runtime-deps test-mcp-container-build test-mcp-container-http test-mcp-checksums test-mcp-formula-syntax test-mcp-native-smoke test-mcp-brew-install test-mcp-brew-test test-mcp-brew-uninstall test-mcp-cross-platform test-mcp-e2e test-mcp test-mcp-vscode
+.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-mcp build-all-platforms cross-compile-mcp build-all-platforms-mcp start-service stop-service start-sidecar stop-sidecar lint test test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet update-deps generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components fvt-report docker-image-local docker-mcp-version test-mcp-build-all test-mcp-binary-info test-mcp-binary-naming test-mcp-version test-mcp-no-runtime-deps test-mcp-container-build test-mcp-container-http test-mcp-checksums test-mcp-formula-syntax test-mcp-native-smoke test-mcp-brew-install test-mcp-brew-test test-mcp-brew-uninstall test-mcp-cross-platform test-mcp-e2e test-mcp test-mcp-vscode test-help
 
 GOPATH := $(shell go env GOPATH)
 GOBIN := $(shell go env GOPATH)/bin
@@ -172,7 +172,7 @@ test-coverage: $(BIN_DIR) ## Run unit tests with coverage
 
 test-all: test test-fvt test-fvt-server ## Run all tests (unit + FVT)
 
-test-help:
+test-help: ## Display Go test flags documentation
 	@go help testflag
 
 SERVER_URL ?= http://localhost:8080

--- a/internal/eval_hub/storage/sql/isolation_level_test.go
+++ b/internal/eval_hub/storage/sql/isolation_level_test.go
@@ -26,15 +26,15 @@ func TestGetIsolationLevel(t *testing.T) {
 		}
 	})
 
-	t.Run("driver postgres returns serializable when debug env unset", func(t *testing.T) {
+	t.Run("driver postgres returns read committed when debug env unset", func(t *testing.T) {
 		isolationLevel := ""
 		cfg := &shared.SQLDatabaseConfig{Driver: sql.POSTGRES_DRIVER}
 		level, err := sql.GetIsolationLevel(isolationLevel, cfg, logger)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if level != gosql.LevelSerializable {
-			t.Fatalf("want %v, got %v", gosql.LevelSerializable, level)
+		if level != gosql.LevelReadCommitted {
+			t.Fatalf("want %v, got %v", gosql.LevelReadCommitted, level)
 		}
 	})
 

--- a/internal/eval_hub/storage/sql/serialization_failure.go
+++ b/internal/eval_hub/storage/sql/serialization_failure.go
@@ -2,12 +2,19 @@ package sql
 
 import (
 	"errors"
+	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
 const serializationFailureMaxAttempts = 5
+
+const (
+	serializationRetryBaseDelay = 10 * time.Millisecond
+	serializationRetryMaxDelay  = 250 * time.Millisecond
+)
 
 func isSerializationFailure(err error) bool {
 	if err == nil {
@@ -22,6 +29,18 @@ func isSerializationFailure(err error) bool {
 		strings.Contains(msg, "could not serialize access due to read/write dependencies among transactions")
 }
 
+func serializationFailureBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		return 0
+	}
+	delay := serializationRetryBaseDelay << (attempt - 1)
+	if delay > serializationRetryMaxDelay {
+		delay = serializationRetryMaxDelay
+	}
+	jitter := time.Duration(rand.Int63n(int64(delay/4 + 1)))
+	return delay + jitter
+}
+
 func retryOnSerializationFailure(maxAttempts int, run func() error) error {
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
@@ -32,6 +51,7 @@ func retryOnSerializationFailure(maxAttempts int, run func() error) error {
 		if !isSerializationFailure(lastErr) || attempt == maxAttempts {
 			return lastErr
 		}
+		time.Sleep(serializationFailureBackoff(attempt))
 	}
 	return lastErr
 }

--- a/internal/eval_hub/storage/sql/serialization_failure.go
+++ b/internal/eval_hub/storage/sql/serialization_failure.go
@@ -1,0 +1,37 @@
+package sql
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+const serializationFailureMaxAttempts = 5
+
+func isSerializationFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "40001" {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SQLSTATE 40001") ||
+		strings.Contains(msg, "could not serialize access due to read/write dependencies among transactions")
+}
+
+func retryOnSerializationFailure(maxAttempts int, run func() error) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		lastErr = run()
+		if lastErr == nil {
+			return nil
+		}
+		if !isSerializationFailure(lastErr) || attempt == maxAttempts {
+			return lastErr
+		}
+	}
+	return lastErr
+}

--- a/internal/eval_hub/storage/sql/serialization_failure_test.go
+++ b/internal/eval_hub/storage/sql/serialization_failure_test.go
@@ -57,6 +57,21 @@ func TestIsSerializationFailure(t *testing.T) {
 	}
 }
 
+func TestSerializationFailureBackoff(t *testing.T) {
+	t.Parallel()
+
+	if got := serializationFailureBackoff(0); got != 0 {
+		t.Fatalf("serializationFailureBackoff(0) = %v, want 0", got)
+	}
+	for attempt := 1; attempt <= 10; attempt++ {
+		got := serializationFailureBackoff(attempt)
+		wantMax := serializationRetryMaxDelay + serializationRetryMaxDelay/4
+		if got < serializationRetryBaseDelay || got > wantMax {
+			t.Fatalf("serializationFailureBackoff(%d) = %v, want in [%v, %v]", attempt, got, serializationRetryBaseDelay, wantMax)
+		}
+	}
+}
+
 func TestRetryOnSerializationFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/eval_hub/storage/sql/serialization_failure_test.go
+++ b/internal/eval_hub/storage/sql/serialization_failure_test.go
@@ -1,0 +1,124 @@
+package sql
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestIsSerializationFailure(t *testing.T) {
+	t.Parallel()
+
+	pgErr := &pgconn.PgError{Code: "40001", Message: "could not serialize access due to read/write dependencies among transactions"}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "pg 40001", err: pgErr, want: true},
+		{name: "wrapped pg 40001", err: fmt.Errorf("commit failed: %w", pgErr), want: true},
+		{name: "other pg code", err: &pgconn.PgError{Code: "23505"}, want: false},
+		{name: "generic error", err: errors.New("connection reset"), want: false},
+		{
+			name: "service error with sqlstate text",
+			err: serviceerrors.NewServiceError(
+				messages.DatabaseOperationFailed,
+				"Type", "commit transaction update evaluation job",
+				"ResourceId", "job-1",
+				"Error", "ERROR: could not serialize access due to read/write dependencies among transactions (SQLSTATE 40001)",
+			),
+			want: true,
+		},
+		{
+			name: "service error unrelated",
+			err: serviceerrors.NewServiceError(
+				messages.DatabaseOperationFailed,
+				"Type", "commit transaction update evaluation job",
+				"ResourceId", "job-1",
+				"Error", "connection refused",
+			),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isSerializationFailure(tt.err); got != tt.want {
+				t.Fatalf("isSerializationFailure() = %v, want %v (err=%v)", got, tt.want, tt.err)
+			}
+		})
+	}
+}
+
+func TestRetryOnSerializationFailure(t *testing.T) {
+	t.Parallel()
+
+	serializationErr := &pgconn.PgError{Code: "40001", Message: "could not serialize access"}
+	otherErr := errors.New("permanent failure")
+
+	t.Run("succeeds first attempt", func(t *testing.T) {
+		attempts := 0
+		err := retryOnSerializationFailure(3, func() error {
+			attempts++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("retryOnSerializationFailure() = %v, want nil", err)
+		}
+		if attempts != 1 {
+			t.Fatalf("attempts = %d, want 1", attempts)
+		}
+	})
+
+	t.Run("retries serialization failure then succeeds", func(t *testing.T) {
+		attempts := 0
+		err := retryOnSerializationFailure(3, func() error {
+			attempts++
+			if attempts < 3 {
+				return serializationErr
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("retryOnSerializationFailure() = %v, want nil", err)
+		}
+		if attempts != 3 {
+			t.Fatalf("attempts = %d, want 3", attempts)
+		}
+	})
+
+	t.Run("stops after max attempts", func(t *testing.T) {
+		attempts := 0
+		err := retryOnSerializationFailure(3, func() error {
+			attempts++
+			return serializationErr
+		})
+		if !errors.Is(err, serializationErr) {
+			t.Fatalf("retryOnSerializationFailure() = %v, want serialization error", err)
+		}
+		if attempts != 3 {
+			t.Fatalf("attempts = %d, want 3", attempts)
+		}
+	})
+
+	t.Run("does not retry other errors", func(t *testing.T) {
+		attempts := 0
+		err := retryOnSerializationFailure(3, func() error {
+			attempts++
+			return otherErr
+		})
+		if !errors.Is(err, otherErr) {
+			t.Fatalf("retryOnSerializationFailure() = %v, want other error", err)
+		}
+		if attempts != 1 {
+			t.Fatalf("attempts = %d, want 1", attempts)
+		}
+	})
+}

--- a/internal/eval_hub/storage/sql/sql.go
+++ b/internal/eval_hub/storage/sql/sql.go
@@ -201,7 +201,10 @@ func getIsolationLevel(isolationLevel string, config *shared.SQLDatabaseConfig, 
 	case SQLITE_DRIVER:
 		return sql.LevelDefault, nil
 	case POSTGRES_DRIVER:
-		return sql.LevelSerializable, nil
+		// Read Committed matches PostgreSQL's default and avoids Serializable
+		// snapshot conflicts (SQLSTATE 40001) under concurrent job updates.
+		// Override with DEBUG_SQL_ISOLATION_LEVEL=Serializable when needed.
+		return sql.LevelReadCommitted, nil
 	default:
 		return sql.LevelDefault, nil
 	}

--- a/internal/eval_hub/storage/sql/transaction.go
+++ b/internal/eval_hub/storage/sql/transaction.go
@@ -9,8 +9,14 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
 )
 
+// TransactionFunction runs database work inside a transaction begun by runTransaction.
+// It may be invoked more than once when runTransaction retries on serialization
+// failure (SQLSTATE 40001); callbacks must be retry-safe—limit work to operations
+// against the provided *sql.Tx and avoid irreversible side effects outside the DB.
 type TransactionFunction func(*sql.Tx) error
 
+// withTransaction runs fn inside a transaction, retrying the full transaction on
+// serialization failure via retryOnSerializationFailure. See TransactionFunction.
 func (s *sqlStorage) withTransaction(name string, resourceID string, fn TransactionFunction) error {
 	return retryOnSerializationFailure(serializationFailureMaxAttempts, func() error {
 		err := s.runTransaction(name, resourceID, fn)
@@ -27,6 +33,9 @@ func (s *sqlStorage) withTransaction(name string, resourceID string, fn Transact
 	})
 }
 
+// runTransaction begins a transaction, runs fn, then commits or rolls back.
+// Serialization-failure retries are applied by withTransaction, which re-invokes
+// runTransaction (and thus fn) until success or retryOnSerializationFailure exhausts attempts.
 func (s *sqlStorage) runTransaction(name string, resourceID string, fn TransactionFunction) error {
 	txn, err := s.pool.BeginTx(s.ctx, &sql.TxOptions{Isolation: s.isolationLevel})
 	if err != nil {

--- a/internal/eval_hub/storage/sql/transaction.go
+++ b/internal/eval_hub/storage/sql/transaction.go
@@ -12,6 +12,22 @@ import (
 type TransactionFunction func(*sql.Tx) error
 
 func (s *sqlStorage) withTransaction(name string, resourceID string, fn TransactionFunction) error {
+	return retryOnSerializationFailure(serializationFailureMaxAttempts, func() error {
+		err := s.runTransaction(name, resourceID, fn)
+		if err != nil && isSerializationFailure(err) {
+			s.logger.Warn(
+				"Transaction failed with serialization error; will retry if attempts remain",
+				"name", name,
+				"resource_id", resourceID,
+				"isolation_level", s.isolationLevel.String(),
+				"error", err.Error(),
+			)
+		}
+		return err
+	})
+}
+
+func (s *sqlStorage) runTransaction(name string, resourceID string, fn TransactionFunction) error {
 	txn, err := s.pool.BeginTx(s.ctx, &sql.TxOptions{Isolation: s.isolationLevel})
 	if err != nil {
 		s.logger.Error("Failed to begin transaction", "name", fmt.Sprintf("begin transaction %s", name), "resource_id", resourceID, "isolation_level", s.isolationLevel.String(), "error", err.Error())
@@ -32,6 +48,7 @@ func (s *sqlStorage) withTransaction(name string, resourceID string, fn Transact
 	}
 	if commit {
 		if txnErr := txn.Commit(); txnErr != nil {
+			_ = txn.Rollback()
 			s.logger.Error("Failed to commit transaction", "name", fmt.Sprintf("commit transaction %s", name), "resource_id", resourceID, "isolation_level", s.isolationLevel.String(), "error", txnErr.Error())
 			return serviceerrors.NewServiceError(messages.DatabaseOperationFailed, "Type", fmt.Sprintf("commit transaction %s", name), "ResourceId", resourceID, "Error", txnErr.Error())
 		}


### PR DESCRIPTION
## What and why

- Introduced `isSerializationFailure` and `retryOnSerializationFailure` functions to handle PostgreSQL serialization errors.
- Updated `withTransaction` method to retry transactions on serialization failures.
- Added comprehensive tests for serialization failure scenarios in `serialization_failure_test.go`.
- Modified `GetIsolationLevel` to return `LevelReadCommitted` as the default for PostgreSQL to avoid serialization conflicts.
- Added a new `test-help` target in the Makefile for Go test flags.

Assisted-by: Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transactions now automatically retry when PostgreSQL detects serialization conflicts, improving reliability during concurrent operations.
* **Tests**
  * Added comprehensive test coverage for serialization failure detection and automatic retry logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->