### PR TITLE
feat: add workspace support to MLflow client

### DIFF
--- a/internal/eval_hub/mlflow/mlflow.go
+++ b/internal/eval_hub/mlflow/mlflow.go
@@ -19,6 +19,8 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
+const workspaceProbeTimeout = 5 * time.Second
+
 func NewMLFlowClient(config *config.Config, logger *slog.Logger) (*mlflowclient.Client, error) {
 	url := ""
 	if config.MLFlow != nil && config.MLFlow.TrackingURI != "" {
@@ -93,7 +95,19 @@ func NewMLFlowClient(config *config.Config, logger *slog.Logger) (*mlflowclient.
 		logger.Info("MLflow static auth token configured (fallback)")
 	}
 
-	workspacesEnabled, err := client.ProbeWorkspacesEnabled()
+	if config.IsOTELEnabled() {
+		currentHTTPClient := client.GetHTTPClient()
+		client = client.WithHTTPClient(&http.Client{
+			Transport: otelhttp.NewTransport(currentHTTPClient.Transport),
+			Timeout:   currentHTTPClient.Timeout,
+		})
+		logger.Info("Enabled OTEL transport for MLFlow client")
+	}
+
+	probeCtx, cancel := context.WithTimeout(context.Background(), workspaceProbeTimeout)
+	defer cancel()
+
+	workspacesEnabled, err := client.WithContext(probeCtx).ProbeWorkspacesEnabled()
 	if err != nil {
 		logger.Warn(
 			"Could not probe MLflow workspace support; workspace headers will not be sent",
@@ -114,15 +128,6 @@ func NewMLFlowClient(config *config.Config, logger *slog.Logger) (*mlflowclient.
 				"workspace", config.MLFlow.Workspace,
 			)
 		}
-	}
-
-	if config.IsOTELEnabled() {
-		currentHTTPClient := client.GetHTTPClient()
-		client = client.WithHTTPClient(&http.Client{
-			Transport: otelhttp.NewTransport(currentHTTPClient.Transport),
-			Timeout:   currentHTTPClient.Timeout,
-		})
-		logger.Info("Enabled OTEL transport for MLFlow client")
 	}
 
 	logger.Info("MLFlow tracking enabled", "mlflow_experiment_url", client.GetExperimentsURL())

--- a/internal/eval_hub/mlflow/mlflow.go
+++ b/internal/eval_hub/mlflow/mlflow.go
@@ -93,10 +93,27 @@ func NewMLFlowClient(config *config.Config, logger *slog.Logger) (*mlflowclient.
 		logger.Info("MLflow static auth token configured (fallback)")
 	}
 
-	// Set workspace if configured
+	workspacesEnabled, err := client.ProbeWorkspacesEnabled()
+	if err != nil {
+		logger.Warn(
+			"Could not probe MLflow workspace support; workspace headers will not be sent",
+			"error", err.Error(),
+		)
+		workspacesEnabled = false
+	}
+	client = client.WithWorkspacesSupport(workspacesEnabled)
+	logger.Info("MLflow workspace support probed", "workspaces_enabled", workspacesEnabled)
+
 	if config.MLFlow.Workspace != "" {
-		client = client.WithWorkspace(config.MLFlow.Workspace)
-		logger.Info("MLflow workspace configured", "workspace", config.MLFlow.Workspace)
+		if workspacesEnabled {
+			client = client.WithWorkspace(config.MLFlow.Workspace)
+			logger.Info("MLflow workspace configured", "workspace", config.MLFlow.Workspace)
+		} else {
+			logger.Warn(
+				"MLFLOW_WORKSPACE is set but the MLflow server does not support workspaces; ignoring",
+				"workspace", config.MLFlow.Workspace,
+			)
+		}
 	}
 
 	if config.IsOTELEnabled() {
@@ -160,6 +177,10 @@ func GetOrCreateExperimentID(mlflowClient *mlflowclient.Client, jobConfig *api.E
 
 	if mlflowClient == nil {
 		return "", "", serviceerrors.NewServiceError(messages.MLFlowRequiredForExperiment)
+	}
+
+	if err := mlflowClient.EnsureWorkspace(); err != nil {
+		return "", "", serviceerrors.NewServiceError(messages.MLFlowRequestFailed, "Error", err.Error())
 	}
 
 	mlflowExperiment, err := mlflowClient.GetExperimentByName(jobConfig.Experiment.Name)

--- a/internal/eval_hub/mlflow/mlflow_test.go
+++ b/internal/eval_hub/mlflow/mlflow_test.go
@@ -1,0 +1,316 @@
+package mlflow
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
+	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/eval-hub/eval-hub/pkg/mlflowclient"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+func mlflowServiceConfig(t *testing.T, trackingURI string, mutate func(*config.MLFlowConfig)) *config.Config {
+	t.Helper()
+	cfg := &config.Config{
+		MLFlow: &config.MLFlowConfig{
+			TrackingURI: trackingURI,
+			TokenPath:   filepath.Join(t.TempDir(), "no-such-token"),
+		},
+	}
+	if mutate != nil {
+		mutate(cfg.MLFlow)
+	}
+	return cfg
+}
+
+func TestNewMLFlowClient(t *testing.T) {
+	t.Parallel()
+	logger := testLogger()
+
+	t.Run("no tracking URI", func(t *testing.T) {
+		t.Parallel()
+		client, err := NewMLFlowClient(&config.Config{MLFlow: &config.MLFlowConfig{}}, logger)
+		if err != nil {
+			t.Fatalf("NewMLFlowClient() err = %v", err)
+		}
+		if client != nil {
+			t.Fatal("expected nil client when tracking URI is unset")
+		}
+	})
+
+	t.Run("probes workspaces and configures workspace", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/3.0/mlflow/server-info":
+				_ = json.NewEncoder(w).Encode(mlflowclient.ServerInfoResponse{WorkspacesEnabled: true})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		cfg := mlflowServiceConfig(t, srv.URL, func(m *config.MLFlowConfig) {
+			m.Workspace = "prod-ws"
+			m.Token = "static-token"
+		})
+		client, err := NewMLFlowClient(cfg, logger)
+		if err != nil {
+			t.Fatalf("NewMLFlowClient() err = %v", err)
+		}
+		if !client.WorkspacesEnabled() {
+			t.Fatal("expected workspaces enabled after probe")
+		}
+	})
+
+	t.Run("probe failure still returns client", func(t *testing.T) {
+		t.Parallel()
+		cfg := mlflowServiceConfig(t, "http://127.0.0.1:1", nil)
+		client, err := NewMLFlowClient(cfg, logger)
+		if err != nil {
+			t.Fatalf("NewMLFlowClient() err = %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected client when probe fails")
+		}
+		if client.WorkspacesEnabled() {
+			t.Fatal("expected workspaces disabled when probe fails")
+		}
+	})
+
+	t.Run("workspace ignored when server disables workspaces", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(mlflowclient.ServerInfoResponse{WorkspacesEnabled: false})
+		}))
+		t.Cleanup(srv.Close)
+
+		cfg := mlflowServiceConfig(t, srv.URL, func(m *config.MLFlowConfig) {
+			m.Workspace = "ignored-ws"
+		})
+		client, err := NewMLFlowClient(cfg, logger)
+		if err != nil {
+			t.Fatalf("NewMLFlowClient() err = %v", err)
+		}
+		if client.WorkspacesEnabled() {
+			t.Fatal("expected workspaces disabled")
+		}
+	})
+
+	t.Run("invalid CA certificate path", func(t *testing.T) {
+		t.Parallel()
+		cfg := mlflowServiceConfig(t, "http://localhost:5000", func(m *config.MLFlowConfig) {
+			m.CACertPath = filepath.Join(t.TempDir(), "missing-ca.pem")
+		})
+		_, err := NewMLFlowClient(cfg, logger)
+		if err == nil {
+			t.Fatal("expected error for missing CA file")
+		}
+		if !strings.Contains(err.Error(), "failed to read MLflow CA certificate") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid CA certificate PEM", func(t *testing.T) {
+		t.Parallel()
+		caPath := filepath.Join(t.TempDir(), "bad-ca.pem")
+		if err := os.WriteFile(caPath, []byte("not a certificate"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := mlflowServiceConfig(t, "http://localhost:5000", func(m *config.MLFlowConfig) {
+			m.CACertPath = caPath
+		})
+		_, err := NewMLFlowClient(cfg, logger)
+		if err == nil {
+			t.Fatal("expected error for invalid CA PEM")
+		}
+		if !strings.Contains(err.Error(), "no valid PEM certificates") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestHasExperimentName(t *testing.T) {
+	t.Parallel()
+
+	if HasExperimentName(&api.EvaluationJobConfig{}) {
+		t.Fatal("missing experiment should be false")
+	}
+	if HasExperimentName(&api.EvaluationJobConfig{Experiment: &api.ExperimentConfig{Name: "  "}}) {
+		t.Fatal("whitespace name should be false")
+	}
+	if !HasExperimentName(&api.EvaluationJobConfig{Experiment: &api.ExperimentConfig{Name: "demo"}}) {
+		t.Fatal("expected true for non-empty name")
+	}
+}
+
+func TestInjectEvaluationJobTags(t *testing.T) {
+	t.Parallel()
+
+	desc := "job description"
+	tags := injectEvaluationJobTags("job-1", &api.EvaluationJobConfig{
+		Name:        "eval-name",
+		Description: &desc,
+		Experiment:  &api.ExperimentConfig{Name: "exp", Tags: []api.ExperimentTag{{Key: "custom", Value: "v"}}},
+	})
+	if len(tags) != 5 {
+		t.Fatalf("len(tags) = %d, want 5", len(tags))
+	}
+	tagMap := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		tagMap[tag.Key] = tag.Value
+	}
+	if tagMap["custom"] != "v" {
+		t.Fatalf("custom tag = %q", tagMap["custom"])
+	}
+	if tagMap["context"] != "eval-hub" {
+		t.Fatalf("context tag = %q", tagMap["context"])
+	}
+	if tagMap["evaluation_job_name"] != "eval-name" {
+		t.Fatalf("evaluation_job_name = %q", tagMap["evaluation_job_name"])
+	}
+	if tagMap["evaluation_job_id"] != "job-1" {
+		t.Fatalf("evaluation_job_id = %q", tagMap["evaluation_job_id"])
+	}
+	if tagMap["evaluation_job_description"] != desc {
+		t.Fatalf("evaluation_job_description = %q", tagMap["evaluation_job_description"])
+	}
+}
+
+func TestGetOrCreateExperimentID(t *testing.T) {
+	t.Parallel()
+	logger := testLogger()
+
+	t.Run("no experiment name", func(t *testing.T) {
+		t.Parallel()
+		id, url, err := GetOrCreateExperimentID(mlflowclient.NewClient("http://example"), &api.EvaluationJobConfig{}, "job-1")
+		if err != nil || id != "" || url != "" {
+			t.Fatalf("got id=%q url=%q err=%v", id, url, err)
+		}
+	})
+
+	t.Run("nil client", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := GetOrCreateExperimentID(nil, &api.EvaluationJobConfig{
+			Experiment: &api.ExperimentConfig{Name: "demo"},
+		}, "job-1")
+		assertServiceErrorCode(t, err, messages.MLFlowRequiredForExperiment)
+	})
+
+	t.Run("returns existing active experiment", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/2.0/mlflow/experiments/get-by-name" {
+				_ = json.NewEncoder(w).Encode(mlflowclient.GetExperimentResponse{
+					Experiment: mlflowclient.Experiment{
+						ExperimentID:   "exp-1",
+						Name:           "demo",
+						LifecycleStage: "active",
+					},
+				})
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(srv.Close)
+
+		client := mlflowclient.NewClient(srv.URL).WithContext(t.Context()).WithLogger(logger)
+		id, url, err := GetOrCreateExperimentID(client, &api.EvaluationJobConfig{
+			Experiment: &api.ExperimentConfig{Name: "demo"},
+		}, "job-1")
+		if err != nil {
+			t.Fatalf("GetOrCreateExperimentID() err = %v", err)
+		}
+		if id != "exp-1" {
+			t.Fatalf("experiment id = %q, want exp-1", id)
+		}
+		if url != client.GetExperimentsURL() {
+			t.Fatalf("url = %q, want %q", url, client.GetExperimentsURL())
+		}
+	})
+
+	t.Run("creates experiment when missing", func(t *testing.T) {
+		t.Parallel()
+		var createBody mlflowclient.CreateExperimentRequest
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/2.0/mlflow/experiments/get-by-name":
+				http.Error(w, `{"error_code":"RESOURCE_DOES_NOT_EXIST","message":"not found"}`, http.StatusNotFound)
+			case "/api/2.0/mlflow/experiments/create":
+				if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+					t.Errorf("decode create body: %v", err)
+				}
+				_ = json.NewEncoder(w).Encode(mlflowclient.CreateExperimentResponse{ExperimentID: "new-exp"})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		client := mlflowclient.NewClient(srv.URL).WithContext(t.Context()).WithLogger(logger)
+		id, _, err := GetOrCreateExperimentID(client, &api.EvaluationJobConfig{
+			Name:       "eval",
+			Experiment: &api.ExperimentConfig{Name: "demo"},
+		}, "job-99")
+		if err != nil {
+			t.Fatalf("GetOrCreateExperimentID() err = %v", err)
+		}
+		if id != "new-exp" {
+			t.Fatalf("experiment id = %q, want new-exp", id)
+		}
+		if createBody.Name != "demo" {
+			t.Fatalf("create name = %q", createBody.Name)
+		}
+		foundJobTag := false
+		for _, tag := range createBody.Tags {
+			if tag.Key == "evaluation_job_id" && tag.Value == "job-99" {
+				foundJobTag = true
+			}
+		}
+		if !foundJobTag {
+			t.Fatal("expected evaluation_job_id tag on create request")
+		}
+	})
+
+	t.Run("non-404 get error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/2.0/mlflow/experiments/get-by-name" {
+				http.Error(w, `{"error_code":"INTERNAL_ERROR","message":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(srv.Close)
+
+		client := mlflowclient.NewClient(srv.URL).WithContext(t.Context()).WithLogger(logger)
+		_, _, err := GetOrCreateExperimentID(client, &api.EvaluationJobConfig{
+			Experiment: &api.ExperimentConfig{Name: "demo"},
+		}, "job-1")
+		assertServiceErrorCode(t, err, messages.MLFlowRequestFailed)
+	})
+}
+
+func assertServiceErrorCode(t *testing.T, err error, want *messages.MessageCode) {
+	t.Helper()
+	var se *serviceerrors.ServiceError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected ServiceError, got %T: %v", err, err)
+	}
+	if se.MessageCode() != want {
+		t.Fatalf("message code = %v, want %v", se.MessageCode(), want)
+	}
+}

--- a/pkg/mlflowclient/client.go
+++ b/pkg/mlflowclient/client.go
@@ -30,13 +30,23 @@ const (
 
 // Client represents an MLflow API client
 type Client struct {
-	ctx           context.Context
-	baseURL       string
-	httpClient    *http.Client
-	authToken     string
-	authTokenPath string
-	workspace     string
-	logger        *slog.Logger
+	ctx               context.Context
+	baseURL           string
+	httpClient        *http.Client
+	authToken         string
+	authTokenPath     string
+	workspace         string
+	workspacesEnabled bool
+	workspacesProbed  bool
+	logger            *slog.Logger
+}
+
+func (c *Client) copy() *Client {
+	if c == nil {
+		return nil
+	}
+	clone := *c
+	return &clone
 }
 
 // NewClient creates a new MLflow client
@@ -60,45 +70,27 @@ func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
 	if c == nil {
 		return nil
 	}
-	return &Client{
-		ctx:           c.ctx,
-		baseURL:       c.baseURL,
-		httpClient:    httpClient,
-		authToken:     c.authToken,
-		authTokenPath: c.authTokenPath,
-		workspace:     c.workspace,
-		logger:        c.logger,
-	}
+	cp := c.copy()
+	cp.httpClient = httpClient
+	return cp
 }
 
 func (c *Client) WithContext(ctx context.Context) *Client {
 	if c == nil {
 		return nil
 	}
-	return &Client{
-		ctx:           ctx,
-		baseURL:       c.baseURL,
-		httpClient:    c.httpClient,
-		authToken:     c.authToken,
-		authTokenPath: c.authTokenPath,
-		workspace:     c.workspace,
-		logger:        c.logger,
-	}
+	cp := c.copy()
+	cp.ctx = ctx
+	return cp
 }
 
 func (c *Client) WithLogger(logger *slog.Logger) *Client {
 	if c == nil {
 		return nil
 	}
-	return &Client{
-		ctx:           c.ctx,
-		baseURL:       c.baseURL,
-		httpClient:    c.httpClient,
-		authToken:     c.authToken,
-		authTokenPath: c.authTokenPath,
-		workspace:     c.workspace,
-		logger:        logger,
-	}
+	cp := c.copy()
+	cp.logger = logger
+	return cp
 }
 
 // WithToken sets a static auth token (for local development without a token file).
@@ -106,15 +98,9 @@ func (c *Client) WithToken(authToken string) *Client {
 	if c == nil {
 		return nil
 	}
-	return &Client{
-		ctx:           c.ctx,
-		baseURL:       c.baseURL,
-		httpClient:    c.httpClient,
-		authToken:     authToken,
-		authTokenPath: c.authTokenPath,
-		workspace:     c.workspace,
-		logger:        c.logger,
-	}
+	cp := c.copy()
+	cp.authToken = authToken
+	return cp
 }
 
 // WithTokenPath sets a file path from which the auth token is read on each request.
@@ -124,30 +110,47 @@ func (c *Client) WithTokenPath(authTokenPath string) *Client {
 	if c == nil {
 		return nil
 	}
-	return &Client{
-		ctx:           c.ctx,
-		baseURL:       c.baseURL,
-		httpClient:    c.httpClient,
-		authToken:     c.authToken,
-		authTokenPath: authTokenPath,
-		workspace:     c.workspace,
-		logger:        c.logger,
-	}
+	cp := c.copy()
+	cp.authTokenPath = authTokenPath
+	return cp
 }
 
+// WithWorkspacesSupport records whether the server supports X-MLFLOW-WORKSPACE headers.
+// Call ProbeWorkspacesEnabled during client setup, then pass the result here.
+func (c *Client) WithWorkspacesSupport(enabled bool) *Client {
+	if c == nil {
+		return nil
+	}
+	cp := c.copy()
+	cp.workspacesEnabled = enabled
+	cp.workspacesProbed = true
+	if !enabled {
+		cp.workspace = ""
+	}
+	return cp
+}
+
+// WithWorkspace sets the workspace name sent as X-MLFLOW-WORKSPACE when the server supports workspaces.
 func (c *Client) WithWorkspace(workspace string) *Client {
 	if c == nil {
 		return nil
 	}
-	return &Client{
-		ctx:           c.ctx,
-		baseURL:       c.baseURL,
-		httpClient:    c.httpClient,
-		authToken:     c.authToken,
-		authTokenPath: c.authTokenPath,
-		workspace:     workspace,
-		logger:        c.logger,
+	cp := c.copy()
+	workspace = strings.TrimSpace(workspace)
+	if workspace == "" {
+		cp.workspace = ""
+		return cp
 	}
+	if !cp.workspacesEnabled {
+		cp.logger.Info(
+			"MLflow workspaces not enabled on server; ignoring workspace",
+			"workspace", workspace,
+		)
+		cp.workspace = ""
+		return cp
+	}
+	cp.workspace = workspace
+	return cp
 }
 
 func (c *Client) GetHTTPClient() *http.Client {
@@ -182,8 +185,17 @@ func (c *Client) resolveAuthToken() string {
 	return c.authToken
 }
 
-// doRequest performs an HTTP request to the MLflow API
+// doRequest performs an HTTP request to the MLflow API, including X-MLFLOW-WORKSPACE when configured.
 func (c *Client) doRequest(method, endpoint string, body any) ([]byte, error) {
+	return c.doRequestInternal(method, endpoint, body, true)
+}
+
+// doRequestWithoutWorkspace performs a global MLflow API request (workspace management).
+func (c *Client) doRequestWithoutWorkspace(method, endpoint string, body any) ([]byte, error) {
+	return c.doRequestInternal(method, endpoint, body, false)
+}
+
+func (c *Client) doRequestInternal(method, endpoint string, body any, includeWorkspaceHeader bool) ([]byte, error) {
 	c.logger.Info("MLFlow request started", "method", method, "endpoint", endpoint)
 
 	var reqBody io.Reader
@@ -216,11 +228,10 @@ func (c *Client) doRequest(method, endpoint string, body any) ([]byte, error) {
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
 	}
-	// ODH-specific: the X-MLFLOW-WORKSPACE header is a non-standard extension
-	// used by Open Data Hub MLFlow to scope API requests to a Kubernetes
-	// namespace. This header is only set when workspace is explicitly configured
-	// (via MLFLOW_WORKSPACE env var). It has no effect on upstream MLFlow.
-	if c.workspace != "" {
+	// X-MLFLOW-WORKSPACE scopes requests to a workspace on servers started with
+	// --enable-workspaces (MLflow 3.10+). Sending it when workspaces are disabled
+	// returns FEATURE_DISABLED from MLflow 3.13+.
+	if includeWorkspaceHeader && c.workspacesEnabled && c.workspace != "" {
 		req.Header.Set("X-MLFLOW-WORKSPACE", c.workspace)
 	}
 

--- a/pkg/mlflowclient/client.go
+++ b/pkg/mlflowclient/client.go
@@ -37,7 +37,6 @@ type Client struct {
 	authTokenPath     string
 	workspace         string
 	workspacesEnabled bool
-	workspacesProbed  bool
 	logger            *slog.Logger
 }
 
@@ -123,7 +122,6 @@ func (c *Client) WithWorkspacesSupport(enabled bool) *Client {
 	}
 	cp := c.copy()
 	cp.workspacesEnabled = enabled
-	cp.workspacesProbed = true
 	if !enabled {
 		cp.workspace = ""
 	}
@@ -185,6 +183,18 @@ func (c *Client) resolveAuthToken() string {
 	return c.authToken
 }
 
+func (c *Client) applyAuthHeader(req *http.Request) {
+	token := c.resolveAuthToken()
+	if token == "" {
+		return
+	}
+	if strings.HasPrefix(token, "Bearer ") || strings.HasPrefix(token, "Basic ") {
+		req.Header.Set("Authorization", token)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+}
+
 // doRequest performs an HTTP request to the MLflow API, including X-MLFLOW-WORKSPACE when configured.
 func (c *Client) doRequest(method, endpoint string, body any) ([]byte, error) {
 	return c.doRequestInternal(method, endpoint, body, true)
@@ -221,13 +231,7 @@ func (c *Client) doRequestInternal(method, endpoint string, body any, includeWor
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	if token := c.resolveAuthToken(); token != "" {
-		if strings.HasPrefix(token, "Bearer ") || strings.HasPrefix(token, "Basic ") {
-			req.Header.Set("Authorization", token)
-		} else {
-			req.Header.Set("Authorization", "Bearer "+token)
-		}
-	}
+	c.applyAuthHeader(req)
 	// X-MLFLOW-WORKSPACE scopes requests to a workspace on servers started with
 	// --enable-workspaces (MLflow 3.10+). Sending it when workspaces are disabled
 	// returns FEATURE_DISABLED from MLflow 3.13+.

--- a/pkg/mlflowclient/client_test.go
+++ b/pkg/mlflowclient/client_test.go
@@ -1,0 +1,132 @@
+package mlflowclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveAuthToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("static token", func(t *testing.T) {
+		t.Parallel()
+		c := NewClient("http://example").WithToken("secret")
+		if got := c.resolveAuthToken(); got != "secret" {
+			t.Fatalf("token = %q", got)
+		}
+	})
+
+	t.Run("token file takes precedence", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "token")
+		if err := os.WriteFile(path, []byte("from-file\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		c := NewClient("http://example").WithToken("static").WithTokenPath(path)
+		if got := c.resolveAuthToken(); got != "from-file" {
+			t.Fatalf("token = %q, want from-file", got)
+		}
+	})
+
+	t.Run("falls back when file missing", func(t *testing.T) {
+		t.Parallel()
+		c := NewClient("http://example").
+			WithToken("fallback").
+			WithTokenPath(filepath.Join(t.TempDir(), "missing"))
+		if got := c.resolveAuthToken(); got != "fallback" {
+			t.Fatalf("token = %q, want fallback", got)
+		}
+	})
+}
+
+func TestApplyAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adds Bearer prefix", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest(http.MethodGet, "http://example", nil)
+		NewClient("http://example").WithToken("abc").applyAuthHeader(req)
+		if got := req.Header.Get("Authorization"); got != "Bearer abc" {
+			t.Fatalf("Authorization = %q", got)
+		}
+	})
+
+	t.Run("preserves existing scheme", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest(http.MethodGet, "http://example", nil)
+		NewClient("http://example").WithToken("Bearer preset").applyAuthHeader(req)
+		if got := req.Header.Get("Authorization"); got != "Bearer preset" {
+			t.Fatalf("Authorization = %q", got)
+		}
+	})
+}
+
+func TestCreateExperiment(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != endpointExperimentsCreate {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(CreateExperimentResponse{ExperimentID: "1"})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL).WithContext(t.Context())
+	resp, err := client.CreateExperiment(&CreateExperimentRequest{Name: "demo"})
+	if err != nil {
+		t.Fatalf("CreateExperiment() = %v", err)
+	}
+	if resp.ExperimentID != "1" {
+		t.Fatalf("ExperimentID = %q", resp.ExperimentID)
+	}
+}
+
+func TestGetExperiment(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != endpointExperimentsGetBase {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(GetExperimentResponse{
+			Experiment: Experiment{ExperimentID: "exp-9", Name: "demo"},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL).WithContext(t.Context())
+	resp, err := client.GetExperiment("exp-9")
+	if err != nil {
+		t.Fatalf("GetExperiment() = %v", err)
+	}
+	if resp.Experiment.ExperimentID != "exp-9" {
+		t.Fatalf("ExperimentID = %q", resp.Experiment.ExperimentID)
+	}
+}
+
+func TestDeleteExperiment(t *testing.T) {
+	t.Parallel()
+	var deleted bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == endpointExperimentsDeleteBase {
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL).WithContext(t.Context())
+	if err := client.DeleteExperiment("exp-del"); err != nil {
+		t.Fatalf("DeleteExperiment() = %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected delete endpoint to be called")
+	}
+}

--- a/pkg/mlflowclient/schemas.go
+++ b/pkg/mlflowclient/schemas.go
@@ -96,3 +96,20 @@ type GetExperimentByNameRequest struct {
 type GetExperimentResponse struct {
 	Experiment Experiment `json:"experiment" validate:"required"`
 }
+
+// Workspace is an MLflow workspace (MLflow 3.10+).
+type Workspace struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// GetWorkspaceResponse is the JSON body from GET /api/3.0/mlflow/workspaces/{name}.
+type GetWorkspaceResponse struct {
+	Workspace Workspace `json:"workspace"`
+}
+
+// CreateWorkspaceRequest is the JSON body for POST /api/3.0/mlflow/workspaces.
+type CreateWorkspaceRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}

--- a/pkg/mlflowclient/schemas_test.go
+++ b/pkg/mlflowclient/schemas_test.go
@@ -1,0 +1,94 @@
+package mlflowclient
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestAPIError_Error(t *testing.T) {
+	t.Parallel()
+	err := &APIError{
+		StatusCode:   404,
+		ResponseBody: `{"error_code":"RESOURCE_DOES_NOT_EXIST"}`,
+	}
+	msg := err.Error()
+	if msg == "" {
+		t.Fatal("expected non-empty error message")
+	}
+	if !strings.Contains(msg, "404") || !strings.Contains(msg, "RESOURCE_DOES_NOT_EXIST") {
+		t.Fatalf("Error() = %q", msg)
+	}
+}
+
+func TestIsResourceDoesNotExistError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("structured error", func(t *testing.T) {
+		t.Parallel()
+		err := &APIError{
+			StatusCode: 404,
+			MLFlowError: &MLFlowError{
+				ErrorCode: "RESOURCE_DOES_NOT_EXIST",
+			},
+		}
+		if !IsResourceDoesNotExistError(err) {
+			t.Fatal("expected true")
+		}
+	})
+
+	t.Run("response body fallback", func(t *testing.T) {
+		t.Parallel()
+		err := &APIError{
+			StatusCode:   404,
+			ResponseBody: `{"error_code":"RESOURCE_DOES_NOT_EXIST"}`,
+		}
+		if !IsResourceDoesNotExistError(err) {
+			t.Fatal("expected true")
+		}
+	})
+
+	t.Run("wrong status", func(t *testing.T) {
+		t.Parallel()
+		err := &APIError{StatusCode: 500, MLFlowError: &MLFlowError{ErrorCode: "RESOURCE_DOES_NOT_EXIST"}}
+		if IsResourceDoesNotExistError(err) {
+			t.Fatal("expected false for non-404")
+		}
+	})
+
+	t.Run("wrapped", func(t *testing.T) {
+		t.Parallel()
+		inner := &APIError{StatusCode: 404, MLFlowError: &MLFlowError{ErrorCode: "RESOURCE_DOES_NOT_EXIST"}}
+		if !IsResourceDoesNotExistError(errors.Join(inner)) {
+			t.Fatal("expected errors.As to match wrapped APIError")
+		}
+	})
+}
+
+func TestIsResourceAlreadyExistsError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("structured error", func(t *testing.T) {
+		t.Parallel()
+		err := &APIError{
+			StatusCode: 400,
+			MLFlowError: &MLFlowError{
+				ErrorCode: "RESOURCE_ALREADY_EXISTS",
+			},
+		}
+		if !IsResourceAlreadyExistsError(err) {
+			t.Fatal("expected true")
+		}
+	})
+
+	t.Run("response body fallback", func(t *testing.T) {
+		t.Parallel()
+		err := &APIError{
+			StatusCode:   400,
+			ResponseBody: `{"error_code":"RESOURCE_ALREADY_EXISTS"}`,
+		}
+		if !IsResourceAlreadyExistsError(err) {
+			t.Fatal("expected true")
+		}
+	})
+}

--- a/pkg/mlflowclient/workspaces.go
+++ b/pkg/mlflowclient/workspaces.go
@@ -39,13 +39,7 @@ func (c *Client) ProbeWorkspacesEnabled() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to create server-info request: %w", err)
 	}
-	if token := c.resolveAuthToken(); token != "" {
-		if strings.HasPrefix(token, "Bearer ") || strings.HasPrefix(token, "Basic ") {
-			req.Header.Set("Authorization", token)
-		} else {
-			req.Header.Set("Authorization", "Bearer "+token)
-		}
-	}
+	c.applyAuthHeader(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/pkg/mlflowclient/workspaces.go
+++ b/pkg/mlflowclient/workspaces.go
@@ -1,0 +1,158 @@
+package mlflowclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	endpointServerInfo   = "/api/3.0/mlflow/server-info"
+	workspacesAPIBase    = "/api/3.0/mlflow/workspaces"
+	defaultWorkspaceName = "default"
+)
+
+func workspaceEndpoint(name string) string {
+	return workspacesAPIBase + "/" + url.PathEscape(name)
+}
+
+// ServerInfoResponse is the JSON body from GET /api/3.0/mlflow/server-info (MLflow 3.10+).
+type ServerInfoResponse struct {
+	WorkspacesEnabled bool `json:"workspaces_enabled"`
+}
+
+// ProbeWorkspacesEnabled queries the MLflow server-info endpoint (without a workspace header)
+// and reports whether workspace-scoped APIs are available.
+// Returns false for older servers that do not expose server-info (404).
+func (c *Client) ProbeWorkspacesEnabled() (bool, error) {
+	if c == nil {
+		return false, fmt.Errorf("mlflow client is nil")
+	}
+	if c.ctx == nil {
+		return false, fmt.Errorf("context is nil for MLflow server-info request")
+	}
+
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodGet, c.baseURL+endpointServerInfo, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create server-info request: %w", err)
+	}
+	if token := c.resolveAuthToken(); token != "" {
+		if strings.HasPrefix(token, "Bearer ") || strings.HasPrefix(token, "Basic ") {
+			req.Header.Set("Authorization", token)
+		} else {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to execute server-info request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("failed to read server-info response: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var info ServerInfoResponse
+		if err := json.Unmarshal(respBody, &info); err != nil {
+			return false, fmt.Errorf("failed to unmarshal server-info response: %w", err)
+		}
+		return info.WorkspacesEnabled, nil
+	case http.StatusNotFound:
+		// MLflow releases before workspace support do not expose this endpoint.
+		return false, nil
+	default:
+		return false, fmt.Errorf("server-info returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+}
+
+// WorkspacesEnabled reports whether the client will send X-MLFLOW-WORKSPACE headers.
+func (c *Client) WorkspacesEnabled() bool {
+	if c == nil {
+		return false
+	}
+	return c.workspacesEnabled
+}
+
+// GetWorkspace returns the named workspace, or an error if it does not exist.
+func (c *Client) GetWorkspace(name string) (*Workspace, error) {
+	if c == nil {
+		return nil, fmt.Errorf("mlflow client is nil")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("workspace name is empty")
+	}
+
+	respBody, err := c.doRequestWithoutWorkspace(http.MethodGet, workspaceEndpoint(name), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := unmarshalResponse[GetWorkspaceResponse](respBody)
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Workspace, nil
+}
+
+// CreateWorkspace creates a workspace. Workspace management APIs do not use X-MLFLOW-WORKSPACE.
+func (c *Client) CreateWorkspace(req *CreateWorkspaceRequest) (*Workspace, error) {
+	if c == nil {
+		return nil, fmt.Errorf("mlflow client is nil")
+	}
+	if req == nil || strings.TrimSpace(req.Name) == "" {
+		return nil, fmt.Errorf("create workspace request is nil or missing name")
+	}
+
+	respBody, err := c.doRequestWithoutWorkspace(http.MethodPost, workspacesAPIBase, req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := unmarshalResponse[GetWorkspaceResponse](respBody)
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Workspace, nil
+}
+
+// EnsureWorkspace creates the client's active workspace when workspaces are enabled.
+// The reserved "default" workspace is assumed to exist. Idempotent for concurrent creators.
+func (c *Client) EnsureWorkspace() error {
+	if c == nil || !c.workspacesEnabled || strings.TrimSpace(c.workspace) == "" {
+		return nil
+	}
+	name := strings.TrimSpace(c.workspace)
+	if name == defaultWorkspaceName {
+		return nil
+	}
+
+	_, err := c.GetWorkspace(name)
+	if err == nil {
+		return nil
+	}
+	if !IsResourceDoesNotExistError(err) {
+		return err
+	}
+
+	_, err = c.CreateWorkspace(&CreateWorkspaceRequest{
+		Name:        name,
+		Description: "Created by eval-hub",
+	})
+	if err == nil {
+		c.logger.Info("Created MLflow workspace", "workspace", name)
+		return nil
+	}
+	if IsResourceAlreadyExistsError(err) {
+		return nil
+	}
+	return err
+}

--- a/pkg/mlflowclient/workspaces_test.go
+++ b/pkg/mlflowclient/workspaces_test.go
@@ -1,0 +1,174 @@
+package mlflowclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProbeWorkspacesEnabled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("workspaces enabled", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != endpointServerInfo {
+				t.Fatalf("path = %s, want %s", r.URL.Path, endpointServerInfo)
+			}
+			if got := r.Header.Get("X-MLFLOW-WORKSPACE"); got != "" {
+				t.Fatalf("server-info must not include X-MLFLOW-WORKSPACE, got %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(ServerInfoResponse{WorkspacesEnabled: true})
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL)
+		enabled, err := client.ProbeWorkspacesEnabled()
+		if err != nil {
+			t.Fatalf("ProbeWorkspacesEnabled() = %v", err)
+		}
+		if !enabled {
+			t.Fatal("expected workspaces enabled")
+		}
+	})
+
+	t.Run("workspaces disabled", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(ServerInfoResponse{WorkspacesEnabled: false})
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL)
+		enabled, err := client.ProbeWorkspacesEnabled()
+		if err != nil {
+			t.Fatalf("ProbeWorkspacesEnabled() = %v", err)
+		}
+		if enabled {
+			t.Fatal("expected workspaces disabled")
+		}
+	})
+
+	t.Run("server-info missing on old server", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL)
+		enabled, err := client.ProbeWorkspacesEnabled()
+		if err != nil {
+			t.Fatalf("ProbeWorkspacesEnabled() = %v", err)
+		}
+		if enabled {
+			t.Fatal("expected false for 404 server-info")
+		}
+	})
+}
+
+func TestEnsureWorkspace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates workspace when missing", func(t *testing.T) {
+		t.Parallel()
+		var createCalls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/3.0/mlflow/workspaces/test-tenant":
+				http.Error(w, `{"error_code":"RESOURCE_DOES_NOT_EXIST","message":"Workspace 'test-tenant' not found"}`, http.StatusNotFound)
+			case r.Method == http.MethodPost && r.URL.Path == "/api/3.0/mlflow/workspaces":
+				createCalls++
+				_ = json.NewEncoder(w).Encode(GetWorkspaceResponse{Workspace: Workspace{Name: "test-tenant"}})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithWorkspacesSupport(true).WithWorkspace("test-tenant")
+		if err := client.EnsureWorkspace(); err != nil {
+			t.Fatalf("EnsureWorkspace() = %v", err)
+		}
+		if createCalls != 1 {
+			t.Fatalf("createCalls = %d, want 1", createCalls)
+		}
+	})
+
+	t.Run("skips create when workspace exists", func(t *testing.T) {
+		t.Parallel()
+		var createCalls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet && r.URL.Path == "/api/3.0/mlflow/workspaces/test-tenant" {
+				_ = json.NewEncoder(w).Encode(GetWorkspaceResponse{Workspace: Workspace{Name: "test-tenant"}})
+				return
+			}
+			if r.Method == http.MethodPost && r.URL.Path == "/api/3.0/mlflow/workspaces" {
+				createCalls++
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithWorkspacesSupport(true).WithWorkspace("test-tenant")
+		if err := client.EnsureWorkspace(); err != nil {
+			t.Fatalf("EnsureWorkspace() = %v", err)
+		}
+		if createCalls != 0 {
+			t.Fatalf("createCalls = %d, want 0", createCalls)
+		}
+	})
+}
+
+func TestWithWorkspaceRespectsServerSupport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("omits header when workspaces disabled", func(t *testing.T) {
+		t.Parallel()
+		var gotWorkspaceHeader string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotWorkspaceHeader = r.Header.Get("X-MLFLOW-WORKSPACE")
+			if r.URL.Path == endpointExperimentsGetByNameBase {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error_code":"RESOURCE_DOES_NOT_EXIST"}`))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithWorkspacesSupport(false).WithWorkspace("test-tenant")
+		_, err := client.GetExperimentByName("demo")
+		if err == nil {
+			t.Fatal("expected error for missing experiment")
+		}
+		if gotWorkspaceHeader != "" {
+			t.Fatalf("X-MLFLOW-WORKSPACE = %q, want empty", gotWorkspaceHeader)
+		}
+	})
+
+	t.Run("sends header when workspaces enabled", func(t *testing.T) {
+		t.Parallel()
+		var gotWorkspaceHeader string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotWorkspaceHeader = r.Header.Get("X-MLFLOW-WORKSPACE")
+			if r.URL.Path == endpointExperimentsGetByNameBase {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error_code":"RESOURCE_DOES_NOT_EXIST"}`))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithWorkspacesSupport(true).WithWorkspace("test-tenant")
+		_, err := client.GetExperimentByName("demo")
+		if err == nil {
+			t.Fatal("expected error for missing experiment")
+		}
+		if gotWorkspaceHeader != "test-tenant" {
+			t.Fatalf("X-MLFLOW-WORKSPACE = %q, want test-tenant", gotWorkspaceHeader)
+		}
+	})
+}

