### PR TITLE
test(evalhub): enhance API test scenarios for response codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,12 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
-.idea/.gitignore
-.idea/eval-hub.iml
-.idea/misc.xml
-.idea/modules.xml
-.idea/vcs.xml
-.idea/inspectionProfiles/profiles_settings.xml
 
 # KFP generated pipeline files
 containers/**/*_pipeline.yaml
@@ -245,11 +239,12 @@ node_modules/
 mlflow.db
 mlruns/
 mlflow.log
+
 .idea/
 .serena/
 
-# Claude - for now this is ignored - later we may want to share this
-.claude/settings.local.json
+# Claude - for now everything is ignored
+.claude/
 
 .agentready/
 

--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -91,13 +91,15 @@ Feature: Collections Endpoint
   Scenario: Update collection with non-existent id returns 404
     Given the service is running
     When I send a PUT request to "/api/v1/evaluations/collections/00000000-0000-0000-0000-000000000000" with body "file:/collection_update.json"
-    Then the response code should be 404
+    # 403 is returned by the kube-rbac-proxy - 404 is standalone
+    Then the response code should be 404 or 403
 
   @negative
   Scenario: Update collection with empty id returns 404
     Given the service is running
     When I send a PUT request to "/api/v1/evaluations/collections/" with body "file:/collection_update.json"
-    Then the response code should be 404
+    # 403 is returned by the kube-rbac-proxy - 404 is standalone
+    Then the response code should be 404 or 403
 
   @negative
   Scenario: Update collection without name in body returns 400
@@ -190,7 +192,8 @@ Feature: Collections Endpoint
   Scenario: Patch collection with empty id returns 404
     Given the service is running
     When I send a PATCH request to "/api/v1/evaluations/collections/" with body "file:/patch_collection_name.json"
-    Then the response code should be 404
+    # 403 is returned by the kube-rbac-proxy - 404 is standalone
+    Then the response code should be 404 or 403
 
   @negative
   Scenario: Patch collection with invalid body returns 400
@@ -497,34 +500,34 @@ Feature: Collections Endpoint
     And the response should contain the value "Collection of benchmarks for FVT" at path "$.description"
     And the response should equal the value "0.0" at path "$.pass_criteria.threshold"
     And the array at path "$.benchmarks" in the response should have length 2
-  
+
   Scenario: Verify soft delete of collection returns 204
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
     Then the response code should be 201
     When I send a DELETE request to "/api/v1/evaluations/collections/{id}"
     Then the response code should be 204
-  
+
   @negative
   Scenario: Verify soft deleted collection returns 404 on GET
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
     Then the response code should be 201
     When I send a DELETE request to "/api/v1/evaluations/collections/{id}"
-    Then the response code should be 204  
+    Then the response code should be 204
     When I send a GET request to "/api/v1/evaluations/collections/{id}"
     Then the response code should be 404
-  
+
   @negative
   Scenario: Verify DELETE on a deleted collection returns 404
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
     Then the response code should be 201
     When I send a DELETE request to "/api/v1/evaluations/collections/{id}"
-    Then the response code should be 204  
+    Then the response code should be 204
     When I send a DELETE request to "/api/v1/evaluations/collections/{id}"
     Then the response code should be 404
-  
+
   Scenario: Create collection with weighted benchmarks
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/collections" with body:
@@ -563,7 +566,7 @@ Feature: Collections Endpoint
     And the response should contain the value "2" at path "$.benchmarks[1].weight"
     When I send a DELETE request to "/api/v1/evaluations/collections/{id}?hard_delete=true"
     Then the response code should be 204
-  
+
   Scenario: Weighted benchmarks persist on GET
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/collections" with body:
@@ -602,7 +605,7 @@ Feature: Collections Endpoint
     # Not that a tenant owner can be 'system:serviceaccount:tenant:tenant-user' so we must check for equals and not contains
     And the response should not equal the value "system" at path "$.items[0].resource.owner"
     And the array at path "items" in the response should have length at least 1
-  
+
   Scenario: List collections with scope=system and check it returns only system collection
     Given the service is running
     And there are system collections
@@ -610,13 +613,13 @@ Feature: Collections Endpoint
     Then the response code should be 200
     And the response should equal the value "system" at path "$.items[0].resource.owner"
     And the array at path "items" in the response should have length at least 1
-  
+
   Scenario: Verify out of box collection retrieval by id
     Given the service is running
     And there are system collections
     When I send a GET request to "/api/v1/evaluations/collections/{{value:collection0:id}}"
     Then the response code should be 200
-  
+
   Scenario: Verify out of box collection retrieval - name and category
     Given the service is running
     And there are system collections

--- a/tests/features/evaluations.feature
+++ b/tests/features/evaluations.feature
@@ -702,7 +702,8 @@ Feature: Evaluations Endpoint
     When I send a POST request to "/api/v1/evaluations/jobs/unknown-id" with body "file:/evaluation_job.json"
     Then the response code should be 405
     When I send a GET request to "/api/v1/evaluations/jobs/unknown-id/events"
-    Then the response code should be 405
+    # 403 is returned by the kube-rbac-proxy - 405 is standalone
+    Then the response code should be 405 or 403
 
   Scenario: List evaluation jobs by tags and name
     Given the service is running

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -889,6 +889,13 @@ func (tc *scenarioConfig) theResponseStatusShouldBe(status int) error {
 	return nil
 }
 
+func (tc *scenarioConfig) theResponseStatusShouldBeOr(status1, status2 int) error {
+	if (tc.response.StatusCode != status1) && (tc.response.StatusCode != status2) {
+		return tc.logError(fmt.Errorf("expected status %d or %d, got %d for request %s %s with response %s", status1, status2, tc.response.StatusCode, tc.lastMethod, tc.lastURL, string(tc.body)))
+	}
+	return nil
+}
+
 func (tc *scenarioConfig) theResponseShouldContainWithValue(key, value string) error {
 	var data map[string]interface{}
 	if err := json.Unmarshal(tc.body, &data); err != nil {
@@ -1514,6 +1521,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I send a (POST|PUT|PATCH) request to "([^"]*)" with body "([^"]*)"$`, tc.iSendARequestToWithBody)
 	ctx.Step(`^I send a (POST|PUT|PATCH) request to "([^"]*)" with body:$`, tc.iSendARequestToWithInlineBody)
 	ctx.Step(`^the response code should be (\d+)$`, tc.theResponseStatusShouldBe)
+	ctx.Step(`^the response code should be (\d+) or (\d+)$`, tc.theResponseStatusShouldBeOr)
 	ctx.Step(`^the response should contain "([^"]*)" with value "([^"]*)"$`, tc.theResponseShouldContainWithValue)
 	ctx.Step(`^the response should contain "([^"]*)"$`, tc.theResponseShouldContain)
 	ctx.Step(`^the response should be JSON$`, tc.theResponseShouldBeJSON)


### PR DESCRIPTION
## What and why

- Modified collections and evaluations feature tests to account for potential 403 response codes alongside 404 and 405, reflecting changes in the kube-rbac-proxy behavior.
- Introduced a new step definition to validate response codes against multiple expected values.
- Removed specific .idea files from .gitignore and added a general entry for the .idea directory.
- Updated .claude entry in .gitignore to ignore the entire directory.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded collection endpoint test coverage, including soft-delete validation and system collection scenarios with explicit ownership checks.
  * Updated evaluation endpoint tests to support alternative HTTP status code responses.
  * Enhanced test infrastructure to validate multiple acceptable response codes.

* **Chores**
  * Updated IDE configuration exclusions in `.gitignore`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->