### PR TITLE
feat(evalhub-mcp): add Python wheel build and CI/publish workflows

### DIFF
--- a/.github/workflows/ci-python-mcp.yml
+++ b/.github/workflows/ci-python-mcp.yml
@@ -1,19 +1,19 @@
-name: CI python-server
+name: CI python-mcp
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main, develop ]
     paths:
-      - 'python-server/**'
-      - 'config/**'
-      - 'cmd/eval_hub/**'
-      - 'internal/**'
+      - 'python-mcp/**'
+      - 'cmd/evalhub_mcp/**'
+      - 'internal/evalhub_mcp/**'
       - 'pkg/**'
       - 'Makefile'
-      - '.github/workflows/ci-python-server.yml'
+      - '.github/workflows/ci-python-mcp.yml'
 
 jobs:
-  test-server-wheel:
+  test-mcp-wheel:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
@@ -28,16 +28,13 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: '3.11'
-      - name: Build binary for this platform via cross-compile target
-        run: make cross-compile
-      - name: Build wheel
-        run: make build-wheel
-      - name: Install wheel
+      - name: Build MCP binary for this platform via cross-compile target
+        run: make cross-compile-mcp
+      - name: Build MCP wheel
+        run: make build-mcp-wheel
+      - name: Install MCP wheel
         run: |
           uv venv --python 3.11 .venv
