### PR TITLE
test: use disconnected aware tokenizer in cluster job tests

### DIFF
--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -51,7 +51,7 @@ Feature: Evaluation Jobs
     And the response should contain the value "{{env:MODEL_URL|http://test.com}}" at path "$.model.url"
     And the response should contain the value "test-evaluation-job" at path "$.name"
     And the response should contain the value "10" at path "$.benchmarks[0].parameters.num_examples"
-    And the response should contain the value "google/flan-t5-small" at path "$.benchmarks[0].parameters.tokenizer"
+    And the response should contain the value "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}" at path "$.benchmarks[0].parameters.tokenizer"
     And the response should not contain the value "collection" at path "$.collection"
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
@@ -68,7 +68,7 @@ Feature: Evaluation Jobs
     And the response should contain the value "garak|lm_evaluation_harness" at path "$.benchmarks[0].provider_id"
     And the response should contain the value "3" at path "$.benchmarks[0].parameters.num_fewshot"
     And the response should contain the value "5" at path "$.benchmarks[0].parameters.limit"
-    And the response should contain the value "google/flan-t5-small" at path "$.benchmarks[0].parameters.tokenizer"
+    And the response should contain the value "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}" at path "$.benchmarks[0].parameters.tokenizer"
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
     Then the response code should be 200
     And the response should contain the value "pending" at path "$.status.state"
@@ -78,7 +78,7 @@ Feature: Evaluation Jobs
     And the response should contain the value "garak|lm_evaluation_harness" at path "$.benchmarks[0].provider_id"
     And the response should contain the value "3" at path "$.benchmarks[0].parameters.num_fewshot"
     And the response should contain the value "5" at path "$.benchmarks[0].parameters.limit"
-    And the response should contain the value "google/flan-t5-small" at path "$.benchmarks[0].parameters.tokenizer"
+    And the response should contain the value "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}" at path "$.benchmarks[0].parameters.tokenizer"
     And the response should not contain the value "collection" at path "$.collection"
     And I wait for the evaluation job status to be "completed"
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
@@ -236,35 +236,7 @@ Feature: Evaluation Jobs
 
   Scenario: Evaluation job completes with multi-benchmark collection
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/collections" with body:
-      """
-      {
-        "name": "test-multi-benchmarks-collection",
-        "description": "Collection of multiple benchmarks for FVT",
-        "category": "test",
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "tokenizer": "google/flan-t5-small",
-              "limit": 5,
-              "num_examples": 10
-            }
-          },
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 15,
-              "num_fewshot": 3,
-              "limit": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ]
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection_multi_benchmark.json"
     Then the response code should be 201
     And the "resource.id" field in the response should be saved as "value:collection_id"
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
@@ -374,24 +346,7 @@ Feature: Evaluation Jobs
 
   Scenario: Collection job with parameters
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/collections" with body:
-      """
-      {
-        "name": "job-collection-override",
-        "description": "Override parameter",
-        "category": "test",
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 3,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ]
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection_job_parameters.json"
     Then the response code should be 201
     And the "resource.id" field in the response should be saved as "value:collection_id"
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
@@ -402,7 +357,7 @@ Feature: Evaluation Jobs
     When I send a GET request to "/api/v1/evaluations/collections/{{value:collection_id}}"
     Then the response code should be 200
     And the response should contain the value "3" at path "$.benchmarks[0].parameters.num_examples"
-    And the response should contain the value "google/flan-t5-small" at path "$.benchmarks[0].parameters.tokenizer"
+    And the response should contain the value "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}" at path "$.benchmarks[0].parameters.tokenizer"
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
     Then the response code should be 200
     And the response should contain the value "completed" at path "$.status.state"