--- a/pkg/mlflowclient/workspaces_test.go
+++ b/pkg/mlflowclient/workspaces_test.go
@@ -126,10 +126,10 @@ func TestWithWorkspaceRespectsServerSupport(t *testing.T) {
 
 	t.Run("omits header when workspaces disabled", func(t *testing.T) {
 		t.Parallel()
-		var gotWorkspaceHeader string
+		headerCh := make(chan string, 1)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			gotWorkspaceHeader = r.Header.Get("X-MLFLOW-WORKSPACE")
 			if r.URL.Path == endpointExperimentsGetByNameBase {
+				headerCh <- r.Header.Get("X-MLFLOW-WORKSPACE")
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = w.Write([]byte(`{"error_code":"RESOURCE_DOES_NOT_EXIST"}`))
 				return
@@ -143,6 +143,7 @@ func TestWithWorkspaceRespectsServerSupport(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for missing experiment")
 		}
+		gotWorkspaceHeader := <-headerCh
 		if gotWorkspaceHeader != "" {
 			t.Fatalf("X-MLFLOW-WORKSPACE = %q, want empty", gotWorkspaceHeader)
 		}
@@ -150,10 +151,10 @@ func TestWithWorkspaceRespectsServerSupport(t *testing.T) {
 
 	t.Run("sends header when workspaces enabled", func(t *testing.T) {
 		t.Parallel()
-		var gotWorkspaceHeader string
+		headerCh := make(chan string, 1)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			gotWorkspaceHeader = r.Header.Get("X-MLFLOW-WORKSPACE")
 			if r.URL.Path == endpointExperimentsGetByNameBase {
+				headerCh <- r.Header.Get("X-MLFLOW-WORKSPACE")
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = w.Write([]byte(`{"error_code":"RESOURCE_DOES_NOT_EXIST"}`))
 				return
@@ -167,6 +168,7 @@ func TestWithWorkspaceRespectsServerSupport(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for missing experiment")
 		}
+		gotWorkspaceHeader := <-headerCh
 		if gotWorkspaceHeader != "test-tenant" {
 			t.Fatalf("X-MLFLOW-WORKSPACE = %q, want test-tenant", gotWorkspaceHeader)
 		}

--- a/pkg/mlflowclient/workspaces_test.go
+++ b/pkg/mlflowclient/workspaces_test.go
@@ -121,6 +121,119 @@ func TestEnsureWorkspace(t *testing.T) {
 	})
 }
 
+func TestWorkspacesEnabled(t *testing.T) {
+	t.Parallel()
+	if (*Client)(nil).WorkspacesEnabled() {
+		t.Fatal("nil client should report false")
+	}
+	if NewClient("http://example").WorkspacesEnabled() {
+		t.Fatal("expected false by default")
+	}
+	if !NewClient("http://example").WithWorkspacesSupport(true).WorkspacesEnabled() {
+		t.Fatal("expected true when enabled")
+	}
+}
+
+func TestProbeWorkspacesEnabled_errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil client", func(t *testing.T) {
+		t.Parallel()
+		var c *Client
+		if _, err := c.ProbeWorkspacesEnabled(); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("nil context", func(t *testing.T) {
+		t.Parallel()
+		c := NewClient("http://example")
+		c.ctx = nil
+		if _, err := c.ProbeWorkspacesEnabled(); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("unexpected status", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "server error", http.StatusInternalServerError)
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithContext(t.Context())
+		if _, err := client.ProbeWorkspacesEnabled(); err == nil {
+			t.Fatal("expected error for 500")
+		}
+	})
+
+	t.Run("invalid JSON body", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not-json"))
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithContext(t.Context())
+		if _, err := client.ProbeWorkspacesEnabled(); err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+	})
+}
+
+func TestEnsureWorkspace_edgeCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default workspace is no-op", func(t *testing.T) {
+		t.Parallel()
+		client := NewClient("http://example").WithWorkspacesSupport(true).WithWorkspace("default")
+		if err := client.EnsureWorkspace(); err != nil {
+			t.Fatalf("EnsureWorkspace() = %v", err)
+		}
+	})
+
+	t.Run("workspaces disabled is no-op", func(t *testing.T) {
+		t.Parallel()
+		client := NewClient("http://example").WithWorkspacesSupport(false).WithWorkspace("tenant")
+		if err := client.EnsureWorkspace(); err != nil {
+			t.Fatalf("EnsureWorkspace() = %v", err)
+		}
+	})
+
+	t.Run("create races with RESOURCE_ALREADY_EXISTS", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/3.0/mlflow/workspaces/race-ws":
+				http.Error(w, `{"error_code":"RESOURCE_DOES_NOT_EXIST"}`, http.StatusNotFound)
+			case r.Method == http.MethodPost && r.URL.Path == "/api/3.0/mlflow/workspaces":
+				http.Error(w, `{"error_code":"RESOURCE_ALREADY_EXISTS"}`, http.StatusBadRequest)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithContext(t.Context()).WithWorkspacesSupport(true).WithWorkspace("race-ws")
+		if err := client.EnsureWorkspace(); err != nil {
+			t.Fatalf("EnsureWorkspace() = %v", err)
+		}
+	})
+}
+
+func TestGetWorkspace_validation(t *testing.T) {
+	t.Parallel()
+	var c *Client
+	if _, err := c.GetWorkspace("x"); err == nil {
+		t.Fatal("expected error for nil client")
+	}
+	client := NewClient("http://example")
+	if _, err := client.GetWorkspace("  "); err == nil {
+		t.Fatal("expected error for empty workspace name")
+	}
+}
+
 func TestWithWorkspaceRespectsServerSupport(t *testing.T) {
 	t.Parallel()
 

--- a/tests/mlflow/Makefile
+++ b/tests/mlflow/Makefile
@@ -1,16 +1,47 @@
-.PHONY: clean install-mlflow run-mlflow stop-mlflow cls test-godog-server
+.PHONY: help clean init-python install-mlflow start-mlflow stop-mlflow cls test-godog-server
 
-clean:
+# Local Python environment (uv). Isolated from the repo-root .venv used for FVT.
+VENV_DIR ?= .venv
+PYTHON ?= 3.14
+
+MLFLOW_OLD_VERSION ?= 3.8.1
+MLFLOW_LATEST_VERSION ?= 3.13.0
+MLFLOW_VERSION ?= $(MLFLOW_LATEST_VERSION)
+
+MLFLOW_HOST ?= 127.0.0.1
+MLFLOW_PORT ?= 5000
+MLFLOW_BACKEND_STORE_URI ?= sqlite:///bin/mlflow.db
+MLFLOW_DEFAULT_ARTIFACT_ROOT ?= ./bin/mlruns
+MLFLOW_TRACKING_URI ?= http://127.0.0.1:5000
+MLFLOW_ENABLE_WORKSPACES ?= --enable-workspaces
+
+help: ## Show MLflow dev targets
+	@grep -E '^[a-zA-Z0-9_.-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+clean: ## Remove bin/ artifacts (DB, logs, mlruns)
 	@echo "🧹 Cleaning up MLflow server..."
 	@rm -fr bin
 
-## install-mlflow: Download and install MLflow server
-install-mlflow:
-	@echo "📥 Installing MLflow server..."
-	@./scripts/download_mlflow.sh
+## init-python: Create a local Python virtualenv with uv (required before install-mlflow)
+init-python:
+	@if ! command -v uv >/dev/null 2>&1; then \
+		echo "❌ uv is not installed. Install from https://docs.astral.sh/uv/"; \
+		exit 1; \
+	fi
+	@if [ ! -d "$(VENV_DIR)" ]; then \
+		echo "Creating uv virtual environment at $(VENV_DIR) (Python $(PYTHON))..."; \
+		uv venv $(VENV_DIR) --python $(PYTHON); \
+	else \
+		echo "Virtual environment already exists at $(VENV_DIR)"; \
+	fi
 
-## run-mlflow: Run MLflow server locally in the background
-run-mlflow:
+## install-mlflow: Install MLflow into the uv virtualenv
+install-mlflow: init-python
+	@echo "📥 Installing MLflow server (version $(MLFLOW_VERSION))..."
+	@MLFLOW_VERSION=$(MLFLOW_VERSION) VENV_DIR=$(VENV_DIR) ./scripts/download_mlflow.sh
+
+## start-mlflow: Run MLflow server locally in the background
+start-mlflow: install-mlflow
 	@echo "🛑 Stopping MLflow server..."
 	-@make stop-mlflow
 	-@rm -f mlflow.db tests/features/test_mlflow_${MLFLOW_PORT}.db
@@ -24,13 +55,13 @@ run-mlflow:
 	 MLFLOW_PORT=$(MLFLOW_PORT) \
 	 MLFLOW_BACKEND_STORE_URI=$(MLFLOW_BACKEND_STORE_URI) \
 	 MLFLOW_DEFAULT_ARTIFACT_ROOT=$(MLFLOW_DEFAULT_ARTIFACT_ROOT) \
+	 MLFLOW_ENABLE_WORKSPACES=$(MLFLOW_ENABLE_WORKSPACES) \
+	 VENV_DIR=$(VENV_DIR) \
 	 ./scripts/run_mlflow.sh
 	@echo "   MLflow server started in background. Use 'make stop-mlflow' to stop it."
-	@echo "" #@echo "   You can use 'make test-godog-server' to run BDD tests with the server automatically."
 	@echo ""
 	@echo "   To use the server in your tests:"
-	@echo "   - Set MLFLOW_TRACKING_URI=http://127.0.0.1:5000 in your test environment"
-	@echo "" # @echo "   - Run tests with 'make test-godog'"
+	@echo "   export MLFLOW_TRACKING_URI=$(MLFLOW_TRACKING_URI)"
 	@echo ""
 	@echo "   To stop the server:"
 	@echo "   make stop-mlflow"
@@ -39,12 +70,10 @@ run-mlflow:
 stop-mlflow:
 	./scripts/stop_mlflow.sh
 
-MLFLOW_TRACKING_URI ?= http://127.0.0.1:5000
-
 ## test-godog-server: Run godog tests with automatic server management
-test-godog-server: run-mlflow ; $(info The MLflow server was successfully started)
+test-godog-server: start-mlflow ; $(info The MLflow server was successfully started)
 	@echo "🧪 Running godog BDD tests with test server..."
-	@MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI} go test -v -tags=godog ./...
+	@MLFLOW_TRACKING_URI=$(MLFLOW_TRACKING_URI) go test -v -tags=godog ./...
 	@make stop-mlflow
 
 .PHONY: cls

