### PR TITLE
fix(evalhub-mcp): wire EVALHUB_CA_CERT_PATH into the EvalHub HTTP client

### DIFF
--- a/internal/evalhub_mcp/config/config.go
+++ b/internal/evalhub_mcp/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	ListPageLimit int    `mapstructure:"list_page_limit,omitempty" validate:"omitempty,min=1,max=2000"`
 	TLSCertFile   string `mapstructure:"tls_cert_file"`
 	TLSKeyFile    string `mapstructure:"tls_key_file"`
+	CACertPath    string `mapstructure:"ca_cert_path"`
 }
 
 type Flags struct {
@@ -147,6 +148,7 @@ func applyYAMLConfig(cfg *Config, path string) (*Config, error) {
 		"list_page_limit", "EVALHUB_LIST_PAGE_LIMIT",
 		"tls_cert_file", "EVALHUB_TLS_CERT_FILE",
 		"tls_key_file", "EVALHUB_TLS_KEY_FILE",
+		"ca_cert_path", "EVALHUB_CA_CERT_PATH",
 	)
 	if err != nil {
 		return nil, err
@@ -163,6 +165,7 @@ func applyYAMLConfig(cfg *Config, path string) (*Config, error) {
 		v.SetDefault("list_page_limit", cfg.ListPageLimit)
 		v.SetDefault("tls_cert_file", cfg.TLSCertFile)
 		v.SetDefault("tls_key_file", cfg.TLSKeyFile)
+		v.SetDefault("ca_cert_path", cfg.CACertPath)
 	}
 
 	if path == "" {

--- a/internal/evalhub_mcp/config/config_test.go
+++ b/internal/evalhub_mcp/config/config_test.go
@@ -609,7 +609,7 @@ func TestLoadFlagsTLS(t *testing.T) {
 
 func clearEnv(t *testing.T) {
 	t.Helper()
-	for _, key := range []string{"EVALHUB_BASE_URL", "EVALHUB_TOKEN", "EVALHUB_TENANT", "EVALHUB_INSECURE", "EVALHUB_LIST_PAGE_LIMIT", "EVALHUB_TLS_CERT_FILE", "EVALHUB_TLS_KEY_FILE"} {
+	for _, key := range []string{"EVALHUB_BASE_URL", "EVALHUB_TOKEN", "EVALHUB_TENANT", "EVALHUB_INSECURE", "EVALHUB_LIST_PAGE_LIMIT", "EVALHUB_TLS_CERT_FILE", "EVALHUB_TLS_KEY_FILE", "EVALHUB_CA_CERT_PATH"} {
 		t.Setenv(key, "")
 	}
 }

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/evalhub_mcp/config"
@@ -84,7 +85,20 @@ func NewEvalHubClient(cfg *config.Config, logger *slog.Logger) *evalhubclient.Cl
 	if cfg.Insecure {
 		client = client.WithInsecureSkipVerify()
 	}
-	logger.Info("EvalHub client created", "baseURL", cfg.BaseURL, "tenant", cfg.Tenant, "insecure", cfg.Insecure)
+	if cfg.CACertPath != "" {
+		pemData, err := os.ReadFile(cfg.CACertPath)
+		if err != nil {
+			logger.Error("failed to read CA cert file", "path", cfg.CACertPath, "error", err)
+		} else {
+			withCA, err := client.WithCACert(pemData)
+			if err != nil {
+				logger.Error("failed to configure CA cert", "path", cfg.CACertPath, "error", err)
+			} else {
+				client = withCA
+			}
+		}
+	}
+	logger.Info("EvalHub client created", "baseURL", cfg.BaseURL, "tenant", cfg.Tenant, "insecure", cfg.Insecure, "caCertPath", cfg.CACertPath)
 	return client
 }
 

--- a/pkg/evalhubclient/client.go
+++ b/pkg/evalhubclient/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -162,6 +163,34 @@ func (c *Client) WithInsecureSkipVerify() *Client {
 		Transport: &http.Transport{TLSClientConfig: tlsCfg},
 	}
 	return cp
+}
+
+// WithCACert returns a copy of the client that trusts the PEM-encoded CA certificate(s)
+// in pemData in addition to the system certificate pool. Use this to trust a cluster-internal
+// CA (e.g. the OpenShift service CA) without disabling all certificate verification.
+func (c *Client) WithCACert(pemData []byte) (*Client, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM(pemData) {
+		return nil, fmt.Errorf("no valid PEM certificate found in CA data")
+	}
+
+	var tlsCfg *tls.Config
+	if existing, ok := c.httpClient.Transport.(*http.Transport); ok && existing.TLSClientConfig != nil {
+		tlsCfg = existing.TLSClientConfig.Clone()
+	} else {
+		tlsCfg = &tls.Config{} //nolint:gosec
+	}
+	tlsCfg.RootCAs = pool
+
+	cp := c.clone()
+	cp.httpClient = &http.Client{
+		Timeout:   c.httpClient.Timeout,
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}
+	return cp, nil
 }
 
 // WithMaxRetries returns a copy of the client that retries up to n times on transient failures.


### PR DESCRIPTION
## What and why

The MCP server pod has `EVALHUB_CA_CERT_PATH` set to `/etc/evalhub-mcp/ca/service-ca.crt` and the OpenShift service CA cert mounted at that path by the operator. However, the config struct had no `CACertPath` field and `EVALHUB_CA_CERT_PATH` was never bound, so the env var was silently dropped and the Go HTTP client used only the system cert pool.

The eval-hub service uses a cert signed by the cluster's internal service CA, which is not in the system pool. Every outbound call from the MCP server to `evalhub-evalhub.opendatahub.svc.cluster.local:8443` failed with `x509: certificate signed by unknown authority` after three retries (~3.5 s), causing the MCP integration tests for providers, benchmarks, collections, jobs, and provider-by-ID resources to time out.

Closes #

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

None. `CACertPath` defaults to empty string; existing deployments without `EVALHUB_CA_CERT_PATH` are unaffected. The `insecure` flag continues to work independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added support for custom CA certificate configuration via the `EVALHUB_CA_CERT_PATH` environment variable to enable custom TLS certificate chains
* Server now automatically loads and applies custom CA certificates during EvalHub API client initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->