@@ -415,51 +370,7 @@ Feature: Evaluation Jobs
 
   Scenario: Create threshold-zero collection then submit job and verify completion
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/collections" with body:
-    """
-    {
-        "name": "test-benchmarks-collection-threshold-zero",
-        "category": "test",
-        "description": "Collection of benchmarks for FVT",
-        "pass_criteria": {
-            "threshold": 0
-        },
-        "benchmarks": [
-            {
-                "id": "arc_easy",
-                "provider_id": "lm_evaluation_harness",
-                "primary_score": {
-                    "metric": "acc_norm",
-                    "lower_is_better": false
-                },
-                "pass_criteria": {
-                    "threshold": 0.5
-                },
-                "parameters": {
-                    "limit": 10,
-                    "num_fewshot": 0,
-                    "tokenizer": "google/flan-t5-small"
-                }
-            },
-            {
-                "id": "arc_easy",
-                "provider_id": "lm_evaluation_harness",
-                "primary_score": {
-                    "metric": "acc_norm",
-                    "lower_is_better": false
-                },
-                "pass_criteria": {
-                    "threshold": 0.5
-                },
-                "parameters": {
-                    "limit": 10,
-                    "num_fewshot": 0,
-                    "tokenizer": "google/flan-t5-small"
-                }
-            }
-        ]
-    }
-    """
+    When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection_threshold_zero.json"
     Then the response code should be 201
     And the "resource.id" field in the response should be saved as "value:collection_id"
     And the response should contain the value "test-benchmarks-collection-threshold-zero" at path "$.name"
@@ -1152,32 +1063,7 @@ Feature: Evaluation Jobs
   @kueue
   Scenario: Create evaluation job with Kueue queue
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}"
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 10,
-              "num_fewshot": 3,
-              "limit": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "name": "test-evaluation-job-queue",
-        "queue": {
-          "kind": "kueue",
-          "name": "{{env:QUEUE_NAME|user-queue}}"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_kueue.json"
     Then the response code should be 202
     And the response should contain the value "kueue" at path "$.queue.kind"
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.queue.name"
@@ -1191,31 +1077,7 @@ Feature: Evaluation Jobs
   @kueue
   Scenario: Create evaluation job with queue name only
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}"
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 10,
-              "num_fewshot": 3,
-              "limit": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "name": "test-evaluation-job-queue-name",
-        "queue": {
-          "name": "{{env:QUEUE_NAME|user-queue}}"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_kueue_name_only.json"
     Then the response code should be 202
     And the response should contain the value "kueue" at path "$.queue.kind"
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.queue.name"
@@ -1414,32 +1276,7 @@ Feature: Evaluation Jobs
   @kueue
   Scenario: Create evaluation job with queue name with whitespace is trimmed
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}"
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 10,
-              "num_fewshot": 3,
-              "limit": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "name": "test-evaluation-job-queue",
-        "queue": {
-          "kind": "kueue",
-          "name": "  user-queue  "
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_kueue_whitespace.json"
     Then the response code should be 202
     And the response should contain the value "kueue" at path "$.queue.kind"
     And the response should contain the value "user-queue" at path "$.queue.name"
@@ -1453,57 +1290,11 @@ Feature: Evaluation Jobs
   @kueue
   Scenario: Multiple jobs can use the same queue
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "automation_shared_experiment_job_1",
-        "queue": {
-          "kind": "kueue",
-          "name": "{{env:QUEUE_NAME|user-queue}}"
-        },
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}"
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 3,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ]
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_kueue_shared_job1.json"
     Then the response code should be 202
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.queue.name"
     And the "resource.id" field in the response should be saved as "value:job1_id"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "automation_shared_experiment_job_2",
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}"
-        },
-        "queue": {
-          "kind": "kueue",
-          "name": "{{env:QUEUE_NAME|user-queue}}"
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 3,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ]
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_kueue_shared_job2.json"
     Then the response code should be 202
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.queue.name"
     And the "resource.id" field in the response should be saved as "value:job2_id"