-          uv pip install --python .venv python-server/dist/*.whl
-      - name: Wheel sanity test
-        run: |
-          source .venv/bin/activate
-          chmod +x scripts/gha_wheel_sanity_test.sh
-          ./scripts/gha_wheel_sanity_test.sh
+          uv pip install --python .venv python-mcp/dist/*.whl
+      - name: MCP wheel sanity test
+        run: uv run --python .venv eval-hub-mcp --version

--- a/.github/workflows/publish-python-mcp.yml
+++ b/.github/workflows/publish-python-mcp.yml
@@ -1,0 +1,275 @@
+name: Build and Publish eval-hub-mcp
+
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']  # we haven't established a Tag strategy yet
+  workflow_dispatch:
+    inputs:
+      publish-test-pypi:
+        description: 'Publish to TestPyPI'
+        type: boolean
+        default: true
+      validate-wheels:
+        description: 'Run wheel validation on real runners before publishing'
+        type: boolean
+        default: true
+
+jobs:
+  build-mcp-binaries:
+    name: Build MCP Go binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Linux
+          - goos: linux
+            goarch: amd64
+            output: bin/evalhub-mcp-linux-amd64
+          - goos: linux
+            goarch: arm64
+            output: bin/evalhub-mcp-linux-arm64
+          # macOS
+          - goos: darwin
+            goarch: amd64
+            output: bin/evalhub-mcp-darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            output: bin/evalhub-mcp-darwin-arm64
+          # Windows
+          - goos: windows
+            goarch: amd64
+            output: bin/evalhub-mcp-windows-amd64.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Build binary
+        run: make cross-compile-mcp CROSS_GOOS=${{ matrix.goos }} CROSS_GOARCH=${{ matrix.goarch }}
+
+      - name: Upload binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mcp-binary-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ${{ matrix.output }}
+          retention-days: 7
+
+  build-mcp-wheels:
+    name: Build MCP Python wheels
+    needs: build-mcp-binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: manylinux
+            arch: x86_64
+            goos: linux
+            goarch: amd64
+          - platform: manylinux
+            arch: aarch64
+            goos: linux
+            goarch: arm64
+          - platform: macosx
+            arch: x86_64
+            goos: darwin
+            goarch: amd64
+          - platform: macosx
+            arch: arm64
+            goos: darwin
+            goarch: arm64
+          - platform: win
+            arch: amd64
+            goos: windows
+            goarch: amd64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up uv python
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install wheel and setuptools
+        run: make install-wheel-tools
+
+      - name: Download binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: mcp-binary-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: bin/
+          merge-multiple: true
+
+      - name: List downloaded files
+        run: ls -la bin/
+
+      - name: Build wheel
+        run: |
+          DEV_SUFFIX_ARG=""
+          if [[ ! "${{ github.ref }}" == refs/tags/* ]]; then
+            DEV_SUFFIX_ARG="DEV_SUFFIX=dev${{ github.run_number }}"
+          fi
+          make build-mcp-wheel CROSS_GOOS=${{ matrix.goos }} CROSS_GOARCH=${{ matrix.goarch }} $DEV_SUFFIX_ARG
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mcp-wheel-${{ matrix.platform }}-${{ matrix.arch }}
+          path: python-mcp/dist/*.whl
+          retention-days: 7
+
+  validate-mcp-wheels:
+    name: Validate MCP wheel (${{ matrix.os }})
+    needs: build-mcp-wheels
+    if: github.event_name != 'workflow_dispatch' || inputs.validate-wheels != false
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            wheel-artifact: mcp-wheel-manylinux-x86_64
+          - os: ubuntu-24.04-arm
+            wheel-artifact: mcp-wheel-manylinux-aarch64
+          # Commenting out x86_64 macos as it is hard to come by a runner in GHA
+          # - os: macos-13
+          #   wheel-artifact: mcp-wheel-macosx-x86_64
+          - os: macos-latest
+            wheel-artifact: mcp-wheel-macosx-arm64
+          - os: windows-latest
+            wheel-artifact: mcp-wheel-win-amd64
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Set up uv python
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Download wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ matrix.wheel-artifact }}
+          path: dist/
+
+      - name: Create venv and install wheel
+        shell: bash
+        run: |
+          uv venv .venv
+          uv pip install --python .venv dist/*.whl
+
+      - name: MCP wheel sanity test
+        shell: bash
+        run: uv run --python .venv eval-hub-mcp --version
+
+  publish-mcp:
+    name: Publish to PyPI
+    needs: [build-mcp-wheels, validate-mcp-wheels]
+    # TODO: enable when eval-hub-mcp project is created
+    if: false
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/eval-hub-mcp
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: mcp-wheel-*
+          path: dist/
+          merge-multiple: true
+
+      - name: List wheels
+        run: ls -la dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+
+  check-mcp-testpypi-age:
+    name: Check TestPyPI release age
+    runs-on: ubuntu-latest
+    # TODO: enable when eval-hub-mcp project is created
+    if: false
+    # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+    steps:
+      - name: Check last TestPyPI upload age
+        id: check
+        run: |
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+
+          RESPONSE=$(curl -sf "https://test.pypi.org/pypi/eval-hub-mcp/json") || exit 0
+
+          LATEST_UPLOAD=$(echo "$RESPONSE" | jq -r '
+            [.releases[][] | .upload_time_iso_8601] | max // empty
+          ')
+          [ -z "$LATEST_UPLOAD" ] && exit 0
+
+          UPLOAD_EPOCH=$(date -d "$LATEST_UPLOAD" +%s)
+          NOW_EPOCH=$(date +%s)
+          AGE_DAYS=$(( (NOW_EPOCH - UPLOAD_EPOCH) / 86400 ))
+          echo "Latest TestPyPI upload: $LATEST_UPLOAD ($AGE_DAYS days ago)"
+
+          if [ "$AGE_DAYS" -lt 7 ]; then
+            echo "Last release is only $AGE_DAYS days old — skipping TestPyPI publish"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish-mcp-test-pypi:
+    name: Publish to TestPyPI
+    needs: [build-mcp-wheels, validate-mcp-wheels, check-mcp-testpypi-age]
+    # TODO: enable when eval-hub-mcp project is created
+    if: false
+    # if: >-
+    #   !failure() && !cancelled()
+    #   && (
+    #     (github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/') && inputs.publish-test-pypi)
+    #     || (github.ref == 'refs/heads/main' && needs.check-mcp-testpypi-age.outputs.should_publish == 'true')
+    #   )
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/eval-hub-mcp
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download manylinux x86_64 wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mcp-wheel-manylinux-x86_64
+          path: dist/
+
+      - name: Download macOS arm64 wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mcp-wheel-macosx-arm64
+          path: dist/
+
+      - name: List wheels
+        run: ls -la dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          attestations: false
+          verbose: true

--- a/.github/workflows/publish-python-mcp.yml
+++ b/.github/workflows/publish-python-mcp.yml
@@ -116,11 +116,14 @@ jobs:
       - name: List downloaded files
         run: ls -la bin/
 
-      - name: Build wheel
+      - name: Build MCP wheel
+        env:
+          GH_REF: ${{ github.ref }}
+          GH_RUN_NUMBER: ${{ github.run_number }}
         run: |
           DEV_SUFFIX_ARG=""
-          if [[ ! "${{ github.ref }}" == refs/tags/* ]]; then
-            DEV_SUFFIX_ARG="DEV_SUFFIX=dev${{ github.run_number }}"
+          if [[ ! "${GH_REF}" == refs/tags/* ]]; then
+            DEV_SUFFIX_ARG="DEV_SUFFIX=dev${GH_RUN_NUMBER}"
           fi
           make build-mcp-wheel CROSS_GOOS=${{ matrix.goos }} CROSS_GOARCH=${{ matrix.goarch }} $DEV_SUFFIX_ARG
 

--- a/.github/workflows/publish-python-server.yml
+++ b/.github/workflows/publish-python-server.yml
@@ -117,10 +117,13 @@ jobs:
         run: ls -la bin/
 
       - name: Build wheel
+        env:
+          GH_REF: ${{ github.ref }}
+          GH_RUN_NUMBER: ${{ github.run_number }}
         run: |
           DEV_SUFFIX_ARG=""
-          if [[ ! "${{ github.ref }}" == refs/tags/* ]]; then
-            DEV_SUFFIX_ARG="DEV_SUFFIX=dev${{ github.run_number }}"
+          if [[ ! "${GH_REF}" == refs/tags/* ]]; then
+            DEV_SUFFIX_ARG="DEV_SUFFIX=dev${GH_RUN_NUMBER}"
           fi
           make build-wheel CROSS_GOOS=${{ matrix.goos }} CROSS_GOARCH=${{ matrix.goarch }} $DEV_SUFFIX_ARG
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-mcp build-all-platforms cross-compile-mcp build-all-platforms-mcp start-service stop-service start-sidecar stop-sidecar lint test test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet update-deps generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components fvt-report docker-image-local docker-mcp-version test-mcp-build-all test-mcp-binary-info test-mcp-binary-naming test-mcp-version test-mcp-no-runtime-deps test-mcp-container-build test-mcp-container-http test-mcp-checksums test-mcp-formula-syntax test-mcp-native-smoke test-mcp-brew-install test-mcp-brew-test test-mcp-brew-uninstall test-mcp-cross-platform test-mcp-e2e test-mcp test-mcp-vscode test-help
+.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-mcp build-all-platforms cross-compile-mcp build-all-platforms-mcp start-service stop-service start-sidecar stop-sidecar lint test test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet update-deps generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components fvt-report docker-image-local docker-mcp-version test-mcp-build-all test-mcp-binary-info test-mcp-binary-naming test-mcp-version test-mcp-no-runtime-deps test-mcp-container-build test-mcp-container-http test-mcp-checksums test-mcp-formula-syntax test-mcp-native-smoke test-mcp-brew-install test-mcp-brew-test test-mcp-brew-uninstall test-mcp-cross-platform test-mcp-e2e test-mcp test-mcp-vscode test-help clean-mcp-wheels build-mcp-wheel build-all-mcp-wheels
 
 GOPATH := $(shell go env GOPATH)
 GOBIN := $(shell go env GOPATH)/bin
@@ -304,13 +304,12 @@ cross-compile-mcp: ## Build MCP for specific platform: make cross-compile-mcp CR
 	GOOS=$(CROSS_GOOS) GOARCH=$(CROSS_GOARCH) CGO_ENABLED=0 go build -o $(MCP_CROSS_OUTPUT) -ldflags="-s -w ${LDFLAGS_X}" $(MCP_CMD_PATH)
 	@echo "Built: $(MCP_CROSS_OUTPUT)"
 
+build-mcp-platform-%:
+	@$(MAKE) cross-compile-mcp CROSS_GOOS=$(word 1,$(subst -, ,$*)) CROSS_GOARCH=$(word 2,$(subst -, ,$*))
+
 .PHONY: build-all-platforms-mcp
-build-all-platforms-mcp: ## Build MCP for all supported platforms
-	@$(MAKE) cross-compile-mcp CROSS_GOOS=linux CROSS_GOARCH=amd64
-	@$(MAKE) cross-compile-mcp CROSS_GOOS=linux CROSS_GOARCH=arm64
-	@$(MAKE) cross-compile-mcp CROSS_GOOS=darwin CROSS_GOARCH=amd64
-	@$(MAKE) cross-compile-mcp CROSS_GOOS=darwin CROSS_GOARCH=arm64
-	@$(MAKE) cross-compile-mcp CROSS_GOOS=windows CROSS_GOARCH=amd64
+build-all-platforms-mcp: ## Build MCP for all supported platforms (parallel: make -j5 build-all-platforms-mcp)
+	@$(MAKE) -j5 $(addprefix build-mcp-platform-,$(SUPPORTED_PLATFORMS))
 
 # Python virtual environment - expects uv venv
 VENV_DIR = .venv
@@ -374,6 +373,45 @@ build-wheel-%:
 .PHONY: build-all-wheels
 build-all-wheels: clean-wheels ## Build all Python wheels (parallel: make -j5 build-all-wheels)
 	@$(MAKE) -j5 $(addprefix build-wheel-,$(SUPPORTED_PLATFORMS))
+
+# MCP Python wheel building - platform derived from CROSS_OUTPUT_SUFFIX via SUPPORTED_PLATFORMS table above
+MCP_WHEEL_BUILD_DIR = python-mcp/build-$(CROSS_GOOS)-$(CROSS_GOARCH)
+MCP_WHEEL_BINARY_NAME = evalhub-mcp$(if $(filter windows,$(CROSS_GOOS)),.exe,)
+
+.PHONY: clean-mcp-wheels
+clean-mcp-wheels: ## Clean MCP Python wheel build artifacts
+	@echo "Cleaning MCP wheel build artifacts..."
+	@rm -rf python-mcp/dist/
+	@rm -rf python-mcp/build-*/
+	@rm -rf python-mcp/*.egg-info
+	@rm -f python-mcp/VERSION
+
+.PHONY: build-mcp-wheel
+build-mcp-wheel: ## Build MCP Python wheel: make build-mcp-wheel WHEEL_PLATFORM=manylinux_2_17_x86_64 CROSS_GOOS=linux CROSS_GOARCH=amd64
+	@rm -rf $(MCP_WHEEL_BUILD_DIR)
+	@mkdir -p $(MCP_WHEEL_BUILD_DIR)/binaries $(MCP_WHEEL_BUILD_DIR)/shims python-mcp/dist
+	@cp python-mcp/pyproject.toml python-mcp/setup.py python-mcp/README.md $(MCP_WHEEL_BUILD_DIR)/
+	@cp python-mcp/shims/* $(MCP_WHEEL_BUILD_DIR)/shims/
+	@cp VERSION $(MCP_WHEEL_BUILD_DIR)/VERSION
+	@if [ -n "$(DEV_SUFFIX)" ]; then \
+		BASE=$$(tr -d '\n' < $(MCP_WHEEL_BUILD_DIR)/VERSION); \
+		echo "$${BASE}.$(DEV_SUFFIX)" > $(MCP_WHEEL_BUILD_DIR)/VERSION; \
+		echo "Python package version: $${BASE}.$(DEV_SUFFIX)"; \
+	fi
+	@test -f $(MCP_CROSS_OUTPUT) || $(MAKE) cross-compile-mcp
+	@echo "Staging binary $(MCP_CROSS_OUTPUT) as $(MCP_WHEEL_BINARY_NAME)"
+	@cp $(MCP_CROSS_OUTPUT) $(MCP_WHEEL_BUILD_DIR)/binaries/$(MCP_WHEEL_BINARY_NAME)
+	@chmod +x $(MCP_WHEEL_BUILD_DIR)/binaries/$(MCP_WHEEL_BINARY_NAME)
+	@echo "Building MCP wheel for $(WHEEL_PLATFORM)..."
+	WHEEL_PLATFORM=$(WHEEL_PLATFORM) uv build --wheel $(MCP_WHEEL_BUILD_DIR) --out-dir python-mcp/dist
+	@rm -rf $(MCP_WHEEL_BUILD_DIR)
+
+build-mcp-wheel-%:
+	@$(MAKE) build-mcp-wheel WHEEL_PLATFORM=$(WHEEL_PLATFORM_$*) CROSS_GOOS=$(word 1,$(subst -, ,$*)) CROSS_GOARCH=$(word 2,$(subst -, ,$*))
+
+.PHONY: build-all-mcp-wheels
+build-all-mcp-wheels: clean-mcp-wheels ## Build all MCP Python wheels (parallel: make -j5 build-all-mcp-wheels)
+	@$(MAKE) -j5 $(addprefix build-mcp-wheel-,$(SUPPORTED_PLATFORMS))
 
 .PHONY: cls
 cls:

--- a/python-mcp/.gitignore
+++ b/python-mcp/.gitignore
@@ -1,0 +1,44 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+build-*/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+env/
+ENV/
+.venv
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# Version file (copied from repo root at build time)
+VERSION