--- a/tests/mlflow/Makefile
+++ b/tests/mlflow/Makefile
@@ -13,7 +13,7 @@ MLFLOW_PORT ?= 5000
 MLFLOW_BACKEND_STORE_URI ?= sqlite:///bin/mlflow.db
 MLFLOW_DEFAULT_ARTIFACT_ROOT ?= ./bin/mlruns
 MLFLOW_TRACKING_URI ?= http://127.0.0.1:5000
-MLFLOW_ENABLE_WORKSPACES ?=
+MLFLOW_ENABLE_WORKSPACES ?= false
 
 help: ## Show MLflow dev targets
 	@grep -E '^[a-zA-Z0-9_.-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'

--- a/tests/mlflow/Makefile
+++ b/tests/mlflow/Makefile
@@ -22,8 +22,7 @@ clean: ## Remove bin/ artifacts (DB, logs, mlruns)
 	@echo "🧹 Cleaning up MLflow server..."
 	@rm -fr bin
 
-## init-python: Create a local Python virtualenv with uv (required before install-mlflow)
-init-python:
+init-python: ## Create a local Python virtualenv with uv (required before install-mlflow)
 	@if ! command -v uv >/dev/null 2>&1; then \
 		echo "❌ uv is not installed. Install from https://docs.astral.sh/uv/"; \
 		exit 1; \
