### PR TITLE
fix: RHOAIENG-66269 - trim queue names before validation

### DIFF
--- a/internal/eval_hub/handlers/collections.go
+++ b/internal/eval_hub/handlers/collections.go
@@ -245,7 +245,7 @@ func (h *Handlers) HandleCreateCollection(ctx *executioncontext.ExecutionContext
 			if err != nil {
 				return err
 			}
-			return serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, collection)
+			return serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, collection, nil)
 		},
 		"validation",
 		"validate-collection",
@@ -341,7 +341,7 @@ func (h *Handlers) HandleUpdateCollection(ctx *executioncontext.ExecutionContext
 			if err != nil {
 				return err
 			}
-			return serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, request)
+			return serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, request, nil)
 		},
 		"validation",
 		"validate-collection-update",

--- a/internal/eval_hub/handlers/evaluations.go
+++ b/internal/eval_hub/handlers/evaluations.go
@@ -80,19 +80,6 @@ func (h *Handlers) getStorage(ctx *executioncontext.ExecutionContext) abstractio
 	return h.storage.WithLogger(ctx.Logger).WithContext(ctx.Ctx).WithTenant(ctx.Tenant).WithOwner(ctx.User)
 }
 
-// ApplyEvaluationJobQueueDefaults trims queue name/kind and sets kind to "kueue" when empty.
-// Call after validating a decoded EvaluationJobConfig (e.g. before persisting or starting a job).
-func ApplyEvaluationJobQueueDefaults(cfg *api.EvaluationJobConfig) {
-	if cfg == nil || cfg.Queue == nil {
-		return
-	}
-	cfg.Queue.Name = strings.TrimSpace(cfg.Queue.Name)
-	cfg.Queue.Kind = strings.TrimSpace(cfg.Queue.Kind)
-	if cfg.Queue.Kind == "" {
-		cfg.Queue.Kind = "kueue"
-	}
-}
-
 // HandleCreateEvaluation handles POST /api/v1/evaluations/jobs
 func (h *Handlers) HandleCreateEvaluation(ctx *executioncontext.ExecutionContext, req http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper) {
 	storage := h.getStorage(ctx)
@@ -112,7 +99,7 @@ func (h *Handlers) HandleCreateEvaluation(ctx *executioncontext.ExecutionContext
 			if err != nil {
 				return err
 			}
-			err = serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, evaluation)
+			err = serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, evaluation, api.NormalizeEvaluationJobConfig)
 			if err != nil {
 				return err
 			}
@@ -141,8 +128,6 @@ func (h *Handlers) HandleCreateEvaluation(ctx *executioncontext.ExecutionContext
 		w.Error(err, ctx.RequestID)
 		return
 	}
-
-	ApplyEvaluationJobQueueDefaults(evaluation)
 
 	mlflowExperimentID := ""
 	mlflowExperimentURL := ""
@@ -447,7 +432,7 @@ func (h *Handlers) HandleUpdateEvaluation(ctx *executioncontext.ExecutionContext
 			if err != nil {
 				return err
 			}
-			return serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, status)
+			return serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, status, nil)
 		},
 		"validation",
 		"validate-evaluation-job",

--- a/internal/eval_hub/handlers/evaluations_test.go
+++ b/internal/eval_hub/handlers/evaluations_test.go
@@ -239,40 +239,58 @@ func TestResolveProvider_NotFound(t *testing.T) {
 	}
 }
 
