### PR TITLE
feat(mcp): surface agent discoverability metadata in MCP server

### DIFF
--- a/internal/evalhub_mcp/server/tools.go
+++ b/internal/evalhub_mcp/server/tools.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/eval-hub/eval-hub/pkg/evalhubclient"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -17,6 +18,9 @@ type EvalHubToolClient interface {
 	CreateJob(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error)
 	CancelJob(id string) error
 	GetJob(id string) (*api.EvaluationJobResource, error)
+	ListProviders(opts ...evalhubclient.ListOption) (*api.ProviderResourceList, error)
+	GetProvider(id string) (*api.ProviderResource, error)
+	GetBenchmark(id string) (*api.BenchmarkResource, error)
 }
 
 // --- input types ---
@@ -52,6 +56,11 @@ type ExperimentInput struct {
 	ArtifactLocation string            `json:"artifact_location,omitempty" jsonschema:"Storage location for experiment artifacts"`
 }
 
+type DiscoverProvidersInput struct {
+	TargetType string   `json:"target_type,omitempty" jsonschema:"Filter by target type: model, agent, or inference_server"`
+	Evaluates  []string `json:"evaluates,omitempty" jsonschema:"Filter to providers that evaluate all of these capabilities (e.g. safety, robustness)"`
+}
+
 type CancelJobInput struct {
 	JobID string `json:"job_id" jsonschema:"ID of the evaluation job to cancel"`
 }
@@ -82,11 +91,30 @@ type GetJobStatusOutput struct {
 }
 
 type BenchmarkStatusOutput struct {
-	ID          string `json:"id"`
-	ProviderID  string `json:"provider_id"`
-	Status      string `json:"status"`
-	StartedAt   string `json:"started_at,omitempty"`
-	CompletedAt string `json:"completed_at,omitempty"`
+	ID                   string   `json:"id"`
+	ProviderID           string   `json:"provider_id"`
+	Status               string   `json:"status"`
+	StartedAt            string   `json:"started_at,omitempty"`
+	CompletedAt          string   `json:"completed_at,omitempty"`
+	ResultInterpretation string   `json:"result_interpretation,omitempty"`
+	Complements          []string `json:"complements,omitempty"`
+}
+
+type ProviderSummaryOutput struct {
+	ID                   string   `json:"id"`
+	Name                 string   `json:"name"`
+	Title                string   `json:"title"`
+	Summary              string   `json:"summary,omitempty"`
+	TargetType           string   `json:"target_type,omitempty"`
+	Evaluates            []string `json:"evaluates,omitempty"`
+	Hints                []string `json:"hints,omitempty"`
+	ResultInterpretation []string `json:"result_interpretation,omitempty"`
+	Complements          []string `json:"complements,omitempty"`
+	RecommendedWhen      []string `json:"recommended_when,omitempty"`
+}
+
+type DiscoverProvidersOutput struct {
+	Providers []ProviderSummaryOutput `json:"providers"`
 }
 
 // --- registration ---
@@ -106,6 +134,11 @@ func registerTools(srv *mcp.Server, client EvalHubToolClient, logger *slog.Logge
 		Name:        "get_job_status",
 		Description: "Get the current status of an evaluation job including overall state, progress percentage, and per-benchmark status with timestamps. Designed for polling: call repeatedly to monitor a running evaluation.",
 	}, getJobStatusHandler(client, logger))
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "discover_providers",
+		Description: "Discover evaluation providers. Filter by target_type (model, agent, inference_server) and/or evaluates (e.g. safety, robustness) to find the right provider for your use case. Each result includes a summary, usage hints, result interpretation guidance, and complementary provider suggestions.",
+	}, discoverProvidersHandler(client, logger))
 }
 
 // --- handlers ---
@@ -190,12 +223,128 @@ func getJobStatusHandler(client EvalHubToolClient, logger *slog.Logger) mcp.Tool
 		}
 
 		out := buildJobStatusOutput(job)
+		enrichBenchmarkStatuses(client, log, out.Benchmarks)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: fmt.Sprintf("Job %s: %s (%d%% complete)", out.JobID, out.State, out.Progress)},
 			},
 		}, out, nil
 	}