@@ -35,13 +34,11 @@ init-python:
 		echo "Virtual environment already exists at $(VENV_DIR)"; \
 	fi
 
-## install-mlflow: Install MLflow into the uv virtualenv
-install-mlflow: init-python
+install-mlflow: init-python ## Install MLflow into the uv virtualenv
 	@echo "📥 Installing MLflow server (version $(MLFLOW_VERSION))..."
 	@MLFLOW_VERSION=$(MLFLOW_VERSION) VENV_DIR=$(VENV_DIR) ./scripts/download_mlflow.sh
 
-## start-mlflow: Run MLflow server locally in the background
-start-mlflow: install-mlflow
+start-mlflow: install-mlflow ## Run MLflow server locally in the background
 	@echo "🛑 Stopping MLflow server..."
 	-@make stop-mlflow
 	-@rm -f mlflow.db tests/features/test_mlflow_${MLFLOW_PORT}.db
@@ -66,12 +63,10 @@ start-mlflow: install-mlflow
 	@echo "   To stop the server:"
 	@echo "   make stop-mlflow"
 
-## stop-mlflow: Stop MLflow server (if running)
-stop-mlflow:
+stop-mlflow: ## Stop MLflow server (if running)
 	./scripts/stop_mlflow.sh
 
-## test-godog-server: Run godog tests with automatic server management
-test-godog-server: start-mlflow ; $(info The MLflow server was successfully started)
+test-godog-server: start-mlflow ; $(info The MLflow server was successfully started) ## Run godog tests with automatic server management
 	@echo "🧪 Running godog BDD tests with test server..."
 	@MLFLOW_TRACKING_URI=$(MLFLOW_TRACKING_URI) go test -v -tags=godog ./...
 	@make stop-mlflow

