### PR TITLE
feat(mlflow): add integration tests for MLflow server versions

### DIFF
--- a/internal/eval_hub/mlflow/mlflow_integration_test.go
+++ b/internal/eval_hub/mlflow/mlflow_integration_test.go
@@ -1,0 +1,157 @@
+package mlflow
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/eval-hub/eval-hub/pkg/mlflowclient"
+	"github.com/eval-hub/eval-hub/tests/mlflow/testutil"
+	"github.com/google/uuid"
+)
+
+var (
+	integrationTestLoggerOnce sync.Once
+	integrationTestLogger     *slog.Logger
+)
+
+func testLogger() *slog.Logger {
+	integrationTestLoggerOnce.Do(func() {
+		logPath := filepath.Join(repoBinDir(), "mlflow_tests.log")
+		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			panic(fmt.Sprintf("failed to create MLflow integration test log at %s: %v", logPath, err))
+		}
+		integrationTestLogger = slog.New(slog.NewJSONHandler(logFile, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+	})
+	return integrationTestLogger
+}
+
+func repoBinDir() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		panic(fmt.Sprintf("failed to get working directory: %v", err))
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			binDir := filepath.Join(dir, "bin")
+			if err := os.MkdirAll(binDir, 0o755); err != nil {
+				panic(fmt.Sprintf("failed to create bin directory at %s: %v", binDir, err))
+			}
+			return binDir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			panic("go.mod not found while resolving bin directory for MLflow integration tests")
+		}
+		dir = parent
+	}
+}
+
+// MLflow versions and startup options exercised against a real tracking server.
+var mlflowIntegrationCases = []struct {
+	name             string
+	version          string
+	enableWorkspaces bool
+	port             int
+}{
+	{name: "v3.8.1-default", version: "3.8.1", enableWorkspaces: false, port: 5010},
+	{name: "v3.9.0-default", version: "3.9.0", enableWorkspaces: false, port: 5011},
+	{name: "v3.10.1-default", version: "3.10.1", enableWorkspaces: false, port: 5012},
+	{name: "v3.11.1-default", version: "3.11.1", enableWorkspaces: false, port: 5013},
+	{name: "v3.12.0-default", version: "3.12.0", enableWorkspaces: false, port: 5014},
+	{name: "v3.12.0-workspaces", version: "3.12.0", enableWorkspaces: true, port: 5015},
+	{name: "v3.13.0-default", version: "3.13.0", enableWorkspaces: false, port: 5016},
+	{name: "v3.13.0-workspaces", version: "3.13.0", enableWorkspaces: true, port: 5017},
+}
+
+func TestMLFlowIntegration(t *testing.T) {
+	for _, tc := range mlflowIntegrationCases {
+		logger := testLogger()
+		logger.Info("Starting mlflow test", "name", tc.name, "version", tc.version, "enableWorkspaces", tc.enableWorkspaces, "port", tc.port)
+		t.Run(tc.name, func(t *testing.T) {
+			srv := testutil.StartMLFlowServer(t, testutil.ServerOptions{
+				Version:          tc.version,
+				EnableWorkspaces: tc.enableWorkspaces,
+				Port:             tc.port,
+				Logger:           logger,
+			})
+
+			t.Run("NewMLFlowClient probes server", func(t *testing.T) {
+				cfg := mlflowServiceConfig(t, srv.TrackingURI, func(m *config.MLFlowConfig) {
+					if tc.enableWorkspaces {
+						m.Workspace = "integration-workspace"
+					}
+				})
+				client, err := NewMLFlowClient(cfg, logger)
+				if err != nil {
+					t.Fatalf("NewMLFlowClient() err = %v", err)
+				}
+				if client == nil {
+					t.Fatal("expected non-nil client")
+				}
+				if client.WorkspacesEnabled() != tc.enableWorkspaces {
+					t.Fatalf("WorkspacesEnabled() = %t, want %t", client.WorkspacesEnabled(), tc.enableWorkspaces)
+				}
+				t.Logf("NewMLFlowClient: workspaces_enabled=%t", client.WorkspacesEnabled())
+				// TODO client.GetVersion()
+			})
+
+			t.Run("GetOrCreateExperimentID without workspace", func(t *testing.T) {
+				client := mlflowclient.NewClient(srv.TrackingURI).
+					WithContext(t.Context()).
+					WithLogger(logger)
+				workspacesEnabled, err := client.ProbeWorkspacesEnabled()
+				if err != nil {
+					t.Logf("workspace probe failed: %v", err)
+					workspacesEnabled = false
+				}
+				client = client.WithWorkspacesSupport(workspacesEnabled)
+
+				expName := fmt.Sprintf("test-exp-no-ws-%s-%s", tc.name, uuid.New().String())
+				id, url, err := GetOrCreateExperimentID(client, &api.EvaluationJobConfig{
+					Name:       "eval-job",
+					Experiment: &api.ExperimentConfig{Name: expName},
+				}, "job-1")
+				if err != nil || id == "" || url == "" {
+					t.Fatalf("got id=%q url=%q err=%v", id, url, err)
+				}
+				t.Logf("created experiment: id=%q url=%q", id, url)
+			})
+
+			if tc.enableWorkspaces {
+				t.Run("GetOrCreateExperimentID with workspace", func(t *testing.T) {
+					client := mlflowclient.NewClient(srv.TrackingURI).
+						WithContext(t.Context()).
+						WithLogger(logger)
+					workspacesEnabled, err := client.ProbeWorkspacesEnabled()
+					if err != nil {
+						t.Fatalf("workspace probe failed: %v", err)
+					}
+					if !workspacesEnabled {
+						t.Fatal("expected workspaces to be enabled on server")
+					}
+					client = client.WithWorkspacesSupport(true).WithWorkspace("integration-workspace")
+
+					expName := fmt.Sprintf("test-exp-ws-%s-%s", tc.name, uuid.New().String())
+					id, url, err := GetOrCreateExperimentID(client, &api.EvaluationJobConfig{
+						Name:       "eval-job-ws",
+						Experiment: &api.ExperimentConfig{Name: expName},
+					}, "job-2")
+					if err != nil || id == "" || url == "" {
+						t.Fatalf("got id=%q url=%q err=%v", id, url, err)
+					}
+					t.Logf("created workspace experiment: id=%q url=%q", id, url)
+				})
+			}
+		})
+		logger.Info("Finished mlflow test", "name", tc.name, "version", tc.version, "enableWorkspaces", tc.enableWorkspaces, "port", tc.port)
+	}
+}

