### PR TITLE
fix(mcp): disable go-sdk localhost DNS-rebinding protection behind kube-rbac-proxy

### DIFF
--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -155,7 +155,10 @@ func runStdio(ctx context.Context, srv *mcp.Server) error {
 func runHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *slog.Logger) error {
 	handler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server { return srv },
-		nil,
+		// Server runs behind kube-rbac-proxy which handles authentication;
+		// the default localhost DNS-rebinding protection rejects the proxy's
+		// forwarded Host header and must be disabled.
+		&mcp.StreamableHTTPOptions{DisableLocalhostProtection: true},
 	)
 	return serveHTTP(ctx, handler, cfg, logger)
 }
@@ -164,7 +167,8 @@ func runHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *s
 func runLegacyHTTPSSE(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *slog.Logger) error {
 	handler := mcp.NewSSEHandler(
 		func(r *http.Request) *mcp.Server { return srv },
-		nil,
+		// Same rationale as runHTTP: behind kube-rbac-proxy.
+		&mcp.SSEOptions{DisableLocalhostProtection: true},
 	)
 	return serveHTTP(ctx, handler, cfg, logger)
 }


### PR DESCRIPTION
## What and why

The MCP server is unreachable through the OpenShift Route. All requests return `403 Forbidden: invalid Host header`, while `/health` (which bypasses kube-rbac-proxy via `--ignore-paths`) works fine.

**Root cause:** The go-sdk v1.6.1 `StreamableHTTPHandler` includes DNS rebinding protection that rejects HTTP requests when the server is bound to a localhost address but the `Host` header contains a non-localhost hostname. In production, kube-rbac-proxy sits on `0.0.0.0:8443` and forwards to the MCP server on `127.0.0.1:8445`, preserving the Route's external `Host` header (which triggers the protection).

**Fix:** Pass `DisableLocalhostProtection: true` via `StreamableHTTPOptions` (Streamable HTTP) and `SSEOptions` (legacy HTTP+SSE). Both transports are affected.

The localhost protection guards against DNS rebinding attacks where a browser is tricked into sending requests to `127.0.0.1` via a crafted hostname. In this deployment the MCP server port (8445) is never directly reachable from outside the pod (all external traffic passes through kube-rbac-proxy), which validates bearer tokens against Kubernetes RBAC (`evalhubs/proxy` subresource, `get` + `create` verbs). The go-sdk check is defence-in-depth that is redundant behind the proxy and blocks all legitimate external access.

**Backwards compatibility:** None broken. Port-forward clients (the currently documented path in `MCP.md`) are unaffected — their `Host` header is already `127.0.0.1`. Route access was non-functional before this fix, so no existing working client changes behaviour.

Closes [RHOAIENG-66840](https://redhat.atlassian.net/browse/RHOAIENG-66840)

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

Manual verification:
1. Deploy EvalHub with MCP enabled
2. `curl -k https://<route>/health` -> `{"status":"ok"}` (unchanged)
3. `curl -k -H "Authorization: Bearer $(oc whoami -t)" -H "Content-Type: application/json" https://<route>/ -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo" {"name":"test","version":"0"}}}'` -> valid MCP initialize response (was 403 before)

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated server configuration to enable proper operation when deployed behind reverse proxy setups, ensuring compatibility with proxy-based security layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->