--- a/tests/mlflow/Makefile
+++ b/tests/mlflow/Makefile
@@ -41,7 +41,7 @@ install-mlflow: init-python ## Install MLflow into the uv virtualenv
 start-mlflow: install-mlflow ## Run MLflow server locally in the background
 	@echo "🛑 Stopping MLflow server..."
 	-@make stop-mlflow
-	-@rm -f mlflow.db tests/features/test_mlflow_${MLFLOW_PORT}.db
+	-@rm -f bin/mlflow.db tests/features/test_mlflow_${MLFLOW_PORT}.db
 	@echo "🚀 Starting MLflow server..."
 	@echo "   Host: $(MLFLOW_HOST)"
 	@echo "   Port: $(MLFLOW_PORT)"

--- a/tests/mlflow/Makefile
+++ b/tests/mlflow/Makefile
@@ -13,7 +13,7 @@ MLFLOW_PORT ?= 5000
 MLFLOW_BACKEND_STORE_URI ?= sqlite:///bin/mlflow.db
 MLFLOW_DEFAULT_ARTIFACT_ROOT ?= ./bin/mlruns
 MLFLOW_TRACKING_URI ?= http://127.0.0.1:5000
-MLFLOW_ENABLE_WORKSPACES ?= --enable-workspaces
+MLFLOW_ENABLE_WORKSPACES ?=
 
 help: ## Show MLflow dev targets
 	@grep -E '^[a-zA-Z0-9_.-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'

