### PR TITLE
test(fvt): convert queue whitespace test to negative validation test

### DIFF
--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1274,18 +1274,12 @@ Feature: Evaluation Jobs
     And the response should contain the value "my-test-experiment" at path "$.experiment.name"
 
   @kueue
-  Scenario: Create evaluation job with queue name with whitespace is trimmed
+  @negative
+  Scenario: Create evaluation job with queue name containing whitespace fails
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_kueue_whitespace.json"
-    Then the response code should be 202
-    And the response should contain the value "kueue" at path "$.queue.kind"
-    And the response should contain the value "user-queue" at path "$.queue.name"
-    And I wait for the evaluation job status to be "completed"
-    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
-    Then the response code should be 200
-    And the response should contain the value "completed" at path "$.status.state"
-    And the response should contain the value "kueue" at path "$.queue.kind"
-    And the response should contain the value "user-queue" at path "$.queue.name"
+    Then the response code should be 400
+    And the response should contain the value "request_validation_failed" at path "$.message_code"
 
   @kueue
   Scenario: Multiple jobs can use the same queue


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->
As per dev comment, queue names with whitespace should fail validation (k8s_label_value constraint) and this is working as designed. Converting the positive test to a negative test to match actual API behavior - expects 400 `request_validation_failed` instead of 202 with trimmed name.

Closes  https://redhat.atlassian.net/browse/RHOAIENG-66269

Assisted-by: <!-- Cursor, Claude etc -->

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated queue name validation to reject names containing whitespace characters instead of trimming them. Queue names with whitespace will now return a validation error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->