--- a/python-mcp/README.md
+++ b/python-mcp/README.md
@@ -1,6 +1,6 @@
-# evalhub-mcp
+# eval-hub-mcp
 
-This package distributes the compiled Go evalhub-mcp server binary for multiple
+This package distributes the compiled Go eval-hub-mcp server binary for multiple
 platforms. It installs the binary directly into your `bin/` directory (`Scripts/` on Windows) with no
 Python wrapper — no argument rewriting, no subprocess overhead, no Python
 runtime required at execution time.
@@ -8,7 +8,7 @@ runtime required at execution time.
 ## Installation
 
 ```bash
-pip install evalhub-mcp
+pip install eval-hub-mcp
 ```
 
 ## Usage
@@ -32,7 +32,9 @@ evalhub-mcp --version
 
 ## For eval-hub-sdk Users
 
-If you're using [`eval-hub-sdk`](https://github.com/eval-hub/eval-hub-sdk), you can install the MCP server binary as an extra:
+> **Note:** `eval-hub-sdk[mcp]` currently installs a Python FastMCP-based server. This will be replaced with `eval-hub-mcp` (the Go binary distributed by this package) in a future release.
+
+If you're using [`eval-hub-sdk`](https://github.com/eval-hub/eval-hub-sdk), you can install the MCP server as an extra:
 
 ```bash
 pip install eval-hub-sdk[mcp]

--- a/python-mcp/README.md
+++ b/python-mcp/README.md
@@ -1,0 +1,45 @@
+# evalhub-mcp
+
+This package distributes the compiled Go evalhub-mcp server binary for multiple
+platforms. It installs the binary directly into your `bin/` directory (`Scripts/` on Windows) with no
+Python wrapper — no argument rewriting, no subprocess overhead, no Python
+runtime required at execution time.
+
+## Installation
+
+```bash
+pip install evalhub-mcp
+```
+
+## Usage
+
+```bash
+# Run in stdio mode (default, for IDE integration)
+evalhub-mcp
+
+# Run in HTTP mode
+evalhub-mcp --transport http --port 3001
+
+# Show version
+evalhub-mcp --version
+```
+
+## Supported Platforms
+
+- Linux: x86_64, arm64
+- macOS: x86_64 (Intel), arm64 (Apple Silicon)
+- Windows: x86_64
+
+## For eval-hub-sdk Users
+
+If you're using [`eval-hub-sdk`](https://github.com/eval-hub/eval-hub-sdk), you can install the MCP server binary as an extra:
+
+```bash
+pip install eval-hub-sdk[mcp]
+```
+
+For more information, see the [eval-hub-sdk repository](https://github.com/eval-hub/eval-hub-sdk).
+
+## License
+
+Apache-2.0

--- a/python-mcp/pyproject.toml
+++ b/python-mcp/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eval-hub-mcp"
+dynamic = ["version"]
+description = "MCP server binary for eval-hub"
+authors = [
+    {name = "Rui Vieira", email = "rui@redhat.com"},
+]
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["eval-hub", "mcp", "binary", "model-context-protocol"]
+
+[project.urls]
+Homepage = "https://github.com/eval-hub/eval-hub"
+Repository = "https://github.com/eval-hub/eval-hub"
+"Bug Tracker" = "https://github.com/eval-hub/eval-hub/issues"
+
+[tool.setuptools.dynamic]
+version = {file = "VERSION"}
+
+[tool.setuptools.packages]
+find = {include = []}

--- a/python-mcp/setup.py
+++ b/python-mcp/setup.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+
+from setuptools import setup
+from wheel.bdist_wheel import bdist_wheel
+
+
+class PlatformSpecificWheel(bdist_wheel):
+    """Force wheel to be platform-specific.
+
+    Supports platform override via WHEEL_PLATFORM environment variable
+    for cross-platform wheel building in CI.
+    """
+
+    def finalize_options(self):
+        bdist_wheel.finalize_options(self)
+        self.root_is_pure = False
+
+    def get_tag(self):
+        python, abi, plat = bdist_wheel.get_tag(self)
+        platform_override = os.environ.get("WHEEL_PLATFORM")
+        if platform_override:
+            plat = platform_override
+        python, abi = "py3", "none"
+        return python, abi, plat
+
+
+def _find_files(subdir):
+    d = Path(__file__).parent / subdir
+    if not d.exists():
+        return []
+    return [os.path.join(subdir, f.name) for f in d.iterdir() if f.name != ".gitkeep"]
+
+
+wheel_platform = os.environ.get("WHEEL_PLATFORM", "")
+bin_dir = "Scripts" if "win" in wheel_platform else "bin"
+
+setup(
+    cmdclass={"bdist_wheel": PlatformSpecificWheel},
+    data_files=[(bin_dir, _find_files("binaries") + _find_files("shims"))],
+)

--- a/python-mcp/shims/eval-hub-mcp
+++ b/python-mcp/shims/eval-hub-mcp
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(dirname "$0")/evalhub-mcp" "$@"

--- a/python-mcp/shims/eval-hub-mcp.cmd
+++ b/python-mcp/shims/eval-hub-mcp.cmd
@@ -1,0 +1,2 @@
+@echo off
+"%~dp0evalhub-mcp.exe" %*


### PR DESCRIPTION

## What and why
Changes:- 
- Add python-mcp/ package directory with pyproject.toml, setup.py, shims, and README for distributing the evalhub-mcp Go binary as a Python wheel (eval-hub-mcp on PyPI).
- Add Makefile targets: build-mcp-wheel, build-all-mcp-wheels, clean-mcp-wheels, and parallelize build-all-platforms-mcp with -j5.
- Add ci-python-mcp.yml for PR validation and publish-python-mcp.yml for multi-platform wheel build, validation, and PyPI/TestPyPI publishing.


Closes # Part of  https://redhat.atlassian.net/browse/RHOAIENG-66291

Assisted-by: Claude

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

<img width="1091" height="746" alt="Screenshot 2026-06-10 at 11 09 16 AM" src="https://github.com/user-attachments/assets/11a50185-bf14-4736-8f47-a146fd68f519" />
<img width="913" height="72" alt="Screenshot 2026-06-10 at 12 01 11 PM" src="https://github.com/user-attachments/assets/d8e5b037-7d60-4927-aa06-12a5c5c9fa64" />
<img width="1388" height="666" alt="Screenshot 2026-06-10 at 12 00 25 PM" src="https://github.com/user-attachments/assets/38a8321a-d6e6-4d62-82fc-9ed6a090ddf3" />
<img width="1389" height="862" alt="Screenshot 2026-06-10 at 11 58 31 AM" src="https://github.com/user-attachments/assets/48fccae6-5f51-48ed-a910-35ab9c0d1e0d" />


## Breaking changes
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Python wheel packages now available for the MCP server across multiple supported platforms.

* **Documentation**
  * Added comprehensive documentation for the Python-distributed MCP package.

* **Chores**
  * Configured automated build and distribution pipelines for MCP package creation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->