--- a/tests/mlflow/README.md
+++ b/tests/mlflow/README.md
@@ -1,0 +1,124 @@
+# MLflow local development and tests
+
+This directory runs a **local MLflow tracking server** for development and for godog BDD tests under `features/`. It uses a **dedicated Python virtual environment** in `tests/mlflow/.venv`, managed with [uv](https://docs.astral.sh/uv/). That venv is separate from the repository-root `.venv` used by `make test-fvt` and the Python server.
+
+## Prerequisites
+
+- [uv](https://docs.astral.sh/uv/) on your `PATH`
+- Go (for `make test-godog-server`)
+- `curl` or `wget` (optional; used to wait for server readiness)
+
+## Quick start
+
+```bash
+make install-mlflow   # pip install mlflow into .venv
+make start-mlflow       # start server in the background
+```
+
+Point clients at the server:
+
+```bash
+export MLFLOW_TRACKING_URI=http://127.0.0.1:5000
+```
+
+Stop the server:
+
+```bash
+make stop-mlflow
+```
+
+## Make targets
+
+Run `make help` for a short list.
+
+| Target | Description |
+|--------|-------------|
+| `help` | List targets and descriptions |
+| `init-python` | Create `$(VENV_DIR)` with `uv venv` (default `.venv`, Python `3.14`) |
+| `install-mlflow` | Depends on `init-python`; installs MLflow with `uv pip` into the venv |
+| `start-mlflow` | Stop any existing server, then start MLflow in the background |
+| `stop-mlflow` | Stop processes matching `mlflow.server` |
+| `test-godog-server` | Start server, run godog tests (`-tags=godog`), then stop server |
+| `clean` | Remove `bin/` (SQLite DB, logs, artifact root) |
+| `cls` | Clear the terminal |
+
+Typical workflow: **`init-python` → `install-mlflow` → `start-mlflow`**.
+
+## Configuration
+
+Override defaults on the `make` command line or in the environment:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `VENV_DIR` | `.venv` | uv virtualenv location (under `tests/mlflow`) |
+| `PYTHON` | `3.11` | Python version passed to `uv venv` |
+| `MLFLOW_VERSION` | `3.8.1` | MLflow package version for `uv pip install` (see **MLflow version note** below) |
+| `MLFLOW_HOST` | `127.0.0.1` | Server bind address |
+| `MLFLOW_PORT` | `5000` | Server port |
+| `MLFLOW_BACKEND_STORE_URI` | `sqlite:///bin/mlflow.db` | Tracking store URI |
+| `MLFLOW_DEFAULT_ARTIFACT_ROOT` | `./bin/mlruns` | Artifact storage directory |
+| `MLFLOW_TRACKING_URI` | `http://127.0.0.1:5000` | Used by `test-godog-server` and client apps |
+
+Examples:
+
+```bash
+make init-python PYTHON=3.12
+make install-mlflow MLFLOW_VERSION=3.8.1
+make start-mlflow MLFLOW_PORT=5001
+MLFLOW_TRACKING_URI=http://127.0.0.1:5001 make test-godog-server
+```
+
+## What gets created
+
+- **`.venv/`** — Python environment with `mlflow` CLI (`tests/mlflow/.venv/bin/mlflow`)
+- **`bin/mlflow.db`** — SQLite tracking backend (when using default `MLFLOW_BACKEND_STORE_URI`)
+- **`bin/mlruns/`** — Local artifact store
+- **`bin/mlflow.log`** — Server stdout/stderr from the last `start-mlflow`
+
+`make clean` removes `bin/` only; it does not delete `.venv`. To recreate Python from scratch:
+
+```bash
+rm -rf .venv && make init-python install-mlflow
+```
+
+## Godog tests
+
+MLflow-specific scenarios live in `features/` and are built with the `godog` tag. They expect **`MLFLOW_TRACKING_URI`** to point at a running server.
+
+```bash
+# Managed server (start → test → stop)
+make test-godog-server
+
+# Or use your own server
+make start-mlflow
+export MLFLOW_TRACKING_URI=http://127.0.0.1:5000
+go test -v -tags=godog ./...
+make stop-mlflow
+```
+
+Repository-wide FVT (`make test-fvt` from the repo root) **excludes** `@mlflow` scenarios by default; use this directory when working on MLflow integration tests.
+
+## Scripts
+
+| Script | Role |
+|--------|------|
+| `scripts/download_mlflow.sh` | Installs MLflow into `$(VENV_DIR)` via `uv pip install` |
+| `scripts/start_mlflow.sh` | Starts `mlflow server`, waits for `/health`, logs to `bin/mlflow.log` |
+| `scripts/stop_mlflow.sh` | Stops background MLflow server processes |
+
+`start-mlflow` does auto-install MLflow; run `make clean` if there are issues with the database.
+
+## MLflow version note
+
+Eval-hub probes `GET /api/3.0/mlflow/server-info` at startup and only sends the `X-MLFLOW-WORKSPACE` header when the server reports `workspaces_enabled: true`.
+
+A default local server from `make start-mlflow` does **not** enable workspaces. If you install **MLflow 3.10+** (for example `MLFLOW_VERSION=3.13.0`) and eval-hub still sent workspace headers (for example from `X-Tenant` on job create), MLflow 3.13+ returned `FEATURE_DISABLED` and job creation failed. Eval-hub now skips the workspace header in that case.
+
+For local dev with eval-hub + this Makefile server, stay on the latest version with `--enable-workspaces` unless testing other versions or features.
+
+When workspaces are enabled, eval-hub **creates the workspace automatically** (via `POST /api/3.0/mlflow/workspaces`) before creating experiments, using the tenant from `X-Tenant` as the workspace name (for example `test-tenant`). You do not need to create workspaces manually in the MLflow UI for FVT-style flows.
+
+## Relation to eval-hub
+
+- Eval-hub service MLflow settings (e.g. `MLFLOW_TRACKING_URI` in config) are documented in the main [AGENTS.md](../../AGENTS.md) and config YAML.
+- This tree is only for **local MLflow server + MLflow-focused godog tests**, not for building eval-hub binaries.

--- a/tests/mlflow/README.md
+++ b/tests/mlflow/README.md
@@ -106,7 +106,7 @@ Repository-wide FVT (`make test-fvt` from the repo root) **excludes** `@mlflow` 
 | `scripts/start_mlflow.sh` | Starts `mlflow server`, waits for `/health`, logs to `bin/mlflow.log` |
 | `scripts/stop_mlflow.sh` | Stops background MLflow server processes |
 
-`start-mlflow` does auto-install MLflow; run `make clean` if there are issues with the database.
+`make start-mlflow` installs MLflow first via its `install-mlflow` dependency. The `run_mlflow.sh` script itself does **not** auto-install; it exits with guidance if `mlflow` is missing. Run `make clean` if there are issues with the database.
 
 ## MLflow version note
 

--- a/tests/mlflow/README.md
+++ b/tests/mlflow/README.md
@@ -103,7 +103,7 @@ Repository-wide FVT (`make test-fvt` from the repo root) **excludes** `@mlflow` 
 | Script | Role |
 |--------|------|
 | `scripts/download_mlflow.sh` | Installs MLflow into `$(VENV_DIR)` via `uv pip install` |
-| `scripts/start_mlflow.sh` | Starts `mlflow server`, waits for `/health`, logs to `bin/mlflow.log` |
+| `scripts/run_mlflow.sh` | Starts `mlflow server`, waits for `/health`, logs to `bin/mlflow.log` |
 | `scripts/stop_mlflow.sh` | Stops background MLflow server processes |
 
 `make start-mlflow` installs MLflow first via its `install-mlflow` dependency. The `run_mlflow.sh` script itself does **not** auto-install; it exits with guidance if `mlflow` is missing. Run `make clean` if there are issues with the database.

--- a/tests/mlflow/README.md
+++ b/tests/mlflow/README.md
@@ -11,7 +11,7 @@ This directory runs a **local MLflow tracking server** for development and for g
 ## Quick start
 
 ```bash
-make install-mlflow   # pip install mlflow into .venv
+make install-mlflow   # uv pip install mlflow into .venv (via scripts/download_mlflow.sh)
 make start-mlflow       # start server in the background
 ```
 

--- a/tests/mlflow/README.md
+++ b/tests/mlflow/README.md
@@ -51,8 +51,8 @@ Override defaults on the `make` command line or in the environment:
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `VENV_DIR` | `.venv` | uv virtualenv location (under `tests/mlflow`) |
-| `PYTHON` | `3.11` | Python version passed to `uv venv` |
-| `MLFLOW_VERSION` | `3.8.1` | MLflow package version for `uv pip install` (see **MLflow version note** below) |
+| `PYTHON` | `3.14` | Python version passed to `uv venv` |
+| `MLFLOW_VERSION` | `3.13.0` | MLflow package version for `uv pip install` (see **MLflow version note** below) |
 | `MLFLOW_HOST` | `127.0.0.1` | Server bind address |
 | `MLFLOW_PORT` | `5000` | Server port |
 | `MLFLOW_BACKEND_STORE_URI` | `sqlite:///bin/mlflow.db` | Tracking store URI |

--- a/tests/mlflow/scripts/download_mlflow.sh
+++ b/tests/mlflow/scripts/download_mlflow.sh
@@ -1,52 +1,41 @@
 #!/bin/bash
 
-# Script to download and install MLflow server
-# This script installs MLflow using pip
+# Install MLflow into the local uv virtualenv (see make init-python).
 
-set -e
+set -euo pipefail
 
-# For now we default to uasing version 3.8.1, we would need to see
-# how we want to handle versions and to what extent the API is
-# stable across versions.
-REQUESTED_VERSION=${1:-"3.8.1"}
-# REQUESTED_VERSION=${1:-""}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MLFLOW_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${MLFLOW_DIR}"
 
-REQUESTED_PYTHON_MAJOR_VERSION=${2:-"3"}
-REQUESTED_PYTHON_MINOR_VERSION=${3:-"10"}
+REQUESTED_VERSION="${MLFLOW_VERSION:-3.8.1}"
+REQUESTED_PYTHON_MAJOR_VERSION="${2:-3}"
+REQUESTED_PYTHON_MINOR_VERSION="${3:-10}"
+VENV_DIR="${VENV_DIR:-.venv}"
 
-# Check if Python is installed
-if ! command -v python3 &> /dev/null; then
-    echo "❌ Error: Python 3 is not installed. Please install Python 3 first."
+if [ ! -x "${VENV_DIR}/bin/python" ]; then
+    echo "❌ Error: ${VENV_DIR}/bin/python not found."
+    echo "   Run 'make init-python' in ${MLFLOW_DIR} first."
     exit 1
 fi
 
-# Check if pip is installed
-if ! command -v pip3 &> /dev/null; then
-    echo "❌ Error: pip3 is not installed. Please install pip3 first."
-    exit 1
-fi
+PYTHON="${VENV_DIR}/bin/python"
 
-# Get Python version
-PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
-echo "📦 Python version: $PYTHON_VERSION"
+PYTHON_VERSION=$("${PYTHON}" --version 2>&1 | awk '{print $2}')
+echo "📦 Python version: ${PYTHON_VERSION} (${VENV_DIR})"
 
-# Check Python version >= 3.10
 check_python_version() {
     local version=$1
     local major minor patch
 
-    # Extract major, minor, and patch versions
     IFS='.' read -r major minor patch <<< "$version"
-
-    # Remove any non-numeric characters from patch (e.g., "3.10.0a1" -> "0")
     patch=$(echo "$patch" | sed 's/[^0-9].*//')
 
-    # Compare versions
-    if [ "$major" -lt ${REQUESTED_PYTHON_MAJOR_VERSION} ]; then
+    if [ "$major" -lt "${REQUESTED_PYTHON_MAJOR_VERSION}" ]; then
         return 1
     fi
 
-    if [ "$major" -eq ${REQUESTED_PYTHON_MAJOR_VERSION} ] && [ "$minor" -lt ${REQUESTED_PYTHON_MINOR_VERSION} ]; then
+    if [ "$major" -eq "${REQUESTED_PYTHON_MAJOR_VERSION}" ] && [ "$minor" -lt "${REQUESTED_PYTHON_MINOR_VERSION}" ]; then
         return 1
     fi
 
@@ -55,30 +44,33 @@ check_python_version() {
 
 if ! check_python_version "$PYTHON_VERSION"; then
     echo "❌ Error: Python ${REQUESTED_PYTHON_MAJOR_VERSION}.${REQUESTED_PYTHON_MINOR_VERSION} or higher is required."
-    echo "   Current version: $PYTHON_VERSION"
-    echo "   Please upgrade Python to version ${REQUESTED_PYTHON_MAJOR_VERSION}.${REQUESTED_PYTHON_MINOR_VERSION} or higher."
+    echo "   Current version: ${PYTHON_VERSION}"
+    echo "   Recreate the venv: rm -rf ${VENV_DIR} && make init-python PYTHON=3.11"
     exit 1
 fi
 
 echo "✅ Python version check passed (>= ${REQUESTED_PYTHON_MAJOR_VERSION}.${REQUESTED_PYTHON_MINOR_VERSION})"
 
-# Install MLflow
 echo "📥 Installing MLflow..."
-if [[ "${REQUESTED_VERSION}" != "" ]]; then
-    python3 -m pip install mlflow==${REQUESTED_VERSION}
-else
-    python3 -m pip install mlflow
+if ! command -v uv >/dev/null 2>&1; then
+    echo "❌ Error: uv is not installed. Install from https://docs.astral.sh/uv/"
+    exit 1
 fi
 
-# Verify installation
-if command -v mlflow &> /dev/null; then
-    MLFLOW_VERSION=$(mlflow --version 2>/dev/null | head -n 1)
+if [[ -n "${REQUESTED_VERSION}" ]]; then
+    uv pip install --python "${PYTHON}" "mlflow==${REQUESTED_VERSION}"
+else
+    uv pip install --python "${PYTHON}" mlflow
+fi
+
+if [ -x "${VENV_DIR}/bin/mlflow" ]; then
+    MLFLOW_INSTALLED_VERSION=$("${VENV_DIR}/bin/mlflow" --version 2>/dev/null | head -n 1)
     echo "✅ MLflow installed successfully!"
-    echo "   Version: $MLFLOW_VERSION"
+    echo "   Version: ${MLFLOW_INSTALLED_VERSION}"
     echo ""
     echo "🎉 MLflow is ready to use!"
-    echo "   Run 'make run-mlflow' to start the server"
+    echo "   Run 'make start-mlflow' to start the server"
 else
-    echo "❌ Error: MLflow installation failed or not found in PATH"
+    echo "❌ Error: MLflow installation failed or mlflow not found in ${VENV_DIR}/bin"
     exit 1
 fi

--- a/tests/mlflow/scripts/run_mlflow.sh
+++ b/tests/mlflow/scripts/run_mlflow.sh
@@ -21,7 +21,10 @@ HOST=${MLFLOW_HOST:-"127.0.0.1"}
 PORT=${MLFLOW_PORT:-"5000"}
 BACKEND_URI=${MLFLOW_BACKEND_STORE_URI:-"sqlite:///bin/mlflow.db"}
 DEFAULT_ARTIFACT_ROOT=${MLFLOW_DEFAULT_ARTIFACT_ROOT:-"./bin/mlruns"}
-ENABLE_WORKSPACES=${MLFLOW_ENABLE_WORKSPACES:-""}
+ENABLE_WORKSPACES=""
+if [[ "${MLFLOW_ENABLE_WORKSPACES:-false}" == "true" ]]; then
+    ENABLE_WORKSPACES="--enable-workspaces"
+fi
 
 # Colors for output
 GREEN='\033[0;32m'

--- a/tests/mlflow/scripts/run_mlflow.sh
+++ b/tests/mlflow/scripts/run_mlflow.sh
@@ -5,6 +5,15 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MLFLOW_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${MLFLOW_DIR}"
+
+VENV_DIR="${VENV_DIR:-.venv}"
+if [ -d "${VENV_DIR}/bin" ]; then
+    export PATH="${MLFLOW_DIR}/${VENV_DIR}/bin:${PATH}"
+fi
+
 mkdir -p bin
 
 # Default values
@@ -12,6 +21,7 @@ HOST=${MLFLOW_HOST:-"127.0.0.1"}
 PORT=${MLFLOW_PORT:-"5000"}
 BACKEND_URI=${MLFLOW_BACKEND_STORE_URI:-"sqlite:///bin/mlflow.db"}
 DEFAULT_ARTIFACT_ROOT=${MLFLOW_DEFAULT_ARTIFACT_ROOT:-"./bin/mlruns"}
+ENABLE_WORKSPACES=${MLFLOW_ENABLE_WORKSPACES:-""}
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -28,11 +38,13 @@ echo -e "  ${YELLOW}Backend Store URI:${NC} $BACKEND_URI"
 echo -e "  ${YELLOW}Default Artifact Root:${NC} $DEFAULT_ARTIFACT_ROOT"
 echo ""
 
-# Check if MLflow is installed
+# Check if MLflow is installed in the venv (or on PATH)
 if ! command -v mlflow &> /dev/null; then
-    echo -e "${YELLOW}⚠️  MLflow not found. Installing...${NC}"
-    ./scripts/download_mlflow.sh
-    echo ""
+    echo -e "${YELLOW}⚠️  MLflow not found. Run 'make install-mlflow' first.${NC}"
+    if [ ! -x "${VENV_DIR}/bin/python" ]; then
+        echo -e "${YELLOW}   Hint: make init-python && make install-mlflow${NC}"
+    fi
+    exit 1
 fi
 
 # Create artifact root directory if it doesn't exist
@@ -54,7 +66,7 @@ fi
 echo -e "${GREEN}✅ Starting MLflow server...${NC}"
 MLFLOW_VERSION=$(mlflow --version 2>/dev/null | head -n 1)
 echo -e "${BLUE}📍 MLflow version: ${MLFLOW_VERSION}${NC}"
-echo -e "${BLUE}📍 Server will be available at: http://$HOST:$PORT${NC}"
+echo -e "${BLUE}📍 Server will be available at: http://$HOST:$PORT${NC} with options: ${ENABLE_WORKSPACES}"
 echo -e "${YELLOW}💡 Press Ctrl+C to stop the server${NC}"
 echo ""
 
@@ -62,6 +74,7 @@ echo ""
 mlflow server \
     --host "$HOST" \
     --port "$PORT" \
+    ${ENABLE_WORKSPACES} \
     --backend-store-uri "$BACKEND_URI" \
     --default-artifact-root "$DEFAULT_ARTIFACT_ROOT" | tee bin/mlflow.log &
 


### PR DESCRIPTION
## What and why

- This is for issue https://redhat.atlassian.net/browse/RHOAIENG-65429
- Implemented workspace probing in the MLflow client to check if the server supports workspaces.
- Enhanced the client to conditionally send workspace headers based on server capabilities.
- Added methods for creating and ensuring workspaces, including handling workspace creation when missing.
- Introduced tests for workspace functionality, ensuring proper behavior when workspaces are enabled or disabled.
- Updated Makefile and scripts for local development to support workspace features.
- Tested this against mlflow `3.8.1`, `3.9.0`, `3.10.1`, `3.11.1`, `3.12.0`, `3.13.0` (without workspaces) and `3.13.0` (with workspaces)

Assisted-by: Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MLflow workspace support with automatic server capability detection and conditional workspace header usage
  * Client will ensure/configure an active workspace when supported

* **Documentation**
  * Added guide for local MLflow server setup with configurable versions, virtualenv usage, and workspace options

* **Tests**
  * Added unit tests for workspace probing and ensure/create behavior; test infra updated for workspace scenarios

* **Chores**
  * Revised dev scripts and Make targets to manage local MLflow lifecycle and installation via a virtualenv
<!-- end of auto-generated comment: release notes by coderabbit.ai -->