-func TestApplyEvaluationJobQueueDefaults(t *testing.T) {
+func TestHandleCreateEvaluationAcceptsTrimmedQueueName(t *testing.T) {
 	t.Parallel()
-	t.Run("nil config", func(t *testing.T) {
-		t.Parallel()
-		handlers.ApplyEvaluationJobQueueDefaults(nil)
-	})
-	t.Run("nil queue", func(t *testing.T) {
-		t.Parallel()
-		cfg := &api.EvaluationJobConfig{}
-		handlers.ApplyEvaluationJobQueueDefaults(cfg)
-		if cfg.Queue != nil {
-			t.Fatal("expected Queue to stay nil")
-		}
-	})
-	t.Run("empty kind defaults to kueue", func(t *testing.T) {
-		t.Parallel()
-		cfg := &api.EvaluationJobConfig{
-			Queue: &api.QueueConfig{Name: "  q1  ", Kind: "  "},
-		}
-		handlers.ApplyEvaluationJobQueueDefaults(cfg)
-		if cfg.Queue.Kind != "kueue" || cfg.Queue.Name != "q1" {
-			t.Fatalf("got kind %q name %q", cfg.Queue.Kind, cfg.Queue.Name)
-		}
-	})
-	t.Run("preserves explicit kind", func(t *testing.T) {
-		t.Parallel()
-		cfg := &api.EvaluationJobConfig{
-			Queue: &api.QueueConfig{Name: "q", Kind: "other"},
-		}
-		handlers.ApplyEvaluationJobQueueDefaults(cfg)
-		if cfg.Queue.Kind != "other" {
-			t.Fatalf("got kind %q", cfg.Queue.Kind)
-		}
-	})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	providerConfigs := map[string]api.ProviderResource{
+		"lm_evaluation_harness": {
+			Resource: api.Resource{ID: "lm_evaluation_harness"},
+			ProviderConfig: api.ProviderConfig{
+				Benchmarks: []api.BenchmarkResource{
+					{ID: "arc_easy"},
+				},
+			},
+		},
+	}
+	storage := &fakeStorage{providerConfigs: providerConfigs}
+	runtime := &fakeRuntime{}
+	validate := validation.NewValidator()
+	h := handlers.New(storage, validate, runtime, nil, nil)
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-trim-queue", logger, "test-user", "test-tenant")
+
+	req := &bodyRequest{
+		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs"),
+		body: []byte(`{
+			"name": "test-evaluation-job-queue",
+			"model": {"url": "http://test.com", "name": "test"},
+			"benchmarks": [{"id": "arc_easy", "provider_id": "lm_evaluation_harness"}],
+			"queue": {"kind": "kueue", "name": "  user-queue  "}
+		}`),
+	}
+	recorder := httptest.NewRecorder()
+	resp := MockResponseWrapper{recorder: recorder}
+
+	h.HandleCreateEvaluation(ctx, req, resp)
+
+	if !runtime.called {
+		t.Fatal("expected runtime to be invoked")
+	}
+	if recorder.Code != 202 {
+		t.Fatalf("expected status 202, got %d body %s", recorder.Code, recorder.Body.String())
+	}
+	var job api.EvaluationJobResource
+	if err := json.Unmarshal(recorder.Body.Bytes(), &job); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if job.Queue == nil {
+		t.Fatal("expected queue in response")
+	}
+	if job.Queue.Name != "user-queue" {
+		t.Fatalf("queue.name: got %q want user-queue", job.Queue.Name)
+	}
+	if job.Queue.Kind != "kueue" {
+		t.Fatalf("queue.kind: got %q want kueue", job.Queue.Kind)
+	}
 }
 
 /* TODO: Fix this test

--- a/internal/eval_hub/handlers/providers.go
+++ b/internal/eval_hub/handlers/providers.go
@@ -63,7 +63,7 @@ func (h *Handlers) HandleCreateProvider(ctx *executioncontext.ExecutionContext, 
 			if err != nil {
 				return err
 			}
-			return serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, request)
+			return serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, request, nil)
 		},
 		"validation",
 		"validate-provider",
@@ -240,7 +240,7 @@ func (h *Handlers) HandleUpdateProvider(ctx *executioncontext.ExecutionContext, 
 			if err != nil {
 				return err
 			}
-			return serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, request)
+			return serialization.Unmarshal(h.validate, ctx.WithContext(runtimeCtx), bodyBytes, request, nil)
 		},
 		"validation",
 		"validate-provider-update",

--- a/internal/eval_hub/serialization/json.go
+++ b/internal/eval_hub/serialization/json.go
@@ -9,10 +9,19 @@ import (
 	validator "github.com/go-playground/validator/v10"
 )
 
-func Unmarshal(validate *validator.Validate, executionContext *executioncontext.ExecutionContext, jsonBytes []byte, v any) error {
+// BeforeValidateFunc runs on the decoded value before struct validation. Pass nil when not needed.
+type BeforeValidateFunc func(v any)
+
+// Unmarshal decodes JSON into v, optionally runs beforeValidate, then validates v.
+// Pass beforeValidate (e.g. api.NormalizeEvaluationJobConfig) when fields must be normalized
+// before struct tags such as k8s_label_value are applied.
+func Unmarshal(validate *validator.Validate, executionContext *executioncontext.ExecutionContext, jsonBytes []byte, v any, beforeValidate BeforeValidateFunc) error {
 	err := json.Unmarshal(jsonBytes, v)
 	if err != nil {
 		return serviceerrors.NewServiceError(messages.InvalidJSONRequest, "Error", err.Error())
+	}
+	if beforeValidate != nil {
+		beforeValidate(v)
 	}
 	// now validate the unmarshalled data
 	err = validate.StructCtx(executionContext.Ctx, v)

--- a/internal/eval_hub/serialization/json_test.go
+++ b/internal/eval_hub/serialization/json_test.go
@@ -1,0 +1,36 @@
+package serialization
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
+	"github.com/eval-hub/eval-hub/pkg/api"
+)
+
+func TestUnmarshal_TrimsQueueNameBeforeValidation(t *testing.T) {
+	validate := validation.NewValidator()
+	ctx := executioncontext.NewExecutionContext(
+		context.Background(),
+		"req-trim-queue",
+		slog.New(slog.NewTextHandler(nil, nil)),
+		"test-user",
+		"test-tenant",
+	)
+	body := []byte(`{
+		"name": "test-evaluation-job-queue",
+		"model": {"url": "http://test.com", "name": "test"},
+		"benchmarks": [{"id": "arc_easy", "provider_id": "lm_evaluation_harness"}],
+		"queue": {"kind": "kueue", "name": "  user-queue  "}
+	}`)
+
+	var cfg api.EvaluationJobConfig
+	if err := Unmarshal(validate, ctx, body, &cfg, api.NormalizeEvaluationJobConfig); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if cfg.Queue == nil || cfg.Queue.Name != "user-queue" || cfg.Queue.Kind != "kueue" {
+		t.Fatalf("got queue %+v", cfg.Queue)
+	}
+}

--- a/internal/eval_hub/validation/validator_test.go
+++ b/internal/eval_hub/validation/validator_test.go
@@ -186,6 +186,22 @@ func TestQueueConfig_InvalidNameRejected(t *testing.T) {
 	}
 }
 
+func TestQueueConfig_WhitespaceTrimmedBeforeValidation(t *testing.T) {
+	validate := NewValidator()
+	cfg := api.EvaluationJobConfig{
+		Name:  "test-job",
+		Model: api.ModelRef{URL: "http://test.com", Name: "model"},
+		Benchmarks: []api.EvaluationBenchmarkConfig{
+			{Ref: api.Ref{ID: "b1"}, ProviderID: "provider-1"},
+		},
+		Queue: &api.QueueConfig{Kind: "kueue", Name: "  user-queue  "},
+	}
+	cfg.Normalize()
+	if err := validate.Struct(cfg); err != nil {
+		t.Fatalf("expected no error after normalize, got: %v", err)
+	}
+}
+
 func TestQueueConfig_ValidNameAccepted(t *testing.T) {
 	validate := NewValidator()
 	valid := []string{

--- a/pkg/api/evaluations.go
+++ b/pkg/api/evaluations.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -224,8 +225,31 @@ type CollectionRef struct {
 	Benchmarks []EvaluationBenchmarkConfig `json:"benchmarks,omitempty" validate:"omitempty,dive"`
 }
 
+// NormalizeEvaluationJobConfig trims queue fields on a decoded job config before validation.
+// Intended as a serialization.Unmarshal beforeValidate hook; v must be *EvaluationJobConfig.
+func NormalizeEvaluationJobConfig(v any) {
+	cfg, ok := v.(*EvaluationJobConfig)
+	if !ok || cfg == nil {
+		return
+	}
+	cfg.Normalize()
+}
+
+// Normalize trims queue fields and applies defaults before struct validation.
+// Queue name/kind whitespace is stripped; an empty kind defaults to "kueue".
+func (cfg *EvaluationJobConfig) Normalize() {
+	if cfg == nil || cfg.Queue == nil {
+		return
+	}
+	cfg.Queue.Name = strings.TrimSpace(cfg.Queue.Name)
+	cfg.Queue.Kind = strings.TrimSpace(cfg.Queue.Kind)
+	if cfg.Queue.Kind == "" {
+		cfg.Queue.Kind = "kueue"
+	}
+}
+
 // QueueConfig represents an optional scheduling queue for evaluation jobs.
-// When Kind is empty, the evaluation job API handler normalizes it to "kueue" before persist/runtime.
+// When Kind is empty, Normalize sets it to "kueue" before validation and persist.
 type QueueConfig struct {
 	Kind string `json:"kind,omitempty" validate:"omitempty,oneof=kueue"`
 	Name string `json:"name" validate:"required,k8s_label_value"`

--- a/pkg/api/evaluations_test.go
+++ b/pkg/api/evaluations_test.go
@@ -2,6 +2,54 @@ package api
 
 import "testing"
 
+func TestNormalizeEvaluationJobConfig(t *testing.T) {
+	t.Run("nil and wrong type are no-ops", func(t *testing.T) {
+		NormalizeEvaluationJobConfig(nil)
+		NormalizeEvaluationJobConfig("not-a-job")
+	})
+	t.Run("trims queue on job config", func(t *testing.T) {
+		cfg := &EvaluationJobConfig{
+			Queue: &QueueConfig{Name: "  user-queue  ", Kind: "kueue"},
+		}
+		NormalizeEvaluationJobConfig(cfg)
+		if cfg.Queue.Name != "user-queue" {
+			t.Fatalf("got name %q", cfg.Queue.Name)
+		}
+	})
+}
+
+func TestEvaluationJobConfig_NormalizeQueue(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		var cfg *EvaluationJobConfig
+		cfg.Normalize()
+	})
+	t.Run("nil queue", func(t *testing.T) {
+		cfg := &EvaluationJobConfig{}
+		cfg.Normalize()
+		if cfg.Queue != nil {
+			t.Fatal("expected Queue to stay nil")
+		}
+	})
+	t.Run("trims name and defaults kind", func(t *testing.T) {
+		cfg := &EvaluationJobConfig{
+			Queue: &QueueConfig{Name: "  user-queue  ", Kind: "  "},
+		}
+		cfg.Normalize()
+		if cfg.Queue.Kind != "kueue" || cfg.Queue.Name != "user-queue" {
+			t.Fatalf("got kind %q name %q", cfg.Queue.Kind, cfg.Queue.Name)
+		}
+	})
+	t.Run("preserves explicit kind", func(t *testing.T) {
+		cfg := &EvaluationJobConfig{
+			Queue: &QueueConfig{Name: "q", Kind: "other"},
+		}
+		cfg.Normalize()
+		if cfg.Queue.Kind != "other" {
+			t.Fatalf("got kind %q", cfg.Queue.Kind)
+		}
+	})
+}
+
 func TestIsBenchmarkTerminalState(t *testing.T) {
 	tests := []struct {
 		state    State


### PR DESCRIPTION
## What and why

This PR adds an option to pre-process payloads before validation. Json Unmarshal function accepts a function as parameter which is invoked before the payload is validated. This function can perform defaulting etc before validation.

Closes https://redhat.atlassian.net/browse/RHOAIENG-66269

Assisted-by: Cursor

## Type

- [ ] feat
- [X] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [X] Tests added or updated
- [X] Tested manually

### Manual test result

Queue name "  q_name  " is converted to "q_name" in the response - create does not fail:

<img width="920" height="771" alt="image" src="https://github.com/user-attachments/assets/a42d4f87-f65c-4506-b995-5f3c0e2e786e" />

## Breaking changes

NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue names are now automatically trimmed of leading and trailing whitespace when submitting evaluation jobs, preventing validation errors from accidental spacing.
  * Evaluation job configuration normalization is now applied consistently during request processing to ensure reliable queue parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->