@@ -1589,39 +1380,7 @@ Feature: Evaluation Jobs
   @kueue
   Scenario: Create evaluation job with Kueue queue, tags and pass criteria
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}"
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 10,
-              "num_fewshot": 3,
-              "limit": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "name": "test-evaluation-job-queue-tags-criteria",
-        "queue": {
-          "kind": "kueue",
-          "name": "{{env:QUEUE_NAME|user-queue}}"
-        },
-        "tags": [
-          "integration-test",
-          "kueue-enabled"
-        ],
-        "pass_criteria": {
-          "threshold": 0.8
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_kueue_tags_criteria.json"
     Then the response code should be 202
     And the response should contain the value "kueue" at path "$.queue.kind"
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.queue.name"

--- a/tests/features/jsonnet_test.go
+++ b/tests/features/jsonnet_test.go
@@ -593,3 +593,258 @@ func TestEvaluateEvaluationJobJsonnetWithCollectionId(t *testing.T) {
 		t.Errorf("benchmarks = %#v, want key absent when collection_id is set", job.Benchmarks)
 	}
 }
+
+type jsonnetTestDataRef struct {
+	S3 struct {
+		Bucket    string `json:"bucket"`
+		Key       string `json:"key"`
+		SecretRef string `json:"secret_ref"`
+	} `json:"s3"`
+}
+
+type jsonnetBenchmarkPayload struct {
+	ID          string              `json:"id"`
+	ProviderID  string              `json:"provider_id"`
+	Parameters  map[string]any      `json:"parameters"`
+	TestDataRef *jsonnetTestDataRef `json:"test_data_ref"`
+}
+
+type jsonnetPayloadDocument struct {
+	Name         string                    `json:"name"`
+	Benchmarks   []jsonnetBenchmarkPayload `json:"benchmarks"`
+	PassCriteria *struct {
+		Threshold float64 `json:"threshold"`
+	} `json:"pass_criteria"`
+	Queue *struct {
+		Kind string `json:"kind"`
+		Name string `json:"name"`
+	} `json:"queue"`
+	Tags []string `json:"tags"`
+}
+
+func jsonnetPayloadFilePath(t *testing.T, name string) string {
+	t.Helper()
+	path, err := filepath.Abs(filepath.Join(testDataRoot(), name))
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	return path
+}
+
+func evaluateJsonnetPayloadDocument(t *testing.T, tc *scenarioConfig, file string) jsonnetPayloadDocument {
+	t.Helper()
+	out, err := tc.evaluateJsonnetFile(jsonnetPayloadFilePath(t, file))
+	if err != nil {
+		t.Fatalf("evaluateJsonnetFile(%s): %v", file, err)
+	}
+	var doc jsonnetPayloadDocument
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("unmarshal %s: %v\noutput: %s", file, err, out)
+	}
+	return doc
+}
+
+func assertJsonnetBenchmarksDisconnectedAware(t *testing.T, file string, benchmarks []jsonnetBenchmarkPayload, disconnected bool) {
+	t.Helper()
+	wantTokenizer := "google/flan-t5-small"
+	if disconnected {
+		wantTokenizer = "/test_data/tokenizer"
+	}
+	for i, b := range benchmarks {
+		if b.ID == "" {
+			t.Errorf("%s benchmarks[%d].id is empty", file, i)
+		}
+		if b.ProviderID == "" {
+			t.Errorf("%s benchmarks[%d].provider_id is empty", file, i)
+		}
+		if got := b.Parameters["tokenizer"]; got != wantTokenizer {
+			t.Errorf("%s benchmarks[%d].parameters.tokenizer = %v, want %s", file, i, got, wantTokenizer)
+		}
+		if disconnected {
+			if b.TestDataRef == nil {
+				t.Errorf("%s benchmarks[%d].test_data_ref is nil, want s3 ref", file, i)
+				continue
+			}
+			s3 := b.TestDataRef.S3
+			if s3.Bucket != "mlpipeline" || s3.Key != "offline" || s3.SecretRef != "minio-test" {
+				t.Errorf("%s benchmarks[%d].test_data_ref.s3 = %+v, want mlpipeline/offline/minio-test", file, i, s3)
+			}
+		} else if b.TestDataRef != nil {
+			t.Errorf("%s benchmarks[%d].test_data_ref = %+v, want nil", file, i, b.TestDataRef.S3)
+		}
+	}
+}
+
+func TestEvaluateFVTJsonnetPayloadFiles(t *testing.T) {
+	mlflowOff := false
+	connectedEnv := map[string]string{"ENVIRONMENT_ID": "connected"}
+	disconnectedEnv := map[string]string{
+		"ENVIRONMENT_ID":          "disconnected",
+		"TEST_DATA_S3_BUCKET":     "mlpipeline",
+		"TEST_DATA_S3_KEY":        "offline",
+		"TEST_DATA_S3_SECRET_REF": "minio-test",
+	}
+	queueEnv := map[string]string{"QUEUE_NAME": "user-queue"}
+
+	type payloadCase struct {
+		file                      string
+		env                       map[string]string
+		wantName                  string
+		minBenchmarks             int
+		wantPassCriteriaThreshold *float64
+		wantQueueKind             string
+		wantQueueName             string
+		wantTags                  []string
+	}
+
+	cases := []payloadCase{
+		{
+			file:          "collection.jsonnet",
+			wantName:      "test-benchmarks-collection",
+			minBenchmarks: 1,
+		},
+		{
+			file:          "collection_multi_benchmark.jsonnet",
+			wantName:      "test-multi-benchmarks-collection",
+			minBenchmarks: 2,
+		},
+		{
+			file:          "collection_job_parameters.jsonnet",
+			wantName:      "job-collection-override",
+			minBenchmarks: 1,
+		},
+		{
+			file:                      "collection_threshold_zero.jsonnet",
+			wantName:                  "test-benchmarks-collection-threshold-zero",
+			minBenchmarks:             2,
+			wantPassCriteriaThreshold: ptrFloat64(0),
+		},
+		{
+			file:          "evaluation_job_multiple_benchmark.jsonnet",
+			wantName:      "automation_test_evaluation_multiple_benchmark_job",
+			minBenchmarks: 2,
+		},
+		{
+			file:          "evaluation_job_kueue.jsonnet",
+			wantName:      "test-evaluation-job-queue",
+			minBenchmarks: 1,
+			env:           queueEnv,
+			wantQueueKind: "kueue",
+			wantQueueName: "user-queue",
+		},
+		{
+			file:          "evaluation_job_kueue_name_only.jsonnet",
+			wantName:      "test-evaluation-job-queue-name",
+			minBenchmarks: 1,
+			env:           queueEnv,
+			wantQueueName: "user-queue",
+		},
+		{
+			file:          "evaluation_job_kueue_shared_job1.jsonnet",
+			wantName:      "automation_shared_experiment_job_1",
+			minBenchmarks: 1,
+			env:           queueEnv,
+			wantQueueKind: "kueue",
+			wantQueueName: "user-queue",
+		},
+		{
+			file:          "evaluation_job_kueue_shared_job2.jsonnet",
+			wantName:      "automation_shared_experiment_job_2",
+			minBenchmarks: 1,
+			env:           queueEnv,
+			wantQueueKind: "kueue",
+			wantQueueName: "user-queue",
+		},
+		{
+			file:                      "evaluation_job_kueue_tags_criteria.jsonnet",
+			wantName:                  "test-evaluation-job-queue-tags-criteria",
+			minBenchmarks:             1,
+			env:                       queueEnv,
+			wantQueueKind:             "kueue",
+			wantQueueName:             "user-queue",
+			wantTags:                  []string{"integration-test", "kueue-enabled"},
+			wantPassCriteriaThreshold: ptrFloat64(0.8),
+		},
+		{
+			file:          "evaluation_job_kueue_whitespace.jsonnet",
+			wantName:      "test-evaluation-job-queue",
+			minBenchmarks: 1,
+			wantQueueKind: "kueue",
+			wantQueueName: "  user-queue  ",
+		},
+	}
+
+	for _, disconnected := range []bool{false, true} {
+		mode := "connected"
+		baseEnv := connectedEnv
+		if disconnected {
+			mode = "disconnected"
+			baseEnv = disconnectedEnv
+		}
+		for _, tc := range cases {
+			name := mode + "/" + tc.file
+			t.Run(name, func(t *testing.T) {
+				env := make(map[string]string, len(baseEnv)+len(tc.env))
+				for k, v := range baseEnv {
+					env[k] = v
+				}
+				for k, v := range tc.env {
+					env[k] = v
+				}
+				sc := &scenarioConfig{
+					values:               map[string]string{},
+					jsonnetHarnessEnv:    env,
+					jsonnetMlflowEnabled: &mlflowOff,
+				}
+				doc := evaluateJsonnetPayloadDocument(t, sc, tc.file)
+
+				if doc.Name != tc.wantName {
+					t.Errorf("name = %q, want %q", doc.Name, tc.wantName)
+				}
+				if len(doc.Benchmarks) < tc.minBenchmarks {
+					t.Fatalf("benchmarks = %d, want at least %d", len(doc.Benchmarks), tc.minBenchmarks)
+				}
+				assertJsonnetBenchmarksDisconnectedAware(t, tc.file, doc.Benchmarks, disconnected)
+
+				if tc.wantPassCriteriaThreshold != nil {
+					if doc.PassCriteria == nil {
+						t.Fatal("pass_criteria is nil")
+					}
+					if doc.PassCriteria.Threshold != *tc.wantPassCriteriaThreshold {
+						t.Errorf("pass_criteria.threshold = %v, want %v", doc.PassCriteria.Threshold, *tc.wantPassCriteriaThreshold)
+					}
+				}
+				if tc.wantQueueKind != "" {
+					if doc.Queue == nil {
+						t.Fatal("queue is nil")
+					}
+					if doc.Queue.Kind != tc.wantQueueKind {
+						t.Errorf("queue.kind = %q, want %q", doc.Queue.Kind, tc.wantQueueKind)
+					}
+				}
+				if tc.wantQueueName != "" {
+					if doc.Queue == nil {
+						t.Fatal("queue is nil")
+					}
+					if doc.Queue.Name != tc.wantQueueName {
+						t.Errorf("queue.name = %q, want %q", doc.Queue.Name, tc.wantQueueName)
+					}
+				}
+				if tc.wantTags != nil {
+					if len(doc.Tags) != len(tc.wantTags) {
+						t.Fatalf("tags = %#v, want %#v", doc.Tags, tc.wantTags)
+					}
+					for i, tag := range tc.wantTags {
+						if doc.Tags[i] != tag {
+							t.Errorf("tags[%d] = %q, want %q", i, doc.Tags[i], tag)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func ptrFloat64(v float64) *float64 {
+	return &v
+}

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -523,6 +523,14 @@ func (tc *scenarioConfig) iWaitForEvaluationJobStatus(expectedStatus string) err
 
 var errTestFileNotFound = errors.New("test file not found")
 
+// fvtBenchmarkTokenizer returns the expected benchmark tokenizer for FVT assertions and payloads.
+func fvtBenchmarkTokenizer() string {
+	if strings.Contains(strings.ToLower(os.Getenv("ENVIRONMENT_ID")), "disconnected") {
+		return "/test_data/tokenizer"
+	}
+	return "google/flan-t5-small"
+}
+
 func (tc *scenarioConfig) findFile(fileName string) (string, error) {
 	file := filepath.Join(testDataRoot(), fileName)
 	_, err := os.Stat(file)
@@ -576,6 +584,8 @@ func (tc *scenarioConfig) substituteValues(body string) (string, error) {
 				var value string
 				if v, found := gpuTestSuiteSubstValue(envName); found {
 					value = v
+				} else if envName == "FVT_BENCHMARK_TOKENIZER" {
+					value = fvtBenchmarkTokenizer()
 				} else if envValue, envOk := os.LookupEnv(envName); envOk {
 					value = envValue
 				} else if hasFallback {

--- a/tests/features/test_data/collection.jsonnet
+++ b/tests/features/test_data/collection.jsonnet
@@ -1,0 +1,10 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'test-benchmarks-collection',
+  description: 'Collection of benchmarks for FVT',
+  category: 'test',
+  benchmarks: [
+    test.arcEasyBenchmark({ weight: 3 }),
+  ],
+}

--- a/tests/features/test_data/collection_job_parameters.jsonnet
+++ b/tests/features/test_data/collection_job_parameters.jsonnet
@@ -1,0 +1,12 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'job-collection-override',
+  description: 'Override parameter',
+  category: 'test',
+  benchmarks: [
+    test.benchmark('arc_easy', 'lm_evaluation_harness', {
+      num_examples: 3,
+    }),
+  ],
+}

--- a/tests/features/test_data/collection_multi_benchmark.jsonnet
+++ b/tests/features/test_data/collection_multi_benchmark.jsonnet
@@ -1,0 +1,18 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'test-multi-benchmarks-collection',
+  description: 'Collection of multiple benchmarks for FVT',
+  category: 'test',
+  benchmarks: [
+    test.benchmark('arc_easy', 'lm_evaluation_harness', {
+      limit: 5,
+      num_examples: 10,
+    }),
+    test.benchmark('arc_easy', 'lm_evaluation_harness', {
+      num_examples: 15,
+      num_fewshot: 3,
+      limit: 5,
+    }),
+  ],
+}

--- a/tests/features/test_data/collection_threshold_zero.jsonnet
+++ b/tests/features/test_data/collection_threshold_zero.jsonnet
@@ -1,0 +1,35 @@
+local test = import 'test.libsonnet';
+local harness = std.parseJson(std.extVar('harness'));
+
+local thresholdZeroBenchmark() =
+  {
+    id: 'arc_easy',
+    provider_id: 'lm_evaluation_harness',
+    primary_score: {
+      metric: 'acc_norm',
+      lower_is_better: false,
+    },
+    pass_criteria: {
+      threshold: 0.5,
+    },
+    parameters: {
+      limit: 10,
+      num_fewshot: 0,
+      tokenizer: test.defaultTokenizer(),
+    },
+  } + if harness.disconnected then {
+    test_data_ref: test.testDataRef(),
+  } else {};
+
+{
+  name: 'test-benchmarks-collection-threshold-zero',
+  category: 'test',
+  description: 'Collection of benchmarks for FVT',
+  pass_criteria: {
+    threshold: 0,
+  },
+  benchmarks: [
+    thresholdZeroBenchmark(),
+    thresholdZeroBenchmark(),
+  ],
+}

--- a/tests/features/test_data/evaluation_job_kueue.jsonnet
+++ b/tests/features/test_data/evaluation_job_kueue.jsonnet
@@ -1,0 +1,11 @@
+local test = import 'test.libsonnet';
+
+{
+  model: test.model(),
+  benchmarks: [test.arcEasyBenchmark({})],
+  name: 'test-evaluation-job-queue',
+  queue: {
+    kind: 'kueue',
+    name: test.env('QUEUE_NAME', 'user-queue'),
+  },
+}

--- a/tests/features/test_data/evaluation_job_kueue_name_only.jsonnet
+++ b/tests/features/test_data/evaluation_job_kueue_name_only.jsonnet
@@ -1,0 +1,10 @@
+local test = import 'test.libsonnet';
+
+{
+  model: test.model(),
+  benchmarks: [test.arcEasyBenchmark({})],
+  name: 'test-evaluation-job-queue-name',
+  queue: {
+    name: test.env('QUEUE_NAME', 'user-queue'),
+  },
+}

--- a/tests/features/test_data/evaluation_job_kueue_shared_job1.jsonnet
+++ b/tests/features/test_data/evaluation_job_kueue_shared_job1.jsonnet
@@ -1,0 +1,13 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'automation_shared_experiment_job_1',
+  queue: {
+    kind: 'kueue',
+    name: test.env('QUEUE_NAME', 'user-queue'),
+  },
+  model: test.model(),
+  benchmarks: [
+    test.benchmark('arc_easy', 'lm_evaluation_harness', { num_examples: 3 }),
+  ],
+}

--- a/tests/features/test_data/evaluation_job_kueue_shared_job2.jsonnet
+++ b/tests/features/test_data/evaluation_job_kueue_shared_job2.jsonnet
@@ -1,0 +1,13 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'automation_shared_experiment_job_2',
+  model: test.model(),
+  queue: {
+    kind: 'kueue',
+    name: test.env('QUEUE_NAME', 'user-queue'),
+  },
+  benchmarks: [
+    test.benchmark('arc_easy', 'lm_evaluation_harness', { num_examples: 3 }),
+  ],
+}

--- a/tests/features/test_data/evaluation_job_kueue_tags_criteria.jsonnet
+++ b/tests/features/test_data/evaluation_job_kueue_tags_criteria.jsonnet
@@ -1,0 +1,18 @@
+local test = import 'test.libsonnet';
+
+{
+  model: test.model(),
+  benchmarks: [test.arcEasyBenchmark({})],
+  name: 'test-evaluation-job-queue-tags-criteria',
+  queue: {
+    kind: 'kueue',
+    name: test.env('QUEUE_NAME', 'user-queue'),
+  },
+  tags: [
+    'integration-test',
+    'kueue-enabled',
+  ],
+  pass_criteria: {
+    threshold: 0.8,
+  },
+}

--- a/tests/features/test_data/evaluation_job_kueue_whitespace.jsonnet
+++ b/tests/features/test_data/evaluation_job_kueue_whitespace.jsonnet
@@ -1,0 +1,11 @@
+local test = import 'test.libsonnet';
+
+{
+  model: test.model(),
+  benchmarks: [test.arcEasyBenchmark({})],
+  name: 'test-evaluation-job-queue',
+  queue: {
+    kind: 'kueue',
+    name: '  user-queue  ',
+  },
+}

--- a/tests/features/test_data/evaluation_job_multiple_benchmark.jsonnet
+++ b/tests/features/test_data/evaluation_job_multiple_benchmark.jsonnet
@@ -1,0 +1,22 @@
+local test = import 'test.libsonnet';
+
+test.mergeOptional(
+  {
+    name: 'automation_test_evaluation_multiple_benchmark_job',
+    description: 'This is a test job for automation using multiple benchmarks',
+    tags: [
+      'evalhub',
+      'test',
+    ],
+    model: test.model(),
+    benchmarks: [
+      test.benchmark('arc_easy', 'lm_evaluation_harness', { num_examples: 5 }),
+      test.benchmark('arc_easy', 'lm_evaluation_harness', { num_examples: 10 }),
+    ],
+    pass_criteria: {
+      threshold: 0.5,
+    },
+    custom: {},
+  },
+  test.experiment('automation_test_experiment'),
+)

--- a/tests/features/test_data/jsonnet/test.libsonnet
+++ b/tests/features/test_data/jsonnet/test.libsonnet
@@ -25,34 +25,41 @@ local harness = std.parseJson(std.extVar('harness'));
   mlflow(name)::
     if harness.mlflow_enabled then name else '',
 
-  // Default benchmark for evaluation_job.jsonnet (disconnected vs connected FVT).
-  defaultBenchmark()::
-    if harness.disconnected then {
-      id: 'arc_easy',
-      provider_id: 'lm_evaluation_harness',
-      parameters: {
-        num_examples: 10,
-        num_fewshot: 3,
-        limit: 5,
-        tokenizer: '/test_data/tokenizer',
-      },
-      test_data_ref: {
-        s3: {
-          bucket: $.env('TEST_DATA_S3_BUCKET', 'mlpipeline'),
-          key: $.env('TEST_DATA_S3_KEY', 'offline'),
-          secret_ref: $.env('TEST_DATA_S3_SECRET_REF', 'minio-test'),
-        },
-      },
-    } else {
-      id: 'arc_easy',
-      provider_id: 'lm_evaluation_harness',
-      parameters: {
-        num_examples: 10,
-        num_fewshot: 3,
-        limit: 5,
-        tokenizer: 'google/flan-t5-small',
+  // Tokenizer path for connected vs disconnected cluster FVT.
+  defaultTokenizer()::
+    if harness.disconnected then '/test_data/tokenizer' else 'google/flan-t5-small',
+
+  // Offline test data reference for disconnected runs.
+  testDataRef()::
+    {
+      s3: {
+        bucket: $.env('TEST_DATA_S3_BUCKET', 'mlpipeline'),
+        key: $.env('TEST_DATA_S3_KEY', 'offline'),
+        secret_ref: $.env('TEST_DATA_S3_SECRET_REF', 'minio-test'),
       },
     },
+
+  // Evaluation/collection benchmark with disconnected-aware tokenizer and optional test_data_ref.
+  benchmark(id, providerId, parameters)::
+    local base = {
+      id: id,
+      provider_id: providerId,
+      parameters: {
+        tokenizer: $.defaultTokenizer(),
+      } + parameters,
+    };
+    if harness.disconnected then base + { test_data_ref: $.testDataRef() } else base,
+
+  // arc_easy benchmark with common FVT defaults; extra parameters override or extend.
+  arcEasyBenchmark(parameters={})::
+    $.benchmark('arc_easy', 'lm_evaluation_harness', {
+      num_examples: 10,
+      num_fewshot: 3,
+      limit: 5,
+    } + parameters),
+
+  // Default benchmark for evaluation_job.jsonnet (disconnected vs connected FVT).
+  defaultBenchmark():: $.arcEasyBenchmark({}),
 
   // Default evaluation job model block used across many scenarios.
   model()::


### PR DESCRIPTION
## What and why
Fixes [RHOAIENG-65601](https://redhat.atlassian.net/browse/RHOAIENG-65601) @cluster FVT failures on disconnected RHOAI clusters where tests assumed a connected Hugging Face tokenizer (google/flan-t5-small) while offline clusters use /test_data/tokenizer and MinIO-backed test data.

Changes:

- Add FVT_BENCHMARK_TOKENIZER (from ENVIRONMENT_ID) for job result assertions
- Move collection and Kueue job bodies from inline JSON in the feature file to jsonnet siblings that pick tokenizer and test_data_ref based on connected vs disconnected mode
- Extend test.libsonnet with shared disconnected-aware helpers

<!-- What does this PR do and why? Link to related issues. -->

Closes # https://redhat.atlassian.net/browse/RHOAIENG-65601

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation tokenizer selection now adapts to connected vs disconnected runs via configurable environment-driven default.
  * Improved support for Kueue queue-based job submissions, including name/whitespace handling and shared-queue scenarios.

* **Tests**
  * Replaced large inline payloads with external fixtures and added numerous modular test fixtures for collections, thresholds, and multi-benchmark jobs.
  * Added comprehensive Jsonnet payload evaluation tests and helpers to validate connected/disconnected behaviors and queue/tag/pass-criteria cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->