### PR TITLE
test(mlflow): add a unit tests for mlflow checks

### DIFF
--- a/internal/eval_hub/mlflow/mlflow_test.go
+++ b/internal/eval_hub/mlflow/mlflow_test.go
@@ -3,6 +3,7 @@ package mlflow
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -313,4 +314,47 @@ func assertServiceErrorCode(t *testing.T, err error, want *messages.MessageCode)
 	if se.MessageCode() != want {
 		t.Fatalf("message code = %v, want %v", se.MessageCode(), want)
 	}
+}
+
+func TestGetOrCreateExperimentIDOnServer(t *testing.T) {
+	mlflowURL := os.Getenv("MLFLOW_TRACKING_URI")
+	if mlflowURL == "" {
+		t.Skip("MLFLOW_TRACKING_URI is not set")
+	}
+
+	client := mlflowclient.NewClient(mlflowURL).WithContext(t.Context()).WithLogger(testLogger())
+
+	enabledWorkspaces := false
+
+	t.Run("probe workspaces", func(t *testing.T) {
+		workspacesEnabled, err := client.WithContext(t.Context()).ProbeWorkspacesEnabled()
+		if err != nil {
+			t.Logf("Could not probe MLflow workspace support; workspace headers will not be sent: %s", err.Error())
+			workspacesEnabled = false
+		}
+		client = client.WithWorkspacesSupport(workspacesEnabled)
+		t.Logf("MLflow workspace support probed: workspaces enabled %t", workspacesEnabled)
+		enabledWorkspaces = workspacesEnabled
+	})
+
+	t.Run(fmt.Sprintf("create experiment - no workspace (workspaces enabled=%t)", enabledWorkspaces), func(t *testing.T) {
+		jobConfig := &api.EvaluationJobConfig{Experiment: &api.ExperimentConfig{Name: "test-experiment1"}}
+		id, url, err := GetOrCreateExperimentID(client, jobConfig, "job-1")
+		if err != nil || id == "" || url == "" {
+			t.Fatalf("got id=%q url=%q err=%v", id, url, err)
+		}
+		t.Logf("created experiment: id=%q url=%q", id, url)
+	})
+
+	t.Run(fmt.Sprintf("create experiment - with workspace (workspaces enabled=%t)", enabledWorkspaces), func(t *testing.T) {
+		if enabledWorkspaces {
+			client = client.WithWorkspace("test-workspace")
+		}
+		jobConfig := &api.EvaluationJobConfig{Experiment: &api.ExperimentConfig{Name: "test-experiment2"}}
+		id, url, err := GetOrCreateExperimentID(client, jobConfig, "job-1")
+		if err != nil || id == "" || url == "" {
+			t.Fatalf("got id=%q url=%q err=%v", id, url, err)
+		}
+		t.Logf("created experiment: id=%q url=%q", id, url)
+	})
 }

--- a/tests/mlflow/Makefile
+++ b/tests/mlflow/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help clean init-python install-mlflow start-mlflow stop-mlflow cls test-godog-server
+.PHONY: help clean init-python install-mlflow start-mlflow stop-mlflow cls test-godog-server run-unit-test
 
 # Local Python environment (uv). Isolated from the repo-root .venv used for FVT.
 VENV_DIR ?= .venv
@@ -74,3 +74,8 @@ test-godog-server: start-mlflow ; $(info The MLflow server was successfully star
 .PHONY: cls
 cls:
 	printf "\33c\e[3J"
+
+MLFLOW_UNIT_TEST ?= TestGetOrCreateExperimentIDOnServer
+
+run-unit-test:
+	go test -v ../../internal/eval_hub/mlflow -run $(MLFLOW_UNIT_TEST) -count=1


### PR DESCRIPTION
## What and why

- Introduced a new test function to validate the behavior of GetOrCreateExperimentID when creating experiments with and without workspace support.
- Enhanced the Makefile to include a target for running the new unit test.
- Added logging for experiment creation results and workspace probing status.

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for MLflow experiment creation functionality, including environment-based configuration, workspace support detection, and validation of experiment identifiers and URLs across different scenarios.

* **Chores**
  * Added `run-unit-test` make target to streamline execution of MLflow unit tests with configurable test selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->