+}
+
+func discoverProvidersHandler(client EvalHubToolClient, logger *slog.Logger) mcp.ToolHandlerFor[DiscoverProvidersInput, DiscoverProvidersOutput] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input DiscoverProvidersInput) (*mcp.CallToolResult, DiscoverProvidersOutput, error) {
+		log := requestLogger(ctx, logger)
+		log.Debug("discover_providers called", "target_type", input.TargetType, "evaluates", input.Evaluates)
+
+		list, err := client.ListProviders()
+		if err != nil {
+			log.Error("discover_providers failed", "error", err)
+			return errorResult(fmt.Sprintf("failed to list providers: %v", err)), DiscoverProvidersOutput{}, nil
+		}
+
+		hasFilter := input.TargetType != "" || len(input.Evaluates) > 0
+		var providers []ProviderSummaryOutput
+		for _, p := range list.Items {
+			if hasFilter && p.Agent == nil {
+				continue
+			}
+			if input.TargetType != "" && (p.Agent == nil || p.Agent.TargetType != input.TargetType) {
+				continue
+			}
+			if len(input.Evaluates) > 0 && !agentEvaluatesAll(p.Agent, input.Evaluates) {
+				continue
+			}
+			providers = append(providers, toProviderSummary(p))
+		}
+
+		if providers == nil {
+			providers = []ProviderSummaryOutput{}
+		}
+
+		out := DiscoverProvidersOutput{Providers: providers}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Found %d providers", len(providers))},
+			},
+		}, out, nil
+	}
+}
+
+func toProviderSummary(p api.ProviderResource) ProviderSummaryOutput {
+	out := ProviderSummaryOutput{
+		ID:    p.Resource.ID,
+		Name:  p.Name,
+		Title: p.Title,
+	}
+	if p.Agent != nil {
+		out.Summary = p.Agent.Summary
+		out.TargetType = p.Agent.TargetType
+		out.Evaluates = p.Agent.Evaluates
+		out.Hints = p.Agent.Hints
+		out.ResultInterpretation = p.Agent.ResultInterpretation
+		out.Complements = p.Agent.Complements
+		out.RecommendedWhen = p.Agent.RecommendedWhen
+	}
+	return out
+}
+
+func enrichBenchmarkStatuses(client EvalHubToolClient, log *slog.Logger, benchmarks []BenchmarkStatusOutput) {
+	providerIDs := make(map[string]struct{})
+	for _, b := range benchmarks {
+		if api.IsBenchmarkTerminalState(api.State(b.Status)) {
+			providerIDs[b.ProviderID] = struct{}{}
+		}
+	}
+	if len(providerIDs) == 0 {
+		return
+	}
+
+	providers := make(map[string]*api.ProviderResource, len(providerIDs))
+	for pid := range providerIDs {
+		p, err := client.GetProvider(pid)
+		if err != nil {
+			log.Debug("could not fetch provider for enrichment", "provider_id", pid, "error", err)
+			continue
+		}
+		providers[pid] = p
+	}
+
+	for i := range benchmarks {
+		b := &benchmarks[i]
+		if !api.IsBenchmarkTerminalState(api.State(b.Status)) {
+			continue
+		}
+		p, ok := providers[b.ProviderID]
+		if !ok {
+			continue
+		}
+		if p.Agent != nil {
+			b.Complements = p.Agent.Complements
+		}
+		for _, bm := range p.Benchmarks {
+			if bm.ID == b.ID && bm.Agent != nil {
+				b.ResultInterpretation = bm.Agent.ResultInterpretation
+				break
+			}
+		}
+	}
+}
+
+func agentEvaluatesAll(agent *api.AgentMetadata, required []string) bool {
+	if agent == nil {
+		return false
+	}
+	have := make(map[string]struct{}, len(agent.Evaluates))
+	for _, e := range agent.Evaluates {
+		have[e] = struct{}{}
+	}
+	for _, r := range required {
+		if _, ok := have[r]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // --- helpers ---

--- a/internal/evalhub_mcp/server/tools_test.go
+++ b/internal/evalhub_mcp/server/tools_test.go
@@ -16,9 +16,12 @@ import (
 // --- mock tool client ---
 
 type mockToolClient struct {
-	createJobFn func(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error)
-	cancelJobFn func(id string) error
-	getJobFn    func(id string) (*api.EvaluationJobResource, error)
+	createJobFn    func(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error)
+	cancelJobFn    func(id string) error
+	getJobFn       func(id string) (*api.EvaluationJobResource, error)
+	listProviderFn func(opts ...evalhubclient.ListOption) (*api.ProviderResourceList, error)
+	getProviderFn  func(id string) (*api.ProviderResource, error)
+	getBenchmarkFn func(id string) (*api.BenchmarkResource, error)
 }
 
 func (m *mockToolClient) CreateJob(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error) {
@@ -50,6 +53,33 @@ func (m *mockToolClient) GetJob(id string) (*api.EvaluationJobResource, error) {
 	return nil, &evalhubclient.APIError{
 		StatusCode: http.StatusNotFound,
 		Message:    fmt.Sprintf("job %q not found", id),
+	}
+}
+
+func (m *mockToolClient) ListProviders(opts ...evalhubclient.ListOption) (*api.ProviderResourceList, error) {
+	if m.listProviderFn != nil {
+		return m.listProviderFn(opts...)
+	}
+	return &api.ProviderResourceList{Items: []api.ProviderResource{}}, nil
+}
+
+func (m *mockToolClient) GetProvider(id string) (*api.ProviderResource, error) {
+	if m.getProviderFn != nil {
+		return m.getProviderFn(id)
+	}
+	return nil, &evalhubclient.APIError{
+		StatusCode: http.StatusNotFound,
+		Message:    fmt.Sprintf("provider %q not found", id),
+	}
+}
+
+func (m *mockToolClient) GetBenchmark(id string) (*api.BenchmarkResource, error) {
+	if m.getBenchmarkFn != nil {
+		return m.getBenchmarkFn(id)
+	}
+	return nil, &evalhubclient.APIError{
+		StatusCode: http.StatusNotFound,
+		Message:    fmt.Sprintf("benchmark %q not found", id),
 	}
 }
 
@@ -122,7 +152,7 @@ func callToolExpectError(t *testing.T, ctx context.Context, cs *mcp.ClientSessio
 
 // --- tools/list ---
 
-func TestToolsListIncludesAllThree(t *testing.T) {
+func TestToolsListIncludesAll(t *testing.T) {
 	t.Parallel()
 	ctx, cs := connectWithTools(t, &mockToolClient{})
 
@@ -132,9 +162,10 @@ func TestToolsListIncludesAllThree(t *testing.T) {
 	}
 
 	want := map[string]bool{
-		"submit_evaluation": false,
-		"cancel_job":        false,
-		"get_job_status":    false,
+		"submit_evaluation":  false,
+		"cancel_job":         false,
+		"get_job_status":     false,
+		"discover_providers": false,
 	}
 	for _, tool := range result.Tools {
 		if _, ok := want[tool.Name]; ok {
@@ -555,6 +586,336 @@ func TestGetJobStatusEmptyID(t *testing.T) {
 
 	if msg == "" {
 		t.Error("expected non-empty error message for empty job_id")
+	}
+}
+
+// --- discover_providers ---
+
+func testProviders() []api.ProviderResource {
+	return []api.ProviderResource{
+		{
+			Resource:       api.Resource{ID: "garak"},
+			ProviderConfig: api.ProviderConfig{Name: "garak", Title: "Garak Safety"},
+		},
+		{
+			Resource: api.Resource{ID: "agentdojo"},
+			ProviderConfig: api.ProviderConfig{
+				Name:  "agentdojo",
+				Title: "AgentDojo",
+				Agent: &api.AgentMetadata{
+					TargetType:           "agent",
+					Evaluates:            []string{"safety", "prompt-injection"},
+					Summary:              "Test agent resilience to prompt injection",
+					Hints:                []string{"Requires tool-calling model"},
+					ResultInterpretation: []string{"High utility + low security = dangerous"},
+					Complements:          []string{"garak"},
+					RecommendedWhen:      []string{"Evaluating agentic systems"},
+				},
+			},
+		},
+		{
+			Resource: api.Resource{ID: "lmeval"},
+			ProviderConfig: api.ProviderConfig{
+				Name:  "lm_evaluation_harness",
+				Title: "LM Evaluation Harness",
+				Agent: &api.AgentMetadata{
+					TargetType: "model",
+					Evaluates:  []string{"knowledge", "reasoning"},
+					Summary:    "Standard academic benchmarks",
+				},
+			},
+		},
+	}
+}
+
+func mockWithProviders(providers []api.ProviderResource) *mockToolClient {
+	providerMap := make(map[string]*api.ProviderResource, len(providers))
+	for i := range providers {
+		providerMap[providers[i].Resource.ID] = &providers[i]
+	}
+	return &mockToolClient{
+		listProviderFn: func(opts ...evalhubclient.ListOption) (*api.ProviderResourceList, error) {
+			return &api.ProviderResourceList{Items: providers}, nil
+		},
+		getProviderFn: func(id string) (*api.ProviderResource, error) {
+			if p, ok := providerMap[id]; ok {
+				return p, nil
+			}
+			return nil, &evalhubclient.APIError{StatusCode: http.StatusNotFound, Message: fmt.Sprintf("provider %q not found", id)}
+		},
+	}
+}
+
+func TestDiscoverProvidersNoFilter(t *testing.T) {
+	t.Parallel()
+	client := mockWithProviders(testProviders())
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[DiscoverProvidersOutput](t, ctx, cs, "discover_providers", map[string]any{})
+
+	if len(out.Providers) != 3 {
+		t.Fatalf("expected 3 providers, got %d", len(out.Providers))
+	}
+	var garakFound bool
+	for _, p := range out.Providers {
+		if p.ID == "garak" {
+			garakFound = true
+			if p.Summary != "" {
+				t.Errorf("garak should have empty summary (no agent block), got %q", p.Summary)
+			}
+		}
+	}
+	if !garakFound {
+		t.Error("garak (no agent block) should be included in unfiltered results")
+	}
+}
+
+func TestDiscoverProvidersFilterByTargetType(t *testing.T) {
+	t.Parallel()
+	client := mockWithProviders(testProviders())
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[DiscoverProvidersOutput](t, ctx, cs, "discover_providers", map[string]any{
+		"target_type": "agent",
+	})
+
+	if len(out.Providers) != 1 {
+		t.Fatalf("expected 1 provider for target_type=agent, got %d", len(out.Providers))
+	}
+	if out.Providers[0].ID != "agentdojo" {
+		t.Errorf("expected agentdojo, got %q", out.Providers[0].ID)
+	}
+	if out.Providers[0].Summary != "Test agent resilience to prompt injection" {
+		t.Errorf("summary not populated: %q", out.Providers[0].Summary)
+	}
+}
+
+func TestDiscoverProvidersFilterByEvaluates(t *testing.T) {
+	t.Parallel()
+	client := mockWithProviders(testProviders())
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[DiscoverProvidersOutput](t, ctx, cs, "discover_providers", map[string]any{
+		"evaluates": []string{"safety"},
+	})
+
+	if len(out.Providers) != 1 {
+		t.Fatalf("expected 1 provider for evaluates=[safety], got %d", len(out.Providers))
+	}
+	if out.Providers[0].ID != "agentdojo" {
+		t.Errorf("expected agentdojo, got %q", out.Providers[0].ID)
+	}
+}
+
+func TestDiscoverProvidersFilterAllNilAgent(t *testing.T) {
+	t.Parallel()
+	client := mockWithProviders([]api.ProviderResource{
+		{
+			Resource:       api.Resource{ID: "bare"},
+			ProviderConfig: api.ProviderConfig{Name: "bare", Title: "Bare Provider"},
+		},
+	})
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[DiscoverProvidersOutput](t, ctx, cs, "discover_providers", map[string]any{
+		"target_type": "model",
+	})
+
+	if len(out.Providers) != 0 {
+		t.Errorf("expected 0 providers when all have nil agent, got %d", len(out.Providers))
+	}
+}
+
+func TestDiscoverProvidersMixedAgentBlocks(t *testing.T) {
+	t.Parallel()
+	client := mockWithProviders(testProviders())
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[DiscoverProvidersOutput](t, ctx, cs, "discover_providers", map[string]any{
+		"target_type": "model",
+	})
+
+	if len(out.Providers) != 1 {
+		t.Fatalf("expected 1 provider for target_type=model, got %d", len(out.Providers))
+	}
+	if out.Providers[0].ID != "lmeval" {
+		t.Errorf("expected lmeval, got %q", out.Providers[0].ID)
+	}
+}
+
+// --- get_job_status enrichment ---
+
+func TestGetJobStatusEnrichedWithAgentMetadata(t *testing.T) {
+	t.Parallel()
+
+	client := mockWithProviders([]api.ProviderResource{
+		{
+			Resource: api.Resource{ID: "test-provider"},
+			ProviderConfig: api.ProviderConfig{
+				Name:  "test-provider",
+				Title: "Test Provider",
+				Agent: &api.AgentMetadata{
+					Complements: []string{"other-provider"},
+				},
+				Benchmarks: []api.BenchmarkResource{
+					{
+						ID:   "bench-1",
+						Name: "Benchmark One",
+						Agent: &api.BenchmarkAgentMetadata{
+							ResultInterpretation: "Higher is better",
+						},
+					},
+				},
+			},
+		},
+	})
+	client.getJobFn = func(id string) (*api.EvaluationJobResource, error) {
+		return &api.EvaluationJobResource{
+			Resource: api.EvaluationResource{
+				Resource: api.Resource{ID: id, CreatedAt: time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)},
+			},
+			Status: &api.EvaluationJobStatus{
+				EvaluationJobState: api.EvaluationJobState{State: api.OverallStateCompleted},
+				Benchmarks: []api.BenchmarkStatus{
+					{
+						ID:          "bench-1",
+						ProviderID:  "test-provider",
+						Status:      api.StateCompleted,
+						StartedAt:   "2026-05-01T10:01:00Z",
+						CompletedAt: "2026-05-01T10:05:00Z",
+					},
+				},
+			},
+		}, nil
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[GetJobStatusOutput](t, ctx, cs, "get_job_status", map[string]any{
+		"job_id": "job-enriched",
+	})
+
+	if len(out.Benchmarks) != 1 {
+		t.Fatalf("expected 1 benchmark, got %d", len(out.Benchmarks))
+	}
+	b := out.Benchmarks[0]
+	if b.ResultInterpretation != "Higher is better" {
+		t.Errorf("result_interpretation = %q, want %q", b.ResultInterpretation, "Higher is better")
+	}
+	if len(b.Complements) != 1 || b.Complements[0] != "other-provider" {
+		t.Errorf("complements = %v, want [other-provider]", b.Complements)
+	}
+}
+
+func TestGetJobStatusNoAgentMetadata(t *testing.T) {
+	t.Parallel()
+
+	client := mockWithProviders([]api.ProviderResource{
+		{
+			Resource: api.Resource{ID: "bare-provider"},
+			ProviderConfig: api.ProviderConfig{
+				Name:  "bare-provider",
+				Title: "Bare Provider",
+				Benchmarks: []api.BenchmarkResource{
+					{ID: "bench-bare", Name: "Bare Benchmark"},
+				},
+			},
+		},
+	})
+	client.getJobFn = func(id string) (*api.EvaluationJobResource, error) {
+		return &api.EvaluationJobResource{
+			Resource: api.EvaluationResource{
+				Resource: api.Resource{ID: id, CreatedAt: time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)},
+			},
+			Status: &api.EvaluationJobStatus{
+				EvaluationJobState: api.EvaluationJobState{State: api.OverallStateCompleted},
+				Benchmarks: []api.BenchmarkStatus{
+					{
+						ID:          "bench-bare",
+						ProviderID:  "bare-provider",
+						Status:      api.StateCompleted,
+						StartedAt:   "2026-05-01T10:01:00Z",
+						CompletedAt: "2026-05-01T10:05:00Z",
+					},
+				},
+			},
+		}, nil
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[GetJobStatusOutput](t, ctx, cs, "get_job_status", map[string]any{
+		"job_id": "job-bare",
+	})
+
+	if len(out.Benchmarks) != 1 {
+		t.Fatalf("expected 1 benchmark, got %d", len(out.Benchmarks))
+	}
+	b := out.Benchmarks[0]
+	if b.ResultInterpretation != "" {
+		t.Errorf("result_interpretation should be empty, got %q", b.ResultInterpretation)
+	}
+	if len(b.Complements) != 0 {
+		t.Errorf("complements should be empty, got %v", b.Complements)
+	}
+}
+
+func TestGetJobStatusRunningNoEnrichment(t *testing.T) {
+	t.Parallel()
+
+	client := mockWithProviders([]api.ProviderResource{
+		{
+			Resource: api.Resource{ID: "some-provider"},
+			ProviderConfig: api.ProviderConfig{
+				Name:  "some-provider",
+				Title: "Some Provider",
+				Agent: &api.AgentMetadata{Complements: []string{"should-not-appear"}},
+				Benchmarks: []api.BenchmarkResource{
+					{
+						ID:   "bench-running",
+						Name: "Running Benchmark",
+						Agent: &api.BenchmarkAgentMetadata{
+							ResultInterpretation: "should-not-appear",
+						},
+					},
+				},
+			},
+		},
+	})
+	client.getJobFn = func(id string) (*api.EvaluationJobResource, error) {
+		return &api.EvaluationJobResource{
+			Resource: api.EvaluationResource{
+				Resource: api.Resource{ID: id, CreatedAt: time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)},
+			},
+			Status: &api.EvaluationJobStatus{
+				EvaluationJobState: api.EvaluationJobState{State: api.OverallStateRunning},
+				Benchmarks: []api.BenchmarkStatus{
+					{
+						ID:         "bench-running",
+						ProviderID: "some-provider",
+						Status:     api.StateRunning,
+						StartedAt:  "2026-05-01T10:01:00Z",
+					},
+				},
+			},
+		}, nil
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[GetJobStatusOutput](t, ctx, cs, "get_job_status", map[string]any{
+		"job_id": "job-running",
+	})
+
+	if len(out.Benchmarks) != 1 {
+		t.Fatalf("expected 1 benchmark, got %d", len(out.Benchmarks))
+	}
+	b := out.Benchmarks[0]
+	if b.ResultInterpretation != "" {
+		t.Errorf("running benchmark should not have result_interpretation, got %q", b.ResultInterpretation)
+	}
+	if len(b.Complements) != 0 {
+		t.Errorf("running benchmark should not have complements, got %v", b.Complements)
 	}
 }
 


### PR DESCRIPTION
## What and why

Closes [RHOAIENG-60133](https://redhat.atlassian.net/browse/RHOAIENG-60133)

The Go MCP server had no way for agents to discover providers based on capabilities or target type. All three existing tools used static hardcoded descriptions, and evaluation results returned no interpretation guidance.

This PR surfaces the provider `agent` block metadata through the MCP server so that connected agents can make context-aware provider selections and interpret evaluation results.

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Changes

- **`discover_providers` tool**: new MCP tool that lists providers with their agent metadata (`summary`, `hints`, `evaluates`, `target_type`, `result_interpretation`, `complements`, `recommended_when`). Supports filtering by `target_type` and `evaluates`; unfiltered queries return all providers (including those without agent blocks); filtered queries exclude providers with no agent metadata.

- **`get_job_status` enrichment**: for benchmarks in a terminal state (completed/failed/cancelled), the response now includes `result_interpretation` from the benchmark's agent block and `complements` from the provider's agent block. Provider fetches are deduplicated by ID. All enrichment is nil-safe, absent agent blocks are silently skipped.

- **`EvalHubToolClient` interface** — extended with `ListProviders`, `GetProvider`, and `GetBenchmark` (all already implemented by `evalhubclient.Client`).

## Testing

- [x] Tests added or updated
- [x] Tested manually

8 new test cases:

- `discover_providers`: no filter, target_type filter, evaluates filter, all-nil-agent filter, mixed agent blocks
- `get_job_status` enrichment: with agent metadata, without agent metadata,  running (no enrichment)

## Breaking changes

None. The new tool is additive, and the enriched fields on `get_job_status` use `omitempty`, existing consumers see no difference unless the provider has agent metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider discovery tool to list and filter available providers by target type and required evaluation capabilities.
  * Job status output now enhanced with result interpretation guidance and complementary provider information.

* **Tests**
  * Added comprehensive test coverage for provider discovery functionality and job status enrichment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->