### PR TITLE
test: mark evaluation job scenario as slow

### DIFF
--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -397,6 +397,7 @@ Feature: Evaluation Jobs
     When I send a DELETE request to "/api/v1/evaluations/collections/{{value:collection_id}}?hard_delete=true"
     Then the response code should be 204
 
+  @slow
   Scenario: Create threshold-zero collection then submit job and verify completion
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/collections" with body:


### PR DESCRIPTION
## What and why

- Added a @slow tag to the "Create threshold-zero collection then submit job and verify completion" scenario in the evaluation_jobs.feature file to indicate that it may take longer to execute.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked a slow-running evaluation job test scenario for improved test organization and categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->