--- a/internal/eval_hub/mlflow/mlflow_test.go
+++ b/internal/eval_hub/mlflow/mlflow_test.go
@@ -3,7 +3,6 @@ package mlflow
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -19,7 +18,7 @@ import (
 	"github.com/eval-hub/eval-hub/pkg/mlflowclient"
 )
 
-func testLogger() *slog.Logger {
+func discardTestLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
 
@@ -39,7 +38,7 @@ func mlflowServiceConfig(t *testing.T, trackingURI string, mutate func(*config.M
 
 func TestNewMLFlowClient(t *testing.T) {
 	t.Parallel()
-	logger := testLogger()
+	logger := discardTestLogger()
 
 	t.Run("no tracking URI", func(t *testing.T) {
 		t.Parallel()
@@ -193,7 +192,7 @@ func TestInjectEvaluationJobTags(t *testing.T) {
 
 func TestGetOrCreateExperimentID(t *testing.T) {
 	t.Parallel()
-	logger := testLogger()
+	logger := discardTestLogger()
 
 	t.Run("no experiment name", func(t *testing.T) {
 		t.Parallel()
@@ -314,47 +313,4 @@ func assertServiceErrorCode(t *testing.T, err error, want *messages.MessageCode)
 	if se.MessageCode() != want {
 		t.Fatalf("message code = %v, want %v", se.MessageCode(), want)
 	}
-}
-
-func TestGetOrCreateExperimentIDOnServer(t *testing.T) {
-	mlflowURL := os.Getenv("MLFLOW_TRACKING_URI")
-	if mlflowURL == "" {
-		t.Skip("MLFLOW_TRACKING_URI is not set")
-	}
-
-	client := mlflowclient.NewClient(mlflowURL).WithContext(t.Context()).WithLogger(testLogger())
-
-	enabledWorkspaces := false
-
-	t.Run("probe workspaces", func(t *testing.T) {
-		workspacesEnabled, err := client.WithContext(t.Context()).ProbeWorkspacesEnabled()
-		if err != nil {
-			t.Logf("Could not probe MLflow workspace support; workspace headers will not be sent: %s", err.Error())
-			workspacesEnabled = false
-		}
-		client = client.WithWorkspacesSupport(workspacesEnabled)
-		t.Logf("MLflow workspace support probed: workspaces enabled %t", workspacesEnabled)
-		enabledWorkspaces = workspacesEnabled
-	})
-
-	t.Run(fmt.Sprintf("create experiment - no workspace (workspaces enabled=%t)", enabledWorkspaces), func(t *testing.T) {
-		jobConfig := &api.EvaluationJobConfig{Experiment: &api.ExperimentConfig{Name: "test-experiment1"}}
-		id, url, err := GetOrCreateExperimentID(client, jobConfig, "job-1")
-		if err != nil || id == "" || url == "" {
-			t.Fatalf("got id=%q url=%q err=%v", id, url, err)
-		}
-		t.Logf("created experiment: id=%q url=%q", id, url)
-	})
-
-	t.Run(fmt.Sprintf("create experiment - with workspace (workspaces enabled=%t)", enabledWorkspaces), func(t *testing.T) {
-		if enabledWorkspaces {
-			client = client.WithWorkspace("test-workspace")
-		}
-		jobConfig := &api.EvaluationJobConfig{Experiment: &api.ExperimentConfig{Name: "test-experiment2"}}
-		id, url, err := GetOrCreateExperimentID(client, jobConfig, "job-1")
-		if err != nil || id == "" || url == "" {
-			t.Fatalf("got id=%q url=%q err=%v", id, url, err)
-		}
-		t.Logf("created experiment: id=%q url=%q", id, url)
-	})
 }

--- a/tests/mlflow/Makefile
+++ b/tests/mlflow/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help clean init-python install-mlflow start-mlflow stop-mlflow cls test-godog-server run-unit-test
+.PHONY: help clean init-python install-mlflow start-mlflow stop-mlflow cls test-godog-server test-unit-server
 
 # Local Python environment (uv). Isolated from the repo-root .venv used for FVT.
 VENV_DIR ?= .venv
@@ -75,7 +75,6 @@ test-godog-server: start-mlflow ; $(info The MLflow server was successfully star
 cls:
 	printf "\33c\e[3J"
 
-MLFLOW_UNIT_TEST ?= TestGetOrCreateExperimentIDOnServer
-
-run-unit-test:
-	go test -v ../../internal/eval_hub/mlflow -run $(MLFLOW_UNIT_TEST) -count=1
+test-unit-server: ## Run MLflow integration unit tests (auto-starts server per case, skips if unavailable)
+	@echo "🧪 Running MLflow integration unit tests..."
+	@go test -v ../../internal/eval_hub/mlflow -run TestMLFlowIntegration -count=1

--- a/tests/mlflow/scripts/run_mlflow.sh
+++ b/tests/mlflow/scripts/run_mlflow.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MLFLOW_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${MLFLOW_DIR}"
@@ -13,6 +19,14 @@ VENV_DIR="${VENV_DIR:-.venv}"
 if [ -d "${VENV_DIR}/bin" ]; then
     export PATH="${MLFLOW_DIR}/${VENV_DIR}/bin:${PATH}"
 fi
+
+# for now we wipe out the mlflow db and mlruns directory
+rm -rf bin/mlflow*.db bin/mlruns
+if [ $? -ne 0 ]; then
+    echo -e "${YELLOW}❌ Failed to wipe out mlflow db and mlruns directory${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✅ Wiped out mlflow db and mlruns directory${NC}"
 
 mkdir -p bin
 
@@ -25,12 +39,6 @@ ENABLE_WORKSPACES=""
 if [[ "${MLFLOW_ENABLE_WORKSPACES:-false}" == "true" ]]; then
     ENABLE_WORKSPACES="--enable-workspaces"
 fi
-
-# Colors for output
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
 
 echo -e "${BLUE}🚀 Starting MLflow server...${NC}"
 echo ""
@@ -73,13 +81,17 @@ echo -e "${BLUE}📍 Server will be available at: http://$HOST:$PORT${NC} with o
 echo -e "${YELLOW}💡 Press Ctrl+C to stop the server${NC}"
 echo ""
 
-# Start MLflow server in background
+# Log to file only — do not write server output to stdout. Background processes that
+# keep stdout open will cause "make start-mlflow" (and go test exec) to hang waiting
+# for EOF on the pipe.
+MLFLOW_LOG_FILE="bin/mlflow_${PORT}.log"
 mlflow server \
     --host "$HOST" \
     --port "$PORT" \
     ${ENABLE_WORKSPACES} \
     --backend-store-uri "$BACKEND_URI" \
-    --default-artifact-root "$DEFAULT_ARTIFACT_ROOT" | tee bin/mlflow.log &
+    --default-artifact-root "$DEFAULT_ARTIFACT_ROOT" \
+    >> "${MLFLOW_LOG_FILE}" 2>&1 &
 
 MLFLOW_PID=$!
 
@@ -135,11 +147,10 @@ wait_for_server() {
 # Wait for server to be ready
 RED='\033[0;31m'
 if wait_for_server; then
-    # Server is ready - if running in background mode, exit successfully
-    # The server will continue running in the background
     echo "Server is ready"
     echo "export MLFLOW_TRACKING_URI=http://$HOST:$PORT"
-    # exit 0
+    echo "Server logs: ${MLFLOW_LOG_FILE}"
+    exit 0
 else
     # Server didn't start properly - try to clean up
     ./scripts/stop_mlflow.sh || true

--- a/tests/mlflow/scripts/run_mlflow.sh
+++ b/tests/mlflow/scripts/run_mlflow.sh
@@ -21,8 +21,7 @@ if [ -d "${VENV_DIR}/bin" ]; then
 fi
 
 # for now we wipe out the mlflow db and mlruns directory
-rm -rf bin/mlflow*.db bin/mlruns
-if [ $? -ne 0 ]; then
+if ! rm -rf bin/mlflow*.db bin/mlruns; then
     echo -e "${YELLOW}❌ Failed to wipe out mlflow db and mlruns directory${NC}"
     exit 1
 fi

--- a/tests/mlflow/testutil/server.go
+++ b/tests/mlflow/testutil/server.go
@@ -1,0 +1,223 @@
+// Package testutil starts and stops a local MLflow tracking server for integration tests.
+// It shells out to the Makefile and scripts under tests/mlflow.
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	defaultHost    = "127.0.0.1"
+	defaultPort    = 5000
+	startTimeout   = 5 * time.Minute
+	stopTimeout    = 30 * time.Second
+	healthTimeout  = 30 * time.Second
+	healthInterval = 500 * time.Millisecond
+)
+
+// ServerOptions configures MLflow server startup (passed to tests/mlflow Makefile targets).
+type ServerOptions struct {
+	Version          string
+	EnableWorkspaces bool
+	Host             string
+	Port             int
+	BackendStoreURI  string
+	ArtifactRoot     string
+	Logger           *slog.Logger
+}
+
+// Server represents a running MLflow tracking server started for a test.
+type Server struct {
+	TrackingURI string
+	options     ServerOptions
+	dir         string
+}
+
+// StartMLFlowServer installs (if needed) and starts MLflow via make start-mlflow.
+// On failure it skips the test instead of failing.
+func StartMLFlowServer(t *testing.T, opts ServerOptions) *Server {
+	t.Helper()
+
+	dir, err := findMLFlowDir()
+	if err != nil {
+		opts.Logger.Error("Skipping tests: MLflow test directory not found", "error", err)
+		t.Skipf("MLflow test directory not found: %v", err)
+	}
+
+	opts = opts.withDefaults()
+	trackingURI := fmt.Sprintf("http://%s:%d", opts.Host, opts.Port)
+
+	if err := runMakeTarget(t, dir, startTimeout, "start-mlflow", opts); err != nil {
+		opts.Logger.Error("Skipping tests: failed to start MLflow server", "error", err, "version", opts.Version, "workspaces", opts.EnableWorkspaces, "port", opts.Port)
+		t.Skipf(
+			"failed to start MLflow server (version=%s workspaces=%t port=%d): %v",
+			opts.Version, opts.EnableWorkspaces, opts.Port, err,
+		)
+	}
+
+	if err := waitForHealth(trackingURI, healthTimeout); err != nil {
+		_ = runMakeTarget(t, dir, stopTimeout, "stop-mlflow", opts)
+		opts.Logger.Error("Skipping tests: MLflow server at %s did not become healthy", "error", err, "trackingURI", trackingURI)
+		t.Skipf("MLflow server at %s did not become healthy: %v", trackingURI, err)
+	}
+
+	srv := &Server{
+		TrackingURI: trackingURI,
+		options:     opts,
+		dir:         dir,
+	}
+	t.Cleanup(func() {
+		srv.stop(t)
+	})
+	opts.Logger.Info("MLflow server ready", "trackingURI", trackingURI, "version", opts.Version, "workspaces", opts.EnableWorkspaces)
+	return srv
+}
+
+func (s *Server) stop(t *testing.T) {
+	t.Helper()
+	if err := runMakeTarget(t, s.dir, stopTimeout, "stop-mlflow", s.options); err != nil {
+		s.options.Logger.Error("failed to stop MLflow server", "error", err)
+	}
+}
+
+func (opts ServerOptions) withDefaults() ServerOptions {
+	if opts.Version == "" {
+		opts.Version = "3.13.0"
+	}
+	if opts.Host == "" {
+		opts.Host = defaultHost
+	}
+	if opts.Port == 0 {
+		opts.Port = defaultPort
+	}
+	if opts.BackendStoreURI == "" {
+		opts.BackendStoreURI = fmt.Sprintf("sqlite:///bin/mlflow_test_%d.db", opts.Port)
+	}
+	if opts.ArtifactRoot == "" {
+		opts.ArtifactRoot = fmt.Sprintf("./bin/mlruns_test_%d", opts.Port)
+	}
+	return opts
+}
+
+func (opts ServerOptions) env() []string {
+	opts = opts.withDefaults()
+	enableWorkspaces := "false"
+	if opts.EnableWorkspaces {
+		enableWorkspaces = "true"
+	}
+	return []string{
+		"MLFLOW_VERSION=" + opts.Version,
+		"MLFLOW_HOST=" + opts.Host,
+		"MLFLOW_PORT=" + strconv.Itoa(opts.Port),
+		"MLFLOW_BACKEND_STORE_URI=" + opts.BackendStoreURI,
+		"MLFLOW_DEFAULT_ARTIFACT_ROOT=" + opts.ArtifactRoot,
+		"MLFLOW_ENABLE_WORKSPACES=" + enableWorkspaces,
+		"MLFLOW_TRACKING_URI=" + fmt.Sprintf("http://%s:%d", opts.Host, opts.Port),
+	}
+}
+
+func findMLFlowDir() (string, error) {
+	return findDir(filepath.Join("tests", "mlflow"), ".", "..", "../..", "../../..", "../../../..")
+}
+
+func findDir(dirName string, dirs ...string) (string, error) {
+	var tried []string
+	for _, dir := range dirs {
+		name, err := filepath.Abs(filepath.Join(dir, dirName))
+		if err != nil {
+			return "", fmt.Errorf("resolve path for %s: %w", filepath.Join(dir, dirName), err)
+		}
+		tried = append(tried, name)
+		if info, err := os.Stat(name); err == nil && info.IsDir() {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("directory %s not found (tried %v)", dirName, tried)
+}
+
+func runMakeTarget(t *testing.T, dir string, timeout time.Duration, target string, opts ServerOptions) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	logPath, err := makeOutputLogPath(dir, opts)
+	if err != nil {
+		return fmt.Errorf("resolve make output log path: %w", err)
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open make output log %s: %w", logPath, err)
+	}
+	defer logFile.Close()
+
+	if _, err := fmt.Fprintf(logFile, "\n--- make %s (%s) at %s ---\n", target, opts.Version, time.Now().Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("write make log header: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "make", target)
+	cmd.Dir = dir
+	if os.Getenv("MLFLOW_SHOW_LOGS") == "true" {
+		cmd.Stdout = io.MultiWriter(logFile, os.Stdout)
+		cmd.Stderr = io.MultiWriter(logFile, os.Stderr)
+	} else {
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+	}
+	cmd.Env = append(os.Environ(), opts.env()...)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("make %s in %s (log: %s): %w", target, dir, logPath, err)
+	}
+	return nil
+}
+
+func makeOutputLogPath(mlflowDir string, opts ServerOptions) (string, error) {
+	opts = opts.withDefaults()
+	binDir, err := repoBinDirFromMLFlowDir(mlflowDir)
+	if err != nil {
+		return "", err
+	}
+	name := "mlflow_" + strings.ReplaceAll(opts.Version, ".", "_")
+	if opts.EnableWorkspaces {
+		name += "_workspaces"
+	}
+	return filepath.Join(binDir, name+".log"), nil
+}
+
+func repoBinDirFromMLFlowDir(mlflowDir string) (string, error) {
+	repoRoot := filepath.Clean(filepath.Join(mlflowDir, "..", ".."))
+	binDir := filepath.Join(repoRoot, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return "", fmt.Errorf("create bin directory at %s: %w", binDir, err)
+	}
+	return binDir, nil
+}
+
+func waitForHealth(trackingURI string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	healthURL := trackingURI + "/health"
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(healthURL)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(healthInterval)
+	}
+	return fmt.Errorf("timed out after %s waiting for %s", timeout, healthURL)
+}

--- a/tests/mlflow/testutil/server.go
+++ b/tests/mlflow/testutil/server.go
@@ -60,7 +60,7 @@ func StartMLFlowServer(t *testing.T, opts ServerOptions) *Server {
 
 	if err := runMakeTarget(t, dir, startTimeout, "start-mlflow", opts); err != nil {
 		opts.Logger.Error("Skipping tests: failed to start MLflow server", "error", err, "version", opts.Version, "workspaces", opts.EnableWorkspaces, "port", opts.Port)
-		t.Skipf(
+		t.Fatalf(
 			"failed to start MLflow server (version=%s workspaces=%t port=%d): %v",
 			opts.Version, opts.EnableWorkspaces, opts.Port, err,
 		)
@@ -69,7 +69,7 @@ func StartMLFlowServer(t *testing.T, opts ServerOptions) *Server {
 	if err := waitForHealth(trackingURI, healthTimeout); err != nil {
 		_ = runMakeTarget(t, dir, stopTimeout, "stop-mlflow", opts)
 		opts.Logger.Error("Skipping tests: MLflow server at %s did not become healthy", "error", err, "trackingURI", trackingURI)
-		t.Skipf("MLflow server at %s did not become healthy: %v", trackingURI, err)
+		t.Fatalf("MLflow server at %s did not become healthy: %v", trackingURI, err)
 	}
 
 	srv := &Server{


### PR DESCRIPTION
## What and why

- Introduced a new integration test file to validate interactions with the MLflow tracking server, covering various MLflow versions and workspace configurations.
- Enhanced the test setup to include logging and dynamic server startup for each test case.
- Updated the Makefile to facilitate running the new integration tests.

Assisted-by: Cursor

Note that you can run just this test as shown below:

```shell
cd tests/mlflow
make test-unit-server
```

Note that the tests will be skipped if `uv` is not installed.

A typical run will look like this:

```shell
% make test-unit-server
🧪 Running MLflow integration unit tests...
=== RUN   TestMLFlowIntegration
=== RUN   TestMLFlowIntegration/v3.8.1-default
=== RUN   TestMLFlowIntegration/v3.8.1-default/NewMLFlowClient_probes_server
    mlflow_integration_test.go:103: NewMLFlowClient: workspaces_enabled=false
=== RUN   TestMLFlowIntegration/v3.8.1-default/GetOrCreateExperimentID_without_workspace
    mlflow_integration_test.go:126: created experiment: id="1" url="http://127.0.0.1:5010/api/2.0/mlflow/experiments"
=== RUN   TestMLFlowIntegration/v3.9.0-default
=== RUN   TestMLFlowIntegration/v3.9.0-default/NewMLFlowClient_probes_server
    mlflow_integration_test.go:103: NewMLFlowClient: workspaces_enabled=false
=== RUN   TestMLFlowIntegration/v3.9.0-default/GetOrCreateExperimentID_without_workspace
    mlflow_integration_test.go:126: created experiment: id="1" url="http://127.0.0.1:5011/api/2.0/mlflow/experiments"
=== RUN   TestMLFlowIntegration/v3.10.1-default
=== RUN   TestMLFlowIntegration/v3.10.1-default/NewMLFlowClient_probes_server
    mlflow_integration_test.go:103: NewMLFlowClient: workspaces_enabled=false
=== RUN   TestMLFlowIntegration/v3.10.1-default/GetOrCreateExperimentID_without_workspace
    mlflow_integration_test.go:126: created experiment: id="1" url="http://127.0.0.1:5012/api/2.0/mlflow/experiments"
=== RUN   TestMLFlowIntegration/v3.11.1-default
=== RUN   TestMLFlowIntegration/v3.11.1-default/NewMLFlowClient_probes_server
    mlflow_integration_test.go:103: NewMLFlowClient: workspaces_enabled=false
=== RUN   TestMLFlowIntegration/v3.11.1-default/GetOrCreateExperimentID_without_workspace
    mlflow_integration_test.go:126: created experiment: id="1" url="http://127.0.0.1:5013/api/2.0/mlflow/experiments"
=== RUN   TestMLFlowIntegration/v3.12.0-default
=== RUN   TestMLFlowIntegration/v3.12.0-default/NewMLFlowClient_probes_server
    mlflow_integration_test.go:103: NewMLFlowClient: workspaces_enabled=false
=== RUN   TestMLFlowIntegration/v3.12.0-default/GetOrCreateExperimentID_without_workspace
    mlflow_integration_test.go:126: created experiment: id="1" url="http://127.0.0.1:5014/api/2.0/mlflow/experiments"
=== RUN   TestMLFlowIntegration/v3.12.0-workspaces
=== RUN   TestMLFlowIntegration/v3.12.0-workspaces/NewMLFlowClient_probes_server
    mlflow_integration_test.go:103: NewMLFlowClient: workspaces_enabled=true
=== RUN   TestMLFlowIntegration/v3.12.0-workspaces/GetOrCreateExperimentID_without_workspace
    mlflow_integration_test.go:126: created experiment: id="1" url="http://127.0.0.1:5015/api/2.0/mlflow/experiments"
=== RUN   TestMLFlowIntegration/v3.12.0-workspaces/GetOrCreateExperimentID_with_workspace
    mlflow_integration_test.go:151: created workspace experiment: id="2" url="http://127.0.0.1:5015/api/2.0/mlflow/experiments"
=== RUN   TestMLFlowIntegration/v3.13.0-default
=== RUN   TestMLFlowIntegration/v3.13.0-default/NewMLFlowClient_probes_server
    mlflow_integration_test.go:103: NewMLFlowClient: workspaces_enabled=false
=== RUN   TestMLFlowIntegration/v3.13.0-default/GetOrCreateExperimentID_without_workspace
    mlflow_integration_test.go:126: created experiment: id="1" url="http://127.0.0.1:5016/api/2.0/mlflow/experiments"
=== RUN   TestMLFlowIntegration/v3.13.0-workspaces
=== RUN   TestMLFlowIntegration/v3.13.0-workspaces/NewMLFlowClient_probes_server
    mlflow_integration_test.go:103: NewMLFlowClient: workspaces_enabled=true
=== RUN   TestMLFlowIntegration/v3.13.0-workspaces/GetOrCreateExperimentID_without_workspace
    mlflow_integration_test.go:126: created experiment: id="1" url="http://127.0.0.1:5017/api/2.0/mlflow/experiments"
=== RUN   TestMLFlowIntegration/v3.13.0-workspaces/GetOrCreateExperimentID_with_workspace
    mlflow_integration_test.go:151: created workspace experiment: id="2" url="http://127.0.0.1:5017/api/2.0/mlflow/experiments"
--- PASS: TestMLFlowIntegration (60.47s)
    --- PASS: TestMLFlowIntegration/v3.8.1-default (5.84s)
        --- PASS: TestMLFlowIntegration/v3.8.1-default/NewMLFlowClient_probes_server (0.00s)
        --- PASS: TestMLFlowIntegration/v3.8.1-default/GetOrCreateExperimentID_without_workspace (0.19s)
    --- PASS: TestMLFlowIntegration/v3.9.0-default (7.11s)
        --- PASS: TestMLFlowIntegration/v3.9.0-default/NewMLFlowClient_probes_server (0.00s)
        --- PASS: TestMLFlowIntegration/v3.9.0-default/GetOrCreateExperimentID_without_workspace (0.03s)
    --- PASS: TestMLFlowIntegration/v3.10.1-default (7.00s)
        --- PASS: TestMLFlowIntegration/v3.10.1-default/NewMLFlowClient_probes_server (0.07s)
        --- PASS: TestMLFlowIntegration/v3.10.1-default/GetOrCreateExperimentID_without_workspace (0.01s)
    --- PASS: TestMLFlowIntegration/v3.11.1-default (7.75s)
        --- PASS: TestMLFlowIntegration/v3.11.1-default/NewMLFlowClient_probes_server (0.07s)
        --- PASS: TestMLFlowIntegration/v3.11.1-default/GetOrCreateExperimentID_without_workspace (0.01s)
    --- PASS: TestMLFlowIntegration/v3.12.0-default (8.80s)
        --- PASS: TestMLFlowIntegration/v3.12.0-default/NewMLFlowClient_probes_server (0.04s)
        --- PASS: TestMLFlowIntegration/v3.12.0-default/GetOrCreateExperimentID_without_workspace (0.01s)
    --- PASS: TestMLFlowIntegration/v3.12.0-workspaces (6.53s)
        --- PASS: TestMLFlowIntegration/v3.12.0-workspaces/NewMLFlowClient_probes_server (0.03s)
        --- PASS: TestMLFlowIntegration/v3.12.0-workspaces/GetOrCreateExperimentID_without_workspace (0.04s)
        --- PASS: TestMLFlowIntegration/v3.12.0-workspaces/GetOrCreateExperimentID_with_workspace (0.01s)
    --- PASS: TestMLFlowIntegration/v3.13.0-default (9.46s)
        --- PASS: TestMLFlowIntegration/v3.13.0-default/NewMLFlowClient_probes_server (0.04s)
        --- PASS: TestMLFlowIntegration/v3.13.0-default/GetOrCreateExperimentID_without_workspace (0.01s)
    --- PASS: TestMLFlowIntegration/v3.13.0-workspaces (7.98s)
        --- PASS: TestMLFlowIntegration/v3.13.0-workspaces/NewMLFlowClient_probes_server (0.04s)
        --- PASS: TestMLFlowIntegration/v3.13.0-workspaces/GetOrCreateExperimentID_without_workspace (0.01s)
        --- PASS: TestMLFlowIntegration/v3.13.0-workspaces/GetOrCreateExperimentID_with_workspace (0.01s)
PASS
ok  	github.com/eval-hub/eval-hub/internal/eval_hub/mlflow	60.860s
```

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced MLflow integration testing with support for multiple server versions and workspace configurations
  * Improved test server management capabilities with automatic startup and shutdown for better test isolation
  * Better server state isolation through explicit cleanup of previous state between consecutive test runs
  * Refined test logging and debugging output for improved visibility during test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->