### PR TITLE
test(evalhub): update response code expectations for unsupported methods

### DIFF
--- a/tests/features/evaluations.feature
+++ b/tests/features/evaluations.feature
@@ -698,9 +698,11 @@ Feature: Evaluations Endpoint
   Scenario: Evaluation endpoints reject unsupported methods
     Given the service is running
     When I send a PUT request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
-    Then the response code should be 405
+    # 403 is returned by the kube-rbac-proxy - 405 is standalone
+    Then the response code should be 405 or 403
     When I send a POST request to "/api/v1/evaluations/jobs/unknown-id" with body "file:/evaluation_job.json"
-    Then the response code should be 405
+    # 403 is returned by the kube-rbac-proxy - 405 is standalone
+    Then the response code should be 405 or 403
     When I send a GET request to "/api/v1/evaluations/jobs/unknown-id/events"
     # 403 is returned by the kube-rbac-proxy - 405 is standalone
     Then the response code should be 405 or 403

--- a/tests/features/providers.feature
+++ b/tests/features/providers.feature
@@ -403,7 +403,8 @@ Feature: Providers Endpoint
   Scenario: Update provider with empty path returns 404
     Given the service is running
     When I send a PUT request to "/api/v1/evaluations/providers/" with body "file:/user_provider_update.json"
-    Then the response code should be 404
+    # 403 is returned by the kube-rbac-proxy - 404 is standalone
+    Then the response code should be 404 or 403
 
   @negative
   Scenario: Get provider with empty path returns 404


### PR DESCRIPTION
## What and why

- Modified evaluation and provider feature tests to reflect that unsupported method requests may return either 403 or 405 response codes, accommodating changes in kube-rbac-proxy behavior.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated evaluation endpoint test scenarios to accept multiple HTTP response codes (405 or 403) for unsupported operations.
  * Updated provider endpoint test scenarios to accept multiple HTTP response codes (404 or 403) for invalid requests.
  * Improved test robustness across different deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->