### PR TITLE
feat: sidecar credential injection for model auth

### DIFF
--- a/internal/eval_hub/config/sidecar_config.go
+++ b/internal/eval_hub/config/sidecar_config.go
@@ -11,7 +11,20 @@ type SidecarConfig struct {
 	EvalHub          *EvalHubClientConfig    `mapstructure:"eval_hub" json:"eval_hub,omitempty"`
 	MLFlow           *SidecarMLFlowConfig    `mapstructure:"mlflow,omitempty" json:"mlflow,omitempty"`
 	OCI              *SidecarOCIConfig       `mapstructure:"oci,omitempty" json:"oci,omitempty"`
+	Model            *SidecarModelConfig     `mapstructure:"model,omitempty" json:"model,omitempty"`
 	SidecarContainer *SidecarContainerConfig `mapstructure:"sidecar_container,omitempty" json:"sidecar_container,omitempty"`
+}
+
+// SidecarModelConfig holds the model credential-injection proxy settings written into
+// sidecar_config.json. The sidecar reads this at startup to configure the model reverse
+// proxy: URL is the model endpoint; AuthSecretMountPath is where the sidecar mounts the
+// model credential secret. The adapter container only sees the ephemeral ref secret
+// with placeholder values like "api-key:ref".
+type SidecarModelConfig struct {
+	URL                 string        `mapstructure:"url,omitempty" json:"url,omitempty"`
+	AuthSecretMountPath string        `mapstructure:"auth_secret_mount_path,omitempty" json:"auth_secret_mount_path,omitempty"`
+	HTTPTimeout         time.Duration `mapstructure:"http_timeout,omitempty" json:"http_timeout,omitempty"`
+	InsecureSkipVerify  bool          `mapstructure:"insecure_skip_verify,omitempty" json:"insecure_skip_verify,omitempty"`
 }
 
 // SidecarOCIConfig holds optional TLS/timeout overrides for the OCI registry HTTP client.

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -51,8 +51,9 @@ const (
 	ociCredentialsMountPath           = "/etc/evalhub/.docker/config.json"
 	ociCredentialsSubPath             = ".dockerconfigjson"
 	envOCIAuthConfigPathName          = "OCI_AUTH_CONFIG_PATH"
-	modelAuthVolumeName               = "model-auth"
+	modelAuthVolumeName               = "model-auth" // real credentials secret; mounted in sidecar (injection) or adapter (direct)
 	modelAuthMountPath                = "/var/run/secrets/model"
+	modelInternalAuthVolumeName       = "model-auth-internal" // internalModelRef projected volume; mounted in adapter during credential injection
 	testDataSecretVolumeName          = "test-data-secret"
 	testDataSecretMountPath           = "/var/run/secrets/test-data"
 	serviceCABundleFile               = "service-ca.crt"
@@ -379,8 +380,44 @@ func buildRuntimeContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 		})
 	}
 
-	// Add model auth secret when configured.
-	if cfg.modelAuthSecretRef != "" {
+	// Add model auth volumes.
+	// Credential-injection path (modelInternalRefSecretName set): adapter receives a projected
+	// volume (model-auth-internal) combining the internalModelRef secret (synthetic refs) and
+	// selective keys from the model credential secret (hf-token, ca_cert with optional:true so
+	// Kubernetes silently omits absent keys). The sidecar gets the real secret separately.
+	// Direct-mount path (no injection): adapter receives the real secret directly as model-auth.
+	if cfg.modelInternalRefSecretName != "" {
+		optionalTrue := true
+		projectedSources := []corev1.VolumeProjection{
+			{
+				Secret: &corev1.SecretProjection{
+					LocalObjectReference: corev1.LocalObjectReference{Name: cfg.modelInternalRefSecretName},
+				},
+			},
+			{
+				Secret: &corev1.SecretProjection{
+					LocalObjectReference: corev1.LocalObjectReference{Name: cfg.modelAuthSecretRef},
+					Items: []corev1.KeyToPath{
+						{Key: modelHFTokenKey, Path: modelHFTokenKey},
+						{Key: modelCACertKey, Path: modelCACertKey},
+					},
+					Optional: &optionalTrue,
+				},
+			},
+		}
+		volumes = append(volumes, corev1.Volume{
+			Name: modelInternalAuthVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{Sources: projectedSources},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      modelInternalAuthVolumeName,
+			MountPath: modelAuthMountPath,
+			ReadOnly:  true,
+		})
+	} else if cfg.modelAuthSecretRef != "" {
+		// Direct-mount path: no credential injection; mount the real secret directly in the adapter.
 		volumes = append(volumes, corev1.Volume{
 			Name: modelAuthVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -486,6 +523,24 @@ func buildSidecarContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      mlflowTokenVolumeName,
 			MountPath: mlflowTokenMountPath,
+			ReadOnly:  true,
+		})
+	}
+
+	// When credential injection is active, mount the real credentials secret in the sidecar at
+	// modelAuthMountPath. The adapter never sees this volume.
+	if cfg.modelInternalRefSecretName != "" && cfg.modelAuthSecretRef != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name: modelAuthVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: cfg.modelAuthSecretRef,
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      modelAuthVolumeName,
+			MountPath: modelAuthMountPath,
 			ReadOnly:  true,
 		})
 	}

--- a/internal/eval_hub/runtimes/k8s/job_config.go
+++ b/internal/eval_hub/runtimes/k8s/job_config.go
@@ -59,15 +59,17 @@ type jobConfig struct {
 	sidecarBaseURL      string // base URL for adapter/runtime to call sidecar's proxy (config.Sidecar.BaseURL)
 	evalHubInstanceName string
 	// evalHubCRNamespace is the namespace of the EvalHub CR (control plane); used for Job labels.
-	evalHubCRNamespace   string
-	mlflowTrackingURI    string
-	mlflowWorkspace      string
-	ociCredentialsSecret string
-	modelAuthSecretRef   string
-	sidecarResources     corev1.ResourceRequirements
-	testDataS3           s3TestDataConfig
-	testDataInitImage    string
-	sidecarConfig        *config.SidecarConfig
+	evalHubCRNamespace         string
+	mlflowTrackingURI          string
+	mlflowWorkspace            string
+	ociCredentialsSecret       string
+	modelAuthSecretRef         string // user's real credentials secret mounted only in sidecar
+	modelInternalRefSecretName string // ephemeral internalModelRef secret mounted in adapter; empty when credential injection is not active
+	modelTargetURL             string // real model URL forwarded by the sidecar model proxy; cleared when hasCredentialKeys=false
+	sidecarResources           corev1.ResourceRequirements
+	testDataS3                 s3TestDataConfig
+	testDataInitImage          string
+	sidecarConfig              *config.SidecarConfig
 	// queueKind and queueName come from evaluation.Queue when set (API layer normalizes empty kind to kueue).
 	queueKind string
 	queueName string
@@ -163,6 +165,15 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 		modelAuthSecretRef = strings.TrimSpace(evaluation.Model.Auth.SecretRef)
 	}
 
+	// modelInternalRefSecretName is set in createBenchmarkResources after inspectModelSecret
+	// confirms proxy-injectable keys. modelTargetURL starts as the model URL when model auth
+	// is configured; cleared in createBenchmarkResources for passthrough-only secrets.
+	modelInternalRefSecretName := ""
+	modelTargetURL := ""
+	if modelAuthSecretRef != "" {
+		modelTargetURL = strings.TrimSpace(evaluation.Model.URL)
+	}
+
 	sidecarImage, sidecarResources, err := sidecarImageAndResources(serviceConfig)
 	if err != nil {
 		return nil, err
@@ -191,38 +202,42 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 		nodeSelector = resolveNodeSelector(runtime.K8s.GPU)
 	}
 
+	resourceGUID := uuid.NewString()
+
 	out := &jobConfig{
-		jobID:                evaluation.Resource.ID,
-		resourceGUID:         uuid.NewString(),
-		namespace:            namespace,
-		providerID:           provider.Resource.ID,
-		benchmarkID:          benchmarkConfig.ID,
-		benchmarkIndex:       benchmarkIndex,
-		adapterImage:         runtime.K8s.Image,
-		sidecarImage:         sidecarImage,
-		entrypoint:           runtime.K8s.Entrypoint,
-		defaultEnv:           runtime.K8s.Env,
-		cpuRequest:           cpuRequest,
-		memoryRequest:        memoryRequest,
-		cpuLimit:             cpuLimit,
-		memoryLimit:          memoryLimit,
-		gpuResource:          gpuResource,
-		gpuCount:             gpuCount,
-		nodeSelector:         nodeSelector,
-		jobSpec:              *spec,
-		serviceAccountName:   serviceAccountName,
-		serviceCAConfigMap:   serviceCAConfigMap,
-		evalHubInstanceName:  evalHubInstanceName,
-		evalHubCRNamespace:   evalHubCRNamespace,
-		mlflowTrackingURI:    mlflowTrackingURI,
-		mlflowWorkspace:      mlflowWorkspace,
-		ociCredentialsSecret: ociCredentialsSecret,
-		modelAuthSecretRef:   modelAuthSecretRef,
-		sidecarResources:     sidecarResources,
-		sidecarBaseURL:       sidecarBaseURL,
-		evalHubURL:           evalHubURL,
-		queueKind:            queueKind,
-		queueName:            queueName,
+		jobID:                      evaluation.Resource.ID,
+		resourceGUID:               resourceGUID,
+		namespace:                  namespace,
+		providerID:                 provider.Resource.ID,
+		benchmarkID:                benchmarkConfig.ID,
+		benchmarkIndex:             benchmarkIndex,
+		adapterImage:               runtime.K8s.Image,
+		sidecarImage:               sidecarImage,
+		entrypoint:                 runtime.K8s.Entrypoint,
+		defaultEnv:                 runtime.K8s.Env,
+		cpuRequest:                 cpuRequest,
+		memoryRequest:              memoryRequest,
+		cpuLimit:                   cpuLimit,
+		memoryLimit:                memoryLimit,
+		gpuResource:                gpuResource,
+		gpuCount:                   gpuCount,
+		nodeSelector:               nodeSelector,
+		jobSpec:                    *spec,
+		serviceAccountName:         serviceAccountName,
+		serviceCAConfigMap:         serviceCAConfigMap,
+		evalHubInstanceName:        evalHubInstanceName,
+		evalHubCRNamespace:         evalHubCRNamespace,
+		mlflowTrackingURI:          mlflowTrackingURI,
+		mlflowWorkspace:            mlflowWorkspace,
+		ociCredentialsSecret:       ociCredentialsSecret,
+		modelAuthSecretRef:         modelAuthSecretRef,
+		modelInternalRefSecretName: modelInternalRefSecretName,
+		modelTargetURL:             modelTargetURL,
+		sidecarResources:           sidecarResources,
+		sidecarBaseURL:             sidecarBaseURL,
+		evalHubURL:                 evalHubURL,
+		queueKind:                  queueKind,
+		queueName:                  queueName,
 		testDataS3: s3TestDataConfig{
 			bucket:    testDataS3Bucket,
 			key:       testDataS3Key,
@@ -230,12 +245,6 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 		},
 	}
 	applyHardwareProfileResources(out, hardwareProfile)
-
-	sidecarJSON, err := sidecarForJobPod(serviceConfig, out)
-	if err != nil {
-		return nil, fmt.Errorf("sidecar config json: %w", err)
-	}
-	out.sidecarConfig = sidecarJSON
 	return out, nil
 }
 

--- a/internal/eval_hub/runtimes/k8s/k8s_helper.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper.go
@@ -181,6 +181,57 @@ func (h *KubernetesHelper) SetConfigMapOwner(ctx context.Context, namespace, nam
 	return err
 }
 
+// GetSecret returns the Secret with the given name in namespace.
+func (h *KubernetesHelper) GetSecret(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
+	if namespace == "" || name == "" {
+		return nil, fmt.Errorf("namespace and name are required")
+	}
+	return h.clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+// CreateSecret creates a Secret in the given namespace.
+func (h *KubernetesHelper) CreateSecret(ctx context.Context, namespace string, secret *corev1.Secret) (*corev1.Secret, error) {
+	if secret == nil || namespace == "" || secret.Name == "" {
+		return nil, fmt.Errorf("secret, namespace, and name are required")
+	}
+	secret.Namespace = namespace
+	return h.clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+}
+
+// DeleteSecret deletes a Secret in the given namespace.
+func (h *KubernetesHelper) DeleteSecret(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
+	if namespace == "" || name == "" {
+		return fmt.Errorf("namespace and name are required")
+	}
+	return h.clientset.CoreV1().Secrets(namespace).Delete(ctx, name, opts)
+}
+
+// ListSecrets returns Secrets matching the label selector.
+func (h *KubernetesHelper) ListSecrets(ctx context.Context, namespace, labelSelector string) ([]corev1.Secret, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	list, err := h.clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// SetSecretOwner sets a single owner reference on the Secret.
+func (h *KubernetesHelper) SetSecretOwner(ctx context.Context, namespace, name string, owner metav1.OwnerReference) error {
+	if namespace == "" || name == "" {
+		return fmt.Errorf("namespace and name are required")
+	}
+	secret, err := h.clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	secret.OwnerReferences = []metav1.OwnerReference{owner}
+	_, err = h.clientset.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	return err
+}
+
 // CreateConfigMapOptions holds optional metadata for CreateConfigMap.
 type CreateConfigMapOptions struct {
 	Labels      map[string]string

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -110,7 +110,6 @@ func (r *K8sRuntime) DeleteEvaluationJobResources(evaluation *api.EvaluationJobR
 	if err != nil {
 		return err
 	}
-
 	var deleteErr error
 	for _, job := range jobs {
 		r.logger.Info(
@@ -123,8 +122,9 @@ func (r *K8sRuntime) DeleteEvaluationJobResources(evaluation *api.EvaluationJobR
 			deleteErr = errors.Join(deleteErr, err)
 		}
 	}
-	// OwnerReferences should GC ConfigMaps when Jobs are deleted, but we delete explicitly
-	// to avoid orphans if the owner ref was never set or the job delete is delayed.
+	// Delete ConfigMaps explicitly to avoid orphans if the owner ref was never set or the
+	// job delete is delayed. OwnerReferences GC them automatically when the Job is removed,
+	// but explicit deletion is a safe belt-and-suspenders measure.
 	for _, configMap := range configMaps {
 		r.logger.Info(
 			"deleting evaluation runtime configmap",
@@ -133,6 +133,23 @@ func (r *K8sRuntime) DeleteEvaluationJobResources(evaluation *api.EvaluationJobR
 			"namespace", namespace,
 		)
 		if err := r.helper.DeleteConfigMap(r.ctx, namespace, configMap.Name); err != nil && !apierrors.IsNotFound(err) {
+			deleteErr = errors.Join(deleteErr, err)
+		}
+	}
+	// Delete ref secrets explicitly using the same label selector so they are never orphaned
+	// even if the Job's owner-reference GC is delayed or the owner ref was never set.
+	secrets, err := r.helper.ListSecrets(r.ctx, namespace, labelSelector)
+	if err != nil {
+		deleteErr = errors.Join(deleteErr, err)
+	}
+	for _, secret := range secrets {
+		r.logger.Info(
+			"deleting evaluation runtime ref secret",
+			"job_id", evaluation.Resource.ID,
+			"secret_name", secret.Name,
+			"namespace", namespace,
+		)
+		if err := r.helper.DeleteSecret(r.ctx, namespace, secret.Name, deleteOptions); err != nil && !apierrors.IsNotFound(err) {
 			deleteErr = errors.Join(deleteErr, err)
 		}
 	}
@@ -187,6 +204,32 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 		"service_ca_configmap", jobConfig.serviceCAConfigMap,
 		"eval_hub_url", jobConfig.evalHubURL,
 	)
+	// Inspect the model credential secret once to decide the auth path. Proxy-injectable keys
+	// (api-key, *_api-key, *_url) activate credential injection — the adapter receives the
+	// ephemeral internalModelRef secret and the sidecar proxies model calls. Passthrough-only
+	// secrets (hf-token/ca_cert) mount directly in the adapter without a ref secret or model proxy.
+	if jobConfig.modelAuthSecretRef != "" {
+		secretInfo, err := inspectModelSecret(ctx, jobConfig.namespace, jobConfig.modelAuthSecretRef, r.helper)
+		if err != nil {
+			logger.Error("kubernetes model secret inspect error", "benchmark_id", benchmarkID, "error", err)
+			return fmt.Errorf("job %s benchmark %s: model secret inspect: %w", evaluation.Resource.ID, benchmarkID, err)
+		}
+		if secretInfo.hasCredentialKeys {
+			jobConfig.modelInternalRefSecretName = buildK8sName(jobConfig.jobID, jobConfig.resourceGUID, "-model-ref")
+			jobConfig.jobSpec.Model.URL = jobConfig.sidecarBaseURL
+		} else {
+			// passthrough-only (e.g. ca_cert only): clear modelTargetURL so sidecar gets no model proxy config
+			jobConfig.modelTargetURL = ""
+			logger.Info("model credential secret has no proxy-injectable keys; disabling credential injection")
+		}
+	}
+	// Build sidecar config after inspectModelSecret so modelTargetURL reflects the final state.
+	sidecarJSON, err := sidecarForJobPod(r.serviceConfig, jobConfig)
+	if err != nil {
+		return fmt.Errorf("job %s benchmark %s: sidecar config json: %w", evaluation.Resource.ID, benchmarkID, err)
+	}
+	jobConfig.sidecarConfig = sidecarJSON
+
 	configMap, err := buildConfigMap(jobConfig)
 	if err != nil {
 		logger.Error("kubernetes configmap build error", "benchmark_id", benchmarkID, "error", err)
@@ -225,18 +268,39 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 	logger.Info("kubernetes resource", "kind", "ConfigMap", "object", configMap)
 	logger.Info("kubernetes resource", "kind", "Job", "object", job)
 
+	// Create the ephemeral internalModelRef secret before the Job so the Pod can mount it.
+	if jobConfig.modelInternalRefSecretName != "" {
+		_, err := buildInternalModelRefSecret(ctx, jobConfig.namespace, jobConfig.modelInternalRefSecretName, jobConfig.modelAuthSecretRef, jobConfig.sidecarBaseURL, jobLabels(jobConfig), r.helper)
+		if err != nil {
+			logger.Error("kubernetes internalModelRef secret create error", "namespace", jobConfig.namespace, "name", jobConfig.modelInternalRefSecretName, "error", err)
+			return fmt.Errorf("job %s benchmark %s: internalModelRef secret: %w", evaluation.Resource.ID, benchmarkID, err)
+		}
+		logger.Info("kubernetes internalModelRef secret created", "namespace", jobConfig.namespace, "name", jobConfig.modelInternalRefSecretName)
+	}
+
+	cleanupModelRefSecret := func() {
+		if jobConfig.modelInternalRefSecretName == "" {
+			return
+		}
+		if cleanupErr := r.helper.DeleteSecret(ctx, jobConfig.namespace, jobConfig.modelInternalRefSecretName, metav1.DeleteOptions{}); cleanupErr != nil && !apierrors.IsNotFound(cleanupErr) {
+			logger.Error("failed to delete internalModelRef secret after error", "error", cleanupErr)
+		}
+	}
+
 	_, err = r.helper.CreateConfigMap(ctx, configMap.Namespace, configMap.Name, configMap.Data, &CreateConfigMapOptions{
 		Labels:      configMap.Labels,
 		Annotations: configMap.Annotations,
 	})
 	if err != nil {
 		logger.Error("kubernetes configmap create error", "namespace", configMap.Namespace, "name", configMap.Name, "error", err)
+		cleanupModelRefSecret()
 		return fmt.Errorf("job %s benchmark %s: %w", evaluation.Resource.ID, benchmarkID, err)
 	}
 
 	createdJob, err := r.helper.CreateJob(ctx, job)
 	if err != nil {
 		logger.Error("kubernetes job create error", "namespace", job.Namespace, "name", job.Name, "error", err)
+		cleanupModelRefSecret()
 		cleanupErr := r.helper.DeleteConfigMap(ctx, configMap.Namespace, configMap.Name)
 		if cleanupErr != nil && !apierrors.IsNotFound(cleanupErr) {
 			if logger != nil {
@@ -266,6 +330,14 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 			return nil
 		}
 		logger.Error("failed to set configmap owner reference", "namespace", configMap.Namespace, "name", configMap.Name, "error", err)
+	}
+	// Point the internalModelRef secret at the Job so Kubernetes GC deletes it when the Job is removed.
+	// If SetSecretOwner fails, delete the secret immediately to avoid orphaning it.
+	if jobConfig.modelInternalRefSecretName != "" {
+		if err := r.helper.SetSecretOwner(ctx, jobConfig.namespace, jobConfig.modelInternalRefSecretName, ownerRef); err != nil {
+			logger.Error("failed to set internalModelRef secret owner reference; cleaning up to avoid orphan", "namespace", jobConfig.namespace, "name", jobConfig.modelInternalRefSecretName, "error", err)
+			cleanupModelRefSecret()
+		}
 	}
 	return nil
 }

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -328,6 +328,7 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 				logger.Error("failed to delete orphaned job", "namespace", createdJob.Namespace, "name", createdJob.Name, "error", delErr)
 				return delErr
 			}
+			cleanupModelRefSecret()
 			return nil
 		}
 		logger.Error("failed to set configmap owner reference", "namespace", configMap.Namespace, "name", configMap.Name, "error", err)

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -208,11 +208,12 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 	// (api-key, *_api-key, *_url) activate credential injection — the adapter receives the
 	// ephemeral internalModelRef secret and the sidecar proxies model calls. Passthrough-only
 	// secrets (hf-token/ca_cert) mount directly in the adapter without a ref secret or model proxy.
+	var secretInfo modelSecretInfo
 	if jobConfig.modelAuthSecretRef != "" {
-		secretInfo, err := inspectModelSecret(ctx, jobConfig.namespace, jobConfig.modelAuthSecretRef, r.helper)
+		secretInfo, err = inspectModelSecret(ctx, jobConfig.namespace, jobConfig.modelAuthSecretRef, r.helper)
 		if err != nil {
 			logger.Error("kubernetes model secret inspect error", "benchmark_id", benchmarkID, "error", err)
-			return fmt.Errorf("job %s benchmark %s: model secret inspect: %w", evaluation.Resource.ID, benchmarkID, err)
+			return fmt.Errorf("job %s benchmark %s: reading model auth secret: %w", evaluation.Resource.ID, benchmarkID, err)
 		}
 		if secretInfo.hasCredentialKeys {
 			jobConfig.modelInternalRefSecretName = buildK8sName(jobConfig.jobID, jobConfig.resourceGUID, "-model-ref")
@@ -270,7 +271,7 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 
 	// Create the ephemeral internalModelRef secret before the Job so the Pod can mount it.
 	if jobConfig.modelInternalRefSecretName != "" {
-		_, err := buildInternalModelRefSecret(ctx, jobConfig.namespace, jobConfig.modelInternalRefSecretName, jobConfig.modelAuthSecretRef, jobConfig.sidecarBaseURL, jobLabels(jobConfig), r.helper)
+		_, err := buildInternalModelRefSecret(ctx, jobConfig.namespace, jobConfig.modelInternalRefSecretName, secretInfo.data, jobConfig.sidecarBaseURL, jobLabels(jobConfig), r.helper)
 		if err != nil {
 			logger.Error("kubernetes internalModelRef secret create error", "namespace", jobConfig.namespace, "name", jobConfig.modelInternalRefSecretName, "error", err)
 			return fmt.Errorf("job %s benchmark %s: internalModelRef secret: %w", evaluation.Resource.ID, benchmarkID, err)

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -447,22 +447,18 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
 func TestBuildInternalModelRefSecretMultiModel(t *testing.T) {
 	// Multi-model credential secret: *_api-key keys become refs, *_url keys become the sidecar
 	// proxy URL, ca_cert is excluded (projected directly from the real secret into the adapter).
-	const realSecretName = "multi-model-creds"
-	realSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: realSecretName, Namespace: "default"},
-		Data: map[string][]byte{
-			"model-1_api-key": []byte("sk-model1"),
-			"model-1_url":     []byte("https://api.openai.com/v1"),
-			"model-2_api-key": []byte("sk-model2"),
-			"model-2_url":     []byte("https://azure.example.com/v1"),
-			"ca_cert":         []byte("-----BEGIN CERTIFICATE-----"),
-		},
+	data := map[string][]byte{
+		"model-1_api-key": []byte("sk-model1"),
+		"model-1_url":     []byte("https://api.openai.com/v1"),
+		"model-2_api-key": []byte("sk-model2"),
+		"model-2_url":     []byte("https://azure.example.com/v1"),
+		"ca_cert":         []byte("-----BEGIN CERTIFICATE-----"),
 	}
-	clientset := fake.NewClientset(realSecret)
+	clientset := fake.NewClientset()
 	helper := &KubernetesHelper{clientset: clientset}
 
 	const sidecarURL = "http://localhost:8080"
-	secret, err := buildInternalModelRefSecret(context.Background(), "default", "multi-model-ref", realSecretName, sidecarURL, nil, helper)
+	secret, err := buildInternalModelRefSecret(context.Background(), "default", "multi-model-ref", data, sidecarURL, nil, helper)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -1110,6 +1110,128 @@ func TestCreateBenchmarkResourcesReturnsErrorWhenOrphanedJobDeletionFails(t *tes
 	}
 }
 
+func TestDeleteEvaluationJobResourcesDeletesRefSecrets(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	jobID := evaluation.Resource.ID
+	namespace := "default"
+	labelKey := labelJobIDKey
+	labelVal := sanitizeLabelValue(jobID)
+
+	// Pre-create a Job, ConfigMap, and ref Secret all carrying the job-ID label,
+	// as they would exist after a successful createBenchmarkResources call.
+	clientset := fake.NewClientset(
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eval-job-1",
+				Namespace: namespace,
+				Labels:    map[string]string{labelKey: labelVal},
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eval-cm-1",
+				Namespace: namespace,
+				Labels:    map[string]string{labelKey: labelVal},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eval-ref-secret-1",
+				Namespace: namespace,
+				Labels:    map[string]string{labelKey: labelVal},
+			},
+		},
+	)
+
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+		ctx:    context.Background(),
+	}
+
+	err := runtime.DeleteEvaluationJobResources(evaluation)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	secrets, listErr := clientset.CoreV1().Secrets(namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", labelKey, labelVal),
+	})
+	if listErr != nil {
+		t.Fatalf("failed to list secrets: %v", listErr)
+	}
+	if len(secrets.Items) != 0 {
+		t.Fatalf("expected ref secret to be deleted, got %d secret(s)", len(secrets.Items))
+	}
+}
+
+func TestDeleteEvaluationJobResourcesIgnoresMissingRefSecret(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+
+	// No pre-created resources — everything is already gone (e.g. GC already ran).
+	clientset := fake.NewClientset()
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+		ctx:    context.Background(),
+	}
+
+	err := runtime.DeleteEvaluationJobResources(evaluation)
+	if err != nil {
+		t.Fatalf("expected no error when resources already gone, got %v", err)
+	}
+}
+
+// TestCreateBenchmarkResourcesDeletesRefSecretWhenConfigMapDeletedMidCreation verifies that
+// when the ConfigMap disappears between Job creation and owner-ref setup (race with hard_delete),
+// the ephemeral internalModelRef secret is cleaned up together with the orphaned Job.
+func TestCreateBenchmarkResourcesDeletesRefSecretWhenConfigMapDeletedMidCreation(t *testing.T) {
+	providerID := "provider-1"
+	evaluation := sampleEvaluation(providerID)
+	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "model-auth-secret"}
+
+	realSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "model-auth-secret", Namespace: "default"},
+		Data:       map[string][]byte{"api-key": []byte("sk-real-key")},
+	}
+	clientset := fake.NewClientset(realSecret)
+	// Simulate ConfigMap NotFound during SetConfigMapOwner (mid-creation race).
+	clientset.PrependReactor("get", "configmaps", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, action.(k8stesting.GetAction).GetName())
+	})
+
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+		serviceConfig: &config.Config{
+			Service: &config.ServiceConfig{
+				EvalInitImage: "eval-init-image",
+			},
+		},
+	}
+
+	storage := &fakeStorage{providerConfigs: sampleProviders(providerID)}
+	err := runtime.createBenchmarkResources(context.Background(), runtime.logger, evaluation, &evaluation.Benchmarks[0], 0, storage)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Both the orphaned Job and the internalModelRef secret must be gone.
+	jobs := listJobsByJobID(t, clientset, evaluation.Resource.ID)
+	if len(jobs) != 0 {
+		t.Fatalf("expected orphaned job to be deleted, got %d job(s)", len(jobs))
+	}
+	secrets, listErr := clientset.CoreV1().Secrets("default").List(context.Background(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", labelJobIDKey, sanitizeLabelValue(evaluation.Resource.ID)),
+	})
+	if listErr != nil {
+		t.Fatalf("failed to list secrets: %v", listErr)
+	}
+	if len(secrets.Items) != 0 {
+		t.Fatalf("expected internalModelRef secret to be deleted after mid-creation race, got %d secret(s)", len(secrets.Items))
+	}
+}
+
 func sampleProviders(providerID string) map[string]api.ProviderResource {
 	return map[string]api.ProviderResource{
 		providerID: {

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -16,6 +16,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -283,7 +284,21 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
 	evaluation := sampleEvaluation(providerID)
 	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "model-auth-secret"}
 
-	clientset := fake.NewClientset()
+	// Pre-create the real secret so the runtime can read its keys to generate the ephemeral
+	// ref secret. Includes ca_cert and hf-token (both excluded from the ref secret and
+	// projected directly from the real secret).
+	realSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "model-auth-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"api-key":  []byte("sk-real-key"),
+			"hf-token": []byte("hf-real-token"),
+			"ca_cert":  []byte("-----BEGIN CERTIFICATE-----"),
+		},
+	}
+	clientset := fake.NewClientset(realSecret)
 	runtime := &K8sRuntime{
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		helper: &KubernetesHelper{clientset: clientset},
@@ -307,22 +322,54 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
 	job := jobs[0]
 	container := job.Spec.Template.Spec.Containers[0]
 
+	// Adapter container: volume must be model-auth-internal (projected), combining the
+	// internalModelRef secret and selective keys from the real secret (hf-token, ca_cert, optional).
 	var foundVolume bool
+	var adapterRefSecretName string
 	for _, volume := range job.Spec.Template.Spec.Volumes {
-		if volume.Name == modelAuthVolumeName {
+		if volume.Name == modelInternalAuthVolumeName {
 			foundVolume = true
-			if volume.VolumeSource.Secret == nil || volume.VolumeSource.Secret.SecretName != "model-auth-secret" {
-				t.Fatalf("expected model auth secret volume to reference %q", "model-auth-secret")
+			if volume.VolumeSource.Projected == nil {
+				t.Fatalf("expected model-auth-internal volume to be a projected volume, got plain Secret")
+			}
+			sources := volume.VolumeSource.Projected.Sources
+			if len(sources) < 2 {
+				t.Fatalf("expected at least 2 projected sources (internalModelRef secret + real secret passthrough), got %d", len(sources))
+			}
+			// First source: internalModelRef secret (no items filter — all ref/placeholder keys)
+			if sources[0].Secret == nil {
+				t.Fatal("expected first projected source to be the internalModelRef secret")
+			}
+			if sources[0].Secret.LocalObjectReference.Name == "model-auth-secret" {
+				t.Fatal("first projected source must be the ephemeral internalModelRef secret, not the real secret")
+			}
+			adapterRefSecretName = sources[0].Secret.LocalObjectReference.Name
+			// Second source: real secret selective projection (hf-token, ca_cert, optional:true)
+			if sources[1].Secret == nil {
+				t.Fatal("expected second projected source to be the real secret (selective)")
+			}
+			if sources[1].Secret.LocalObjectReference.Name != "model-auth-secret" {
+				t.Fatalf("expected second projected source to be the real secret %q, got %q", "model-auth-secret", sources[1].Secret.LocalObjectReference.Name)
+			}
+			projectedKeys := make(map[string]bool)
+			for _, item := range sources[1].Secret.Items {
+				projectedKeys[item.Key] = true
+			}
+			if !projectedKeys["hf-token"] {
+				t.Fatal("expected hf-token to be projected from the real secret into adapter volume")
+			}
+			if !projectedKeys["ca_cert"] {
+				t.Fatal("expected ca_cert to be projected from the real secret into adapter volume")
 			}
 		}
 	}
 	if !foundVolume {
-		t.Fatalf("expected volume %s to be present", modelAuthVolumeName)
+		t.Fatalf("expected volume %s to be present on adapter", modelInternalAuthVolumeName)
 	}
 
 	var foundMount bool
 	for _, mount := range container.VolumeMounts {
-		if mount.Name == modelAuthVolumeName {
+		if mount.Name == modelInternalAuthVolumeName {
 			foundMount = true
 			if mount.MountPath != modelAuthMountPath {
 				t.Fatalf("expected mount path %q, got %q", modelAuthMountPath, mount.MountPath)
@@ -330,9 +377,58 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
 		}
 	}
 	if !foundMount {
-		t.Fatalf("expected volume mount %s to be present", modelAuthVolumeName)
+		t.Fatalf("expected volume mount %s on adapter container", modelInternalAuthVolumeName)
 	}
 
+	// Ref secret must exist with ref/placeholder keys only — no hf-token, no ca_cert.
+	if adapterRefSecretName == "" {
+		t.Fatal("expected a non-empty ref secret name from the projected volume")
+	}
+	refSecret, err := clientset.CoreV1().Secrets("default").Get(context.Background(), adapterRefSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected ephemeral ref secret %q to exist, got error: %v", adapterRefSecretName, err)
+	}
+	if string(refSecret.Data["api-key"]) != "api-key:ref" {
+		t.Fatalf("expected ref secret api-key value %q, got %q", "api-key:ref", string(refSecret.Data["api-key"]))
+	}
+	if _, ok := refSecret.Data["hf-token"]; ok {
+		t.Fatal("hf-token must not appear in the ref secret; it is projected directly from the real secret")
+	}
+	if _, ok := refSecret.Data["ca_cert"]; ok {
+		t.Fatal("ca_cert must not appear in the ref secret; it is projected directly from the real secret")
+	}
+
+	// Sidecar container: should have the real credentials secret mounted as model-auth at modelAuthMountPath.
+	sidecarContainer := findContainer(job.Spec.Template.Spec.InitContainers, sidecarContainerName)
+	if sidecarContainer == nil {
+		t.Fatal("expected sidecar init container")
+	}
+	var foundRealMount bool
+	for _, mount := range sidecarContainer.VolumeMounts {
+		if mount.Name == modelAuthVolumeName {
+			foundRealMount = true
+			if mount.MountPath != modelAuthMountPath {
+				t.Fatalf("expected sidecar real secret mount path %q, got %q", modelAuthMountPath, mount.MountPath)
+			}
+		}
+	}
+	if !foundRealMount {
+		t.Fatalf("expected sidecar to have %s mount at %s", modelAuthVolumeName, modelAuthMountPath)
+	}
+	var foundRealVolume bool
+	for _, volume := range job.Spec.Template.Spec.Volumes {
+		if volume.Name == modelAuthVolumeName {
+			foundRealVolume = true
+			if volume.VolumeSource.Secret == nil || volume.VolumeSource.Secret.SecretName != "model-auth-secret" {
+				t.Fatalf("expected sidecar real secret volume to reference %q", "model-auth-secret")
+			}
+		}
+	}
+	if !foundRealVolume {
+		t.Fatalf("expected volume %s (real creds) to be present for sidecar", modelAuthVolumeName)
+	}
+
+	// Legacy model auth env vars should be absent.
 	envKeys := make(map[string]struct{}, len(container.Env))
 	for _, env := range container.Env {
 		envKeys[env.Name] = struct{}{}
@@ -346,6 +442,153 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnv(t *testing.T) {
 			t.Fatalf("expected env var %s to be absent", key)
 		}
 	}
+}
+
+func TestBuildInternalModelRefSecretMultiModel(t *testing.T) {
+	// Multi-model credential secret: *_api-key keys become refs, *_url keys become the sidecar
+	// proxy URL, ca_cert is excluded (projected directly from the real secret into the adapter).
+	const realSecretName = "multi-model-creds"
+	realSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: realSecretName, Namespace: "default"},
+		Data: map[string][]byte{
+			"model-1_api-key": []byte("sk-model1"),
+			"model-1_url":     []byte("https://api.openai.com/v1"),
+			"model-2_api-key": []byte("sk-model2"),
+			"model-2_url":     []byte("https://azure.example.com/v1"),
+			"ca_cert":         []byte("-----BEGIN CERTIFICATE-----"),
+		},
+	}
+	clientset := fake.NewClientset(realSecret)
+	helper := &KubernetesHelper{clientset: clientset}
+
+	const sidecarURL = "http://localhost:8080"
+	secret, err := buildInternalModelRefSecret(context.Background(), "default", "multi-model-ref", realSecretName, sidecarURL, nil, helper)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cases := map[string]string{
+		"model-1_api-key": "model-1_api-key:ref",
+		"model-2_api-key": "model-2_api-key:ref",
+		"model-1_url":     sidecarURL,
+		"model-2_url":     sidecarURL,
+	}
+	for k, want := range cases {
+		got := string(secret.Data[k])
+		if got != want {
+			t.Errorf("key %q: want %q, got %q", k, want, got)
+		}
+	}
+	if _, ok := secret.Data["ca_cert"]; ok {
+		t.Error("ca_cert must not appear in the internalModelRef secret")
+	}
+}
+
+func TestInspectModelSecretPassthroughOnly(t *testing.T) {
+	// Passthrough-only secret (ca_cert + unknown key): inspectModelSecret must report
+	// hasCredentialKeys=false so no internalModelRef secret is created and no model proxy starts.
+	realSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls-only-creds", Namespace: "default"},
+		Data: map[string][]byte{
+			"ca_cert":        []byte("-----BEGIN CERTIFICATE-----"),
+			"some-other-key": []byte("value"),
+		},
+	}
+	clientset := fake.NewClientset(realSecret)
+	helper := &KubernetesHelper{clientset: clientset}
+
+	info, err := inspectModelSecret(context.Background(), "default", "tls-only-creds", helper)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.hasCredentialKeys {
+		t.Fatal("expected hasCredentialKeys=false for passthrough-only (ca_cert-only) secret")
+	}
+}
+
+func TestIsModelCredentialKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"api-key", true},
+		{"model-1_api-key", true},
+		{"model-1_url", true},
+		{"hf-token", false},
+		{"ca_cert", false},
+		{"some-other-key", false},
+	}
+	for _, tt := range tests {
+		got := isModelCredentialKey(tt.key)
+		if got != tt.want {
+			t.Errorf("isModelCredentialKey(%q) = %v, want %v", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestCreateBenchmarkResourcesPassthroughOnlyModelAuth(t *testing.T) {
+	providerID := "provider-1"
+	evaluation := sampleEvaluation(providerID)
+	evaluation.Model.URL = "https://model.example.com/v1"
+	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "tls-only-creds"}
+
+	realSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls-only-creds", Namespace: "default"},
+		Data: map[string][]byte{
+			"ca_cert": []byte("-----BEGIN CERTIFICATE-----"),
+		},
+	}
+	clientset := fake.NewClientset(realSecret)
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+		serviceConfig: &config.Config{
+			Service: &config.ServiceConfig{
+				EvalInitImage: "eval-init-image",
+			},
+		},
+	}
+
+	storage := &fakeStorage{providerConfigs: sampleProviders(providerID)}
+	err := runtime.createBenchmarkResources(context.Background(), runtime.logger, evaluation, &evaluation.Benchmarks[0], 0, storage)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	jobs := listJobsByJobID(t, clientset, evaluation.Resource.ID)
+	job := jobs[0]
+	container := job.Spec.Template.Spec.Containers[0]
+
+	for _, volume := range job.Spec.Template.Spec.Volumes {
+		if volume.Name == modelAuthVolumeName && volume.VolumeSource.Projected != nil {
+			t.Fatal("expected passthrough-only secret to use direct secret mount, not projected ref volume")
+		}
+	}
+	for _, mount := range job.Spec.Template.Spec.InitContainers[0].VolumeMounts {
+		if mount.Name == modelAuthVolumeName {
+			t.Fatal("expected no sidecar real-secret mount when credential injection is disabled")
+		}
+	}
+
+	secrets, err := clientset.CoreV1().Secrets("default").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list secrets: %v", err)
+	}
+	for _, s := range secrets.Items {
+		if strings.Contains(s.Name, "-model-ref") {
+			t.Fatalf("expected no ephemeral ref secret, found %q", s.Name)
+		}
+	}
+
+	cmName := job.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.Name
+	cm, err := clientset.CoreV1().ConfigMaps("default").Get(context.Background(), cmName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get configmap: %v", err)
+	}
+	if !strings.Contains(cm.Data["job.json"], "https://model.example.com/v1") {
+		t.Fatalf("expected job.json to keep direct model URL, got %s", cm.Data["job.json"])
+	}
+	_ = container
 }
 
 func TestCreateBenchmarkResourcesAddsInitContainerForS3TestData(t *testing.T) {

--- a/internal/eval_hub/runtimes/k8s/secret_builder.go
+++ b/internal/eval_hub/runtimes/k8s/secret_builder.go
@@ -35,12 +35,16 @@ type modelSecretInfo struct {
 	// hasCredentialKeys is true when the secret contains at least one proxy-injectable
 	// key (api-key, *_api-key, *_url), meaning credential injection should be activated.
 	hasCredentialKeys bool
+	// data is the full secret data, populated when hasCredentialKeys is true so callers
+	// can build the internalModelRef secret without a second API call.
+	data map[string][]byte
 }
 
 // inspectModelSecret reads the model credential secret and reports whether it contains
-// proxy-injectable credential keys. Breaks early on first match. When hasCredentialKeys=false
-// (e.g. ca_cert-only secret), no internalModelRef secret is created and no model proxy
-// is started.
+// proxy-injectable credential keys. When hasCredentialKeys=true the full data map is
+// returned so the caller can pass it directly to buildInternalModelRefSecret without a
+// second GetSecret call. When hasCredentialKeys=false (e.g. ca_cert-only secret), no
+// internalModelRef secret is created and no model proxy is started.
 func inspectModelSecret(ctx context.Context, namespace, secretName string, helper *KubernetesHelper) (modelSecretInfo, error) {
 	realSecret, err := helper.GetSecret(ctx, namespace, secretName)
 	if err != nil {
@@ -48,15 +52,15 @@ func inspectModelSecret(ctx context.Context, namespace, secretName string, helpe
 	}
 	for k := range realSecret.Data {
 		if isModelCredentialKey(k) {
-			return modelSecretInfo{hasCredentialKeys: true}, nil
+			return modelSecretInfo{hasCredentialKeys: true, data: realSecret.Data}, nil
 		}
 	}
 	return modelSecretInfo{}, nil
 }
 
 // buildInternalModelRefSecret creates the ephemeral internalModelRef secret in namespace
-// by reading the model credential secret and generating synthetic ref/placeholder values.
-// Only called when hasCredentialKeys=true (verified by inspectModelSecret).
+// from the already-read model credential secret data. Only called when hasCredentialKeys=true
+// (verified by inspectModelSecret, which also provides the data to avoid a second API call).
 //
 // Key filtering rules applied to model credential secret keys:
 //
@@ -72,18 +76,13 @@ func buildInternalModelRefSecret(
 	ctx context.Context,
 	namespace string,
 	refSecretName string,
-	realSecretName string,
+	data map[string][]byte,
 	sidecarProxyURL string,
 	labels map[string]string,
 	helper *KubernetesHelper,
 ) (*corev1.Secret, error) {
-	realSecret, err := helper.GetSecret(ctx, namespace, realSecretName)
-	if err != nil {
-		return nil, fmt.Errorf("get model credential secret %q: %w", realSecretName, err)
-	}
-	data := realSecret.Data
 	if len(data) == 0 {
-		return nil, fmt.Errorf("model credential secret %q has no data keys", realSecretName)
+		return nil, fmt.Errorf("model credential secret data is empty")
 	}
 
 	refData := make(map[string][]byte, len(data))
@@ -103,8 +102,8 @@ func buildInternalModelRefSecret(
 	}
 
 	if len(refData) == 0 {
-		return nil, fmt.Errorf("model credential secret %q contains no recognised credential keys (expected %q or keys with %q or %q suffix)",
-			realSecretName, modelSingleAPIKey, modelAPIKeySuffix, modelURLSuffix)
+		return nil, fmt.Errorf("model credential secret data contains no recognised credential keys (expected %q or keys with %q or %q suffix)",
+			modelSingleAPIKey, modelAPIKeySuffix, modelURLSuffix)
 	}
 
 	secret := &corev1.Secret{

--- a/internal/eval_hub/runtimes/k8s/secret_builder.go
+++ b/internal/eval_hub/runtimes/k8s/secret_builder.go
@@ -1,0 +1,123 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	modelAPIKeySuffix = "_api-key"
+	modelURLSuffix    = "_url"
+	modelHFTokenKey   = "hf-token"
+	modelCACertKey    = "ca_cert"
+	modelSingleAPIKey = "api-key"
+)
+
+// directAdapterSecretKeys are keys from the model credential secret projected directly into
+// the adapter volume rather than replaced with a ref token. These credentials cannot be
+// proxied by the sidecar (HF Hub calls bypass the proxy; ca_cert is a TLS artifact, not an
+// inference credential), so the adapter receives the real values via a selective real-secret
+// projection alongside the internalModelRef secret.
+var directAdapterSecretKeys = []string{modelHFTokenKey, modelCACertKey}
+
+// isModelCredentialKey reports whether k is a proxy-injectable credential key
+// (api-key, *_api-key, or *_url).
+func isModelCredentialKey(k string) bool {
+	return k == modelSingleAPIKey || strings.HasSuffix(k, modelAPIKeySuffix) || strings.HasSuffix(k, modelURLSuffix)
+}
+
+// modelSecretInfo holds the result of inspecting the model credential secret.
+type modelSecretInfo struct {
+	// hasCredentialKeys is true when the secret contains at least one proxy-injectable
+	// key (api-key, *_api-key, *_url), meaning credential injection should be activated.
+	hasCredentialKeys bool
+}
+
+// inspectModelSecret reads the model credential secret and reports whether it contains
+// proxy-injectable credential keys. Breaks early on first match. When hasCredentialKeys=false
+// (e.g. ca_cert-only secret), no internalModelRef secret is created and no model proxy
+// is started.
+func inspectModelSecret(ctx context.Context, namespace, secretName string, helper *KubernetesHelper) (modelSecretInfo, error) {
+	realSecret, err := helper.GetSecret(ctx, namespace, secretName)
+	if err != nil {
+		return modelSecretInfo{}, fmt.Errorf("get model credential secret %q: %w", secretName, err)
+	}
+	for k := range realSecret.Data {
+		if isModelCredentialKey(k) {
+			return modelSecretInfo{hasCredentialKeys: true}, nil
+		}
+	}
+	return modelSecretInfo{}, nil
+}
+
+// buildInternalModelRefSecret creates the ephemeral internalModelRef secret in namespace
+// by reading the model credential secret and generating synthetic ref/placeholder values.
+// Only called when hasCredentialKeys=true (verified by inspectModelSecret).
+//
+// Key filtering rules applied to model credential secret keys:
+//
+//   - "api-key"          → value becomes "api-key:ref" (sidecar injects real key)
+//   - "*_api-key" suffix → value becomes "<key>:ref"   (sidecar injects real key)
+//   - "*_url" suffix     → value becomes sidecarProxyURL (adapter routes through sidecar)
+//   - "hf-token"         → omitted; projected directly from the model credential secret
+//   - "ca_cert"          → omitted; projected directly from the model credential secret
+//   - all other keys     → omitted (conservative; avoids leaking unknown fields)
+//
+// The internalModelRef secret contains only synthetic ref/placeholder values — no real credentials.
+func buildInternalModelRefSecret(
+	ctx context.Context,
+	namespace string,
+	refSecretName string,
+	realSecretName string,
+	sidecarProxyURL string,
+	labels map[string]string,
+	helper *KubernetesHelper,
+) (*corev1.Secret, error) {
+	realSecret, err := helper.GetSecret(ctx, namespace, realSecretName)
+	if err != nil {
+		return nil, fmt.Errorf("get model credential secret %q: %w", realSecretName, err)
+	}
+	data := realSecret.Data
+	if len(data) == 0 {
+		return nil, fmt.Errorf("model credential secret %q has no data keys", realSecretName)
+	}
+
+	refData := make(map[string][]byte, len(data))
+	for k := range data {
+		switch {
+		case isModelCredentialKey(k):
+			if strings.HasSuffix(k, modelURLSuffix) {
+				refData[k] = []byte(sidecarProxyURL)
+			} else {
+				refData[k] = []byte(k + modelRefValueSuffix)
+			}
+		case k == modelHFTokenKey || k == modelCACertKey:
+			// projected directly from the model credential secret into the adapter volume
+		default:
+			// unknown key — omitted from the internalModelRef secret (conservative; avoids leaking unknown fields)
+		}
+	}
+
+	if len(refData) == 0 {
+		return nil, fmt.Errorf("model credential secret %q contains no recognised credential keys (expected %q or keys with %q or %q suffix)",
+			realSecretName, modelSingleAPIKey, modelAPIKeySuffix, modelURLSuffix)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      refSecretName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Data: refData,
+	}
+	return helper.CreateSecret(ctx, namespace, secret)
+}
+
+// modelRefValueSuffix is shared between secret_builder.go and model_proxy.go.
+// Defined here so both sides stay in sync without a cross-package import cycle.
+const modelRefValueSuffix = ":ref"

--- a/internal/eval_hub/runtimes/k8s/secret_builder.go
+++ b/internal/eval_hub/runtimes/k8s/secret_builder.go
@@ -17,13 +17,6 @@ const (
 	modelSingleAPIKey = "api-key"
 )
 
-// directAdapterSecretKeys are keys from the model credential secret projected directly into
-// the adapter volume rather than replaced with a ref token. These credentials cannot be
-// proxied by the sidecar (HF Hub calls bypass the proxy; ca_cert is a TLS artifact, not an
-// inference credential), so the adapter receives the real values via a selective real-secret
-// projection alongside the internalModelRef secret.
-var directAdapterSecretKeys = []string{modelHFTokenKey, modelCACertKey}
-
 // isModelCredentialKey reports whether k is a proxy-injectable credential key
 // (api-key, *_api-key, or *_url).
 func isModelCredentialKey(k string) bool {

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
@@ -51,6 +51,12 @@ func sidecarForJobPod(cfg *config.Config, jc *jobConfig) (*config.SidecarConfig,
 				export.MLFlow.CACertPath = serviceCAMountPath + "/" + serviceCABundleFile
 			}
 		}
+		if jc.modelTargetURL != "" {
+			export.Model = &config.SidecarModelConfig{
+				URL:                 jc.modelTargetURL,
+				AuthSecretMountPath: modelAuthMountPath,
+			}
+		}
 	}
 
 	return export, nil
@@ -72,6 +78,10 @@ func cloneSidecarConfig(sc *config.SidecarConfig) *config.SidecarConfig {
 	if sc.OCI != nil {
 		oci := *sc.OCI
 		out.OCI = &oci
+	}
+	if sc.Model != nil {
+		m := *sc.Model
+		out.Model = &m
 	}
 	// SidecarContainer (image/resources) is for eval-hub job scheduling only, not the sidecar process.
 	return out

--- a/internal/eval_runtime_sidecar/handlers/handlers.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers.go
@@ -22,9 +22,10 @@ type Handlers struct {
 	ociProxy         *httputil.ReverseProxy
 	ociTokenProducer *proxy.OCITokenProducer // created once at startup for OCI auth
 	ociRepository    string                  // from job spec; used to route requests to /registry/{ociRepository}
+	modelProxy       *httputil.ReverseProxy  // model credential-injection proxy; nil when not configured
 }
 
-// New creates handlers and builds reverse proxies for eval-hub, MLflow, and optionally OCI.
+// New creates handlers and builds reverse proxies for eval-hub, MLflow, OCI, and optionally model.
 func New(config *config.Config, logger *slog.Logger) (*Handlers, error) {
 	evalHubProxy, err := newEvalhubProxy(config, logger)
 	if err != nil {
@@ -41,6 +42,11 @@ func New(config *config.Config, logger *slog.Logger) (*Handlers, error) {
 		return nil, err
 	}
 
+	modelProxy, err := newModelProxy(config, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Handlers{
 		logger:           logger,
 		serviceConfig:    config,
@@ -49,6 +55,7 @@ func New(config *config.Config, logger *slog.Logger) (*Handlers, error) {
 		ociProxy:         ociProxy,
 		ociTokenProducer: ociTokenProducer,
 		ociRepository:    ociRepository,
+		modelProxy:       modelProxy,
 	}, nil
 }
 
@@ -119,6 +126,13 @@ func (h *Handlers) parseProxyCall(r *http.Request) (*httputil.ReverseProxy, *pro
 		}
 		return nil, nil, fmt.Errorf("oci proxy is not configured")
 	default:
+		// Model credential-injection proxy is the catch-all: when configured, any request
+		// not matched by the specific prefixes above is forwarded to the model target URL.
+		// The model proxy's Rewrite function performs ref-token substitution and dynamic URL
+		// routing; it does not use AuthTokenInput, so an empty value is returned.
+		if h.modelProxy != nil {
+			return h.modelProxy, &proxy.AuthTokenInput{}, nil
+		}
 		return nil, nil, fmt.Errorf("unknown proxy call: %s", r.RequestURI)
 	}
 }

--- a/internal/eval_runtime_sidecar/handlers/model.go
+++ b/internal/eval_runtime_sidecar/handlers/model.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_runtime_sidecar/proxy"
+)
+
+// ModelAuthSecretMountPathDefault is the default path for the model credentials
+// secret mount in the sidecar container. Must match modelAuthRealMountPath in
+// internal/eval_hub/runtimes/k8s/job_builders.go.
+const ModelAuthSecretMountPathDefault = "/var/run/secrets/model"
+
+// newModelProxy creates a reverse proxy for model credential injection when sidecar.model
+// is configured. Returns (nil, nil) when model credential injection is not configured.
+// The proxy replaces ref-token Authorization headers (e.g. "Bearer api-key:ref") with the
+// real credential read from the secret mount, then forwards to the configured target URL.
+func newModelProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, error) {
+	if config == nil || config.Sidecar == nil || config.Sidecar.Model == nil {
+		return nil, nil
+	}
+	mc := config.Sidecar.Model
+	targetURL := strings.TrimSpace(mc.URL)
+	if targetURL == "" {
+		return nil, nil
+	}
+
+	modelHTTPClient, err := proxy.NewModelHTTPClient(config, config.IsOTELEnabled(), logger)
+	if err != nil {
+		logger.Error("failed to create model HTTP client", "error", err)
+		return nil, fmt.Errorf("failed to create model HTTP client: %w", err)
+	}
+
+	target, err := url.Parse(strings.TrimSuffix(targetURL, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid model url %q: %w", targetURL, err)
+	}
+
+	secretMountPath := strings.TrimSpace(mc.AuthSecretMountPath)
+	if secretMountPath == "" {
+		secretMountPath = ModelAuthSecretMountPathDefault
+	}
+
+	rp := proxy.NewModelReverseProxy(target, modelHTTPClient, logger, secretMountPath)
+	logger.Info("Model credential-injection proxy enabled", "url", targetURL)
+	return rp, nil
+}

--- a/internal/eval_runtime_sidecar/proxy/http_client.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client.go
@@ -127,6 +127,41 @@ func NewMLFlowHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logge
 	return client, nil
 }
 
+// NewModelHTTPClient creates an HTTP client for the model credential-injection proxy.
+// When Sidecar.Model is nil, system defaults are used (no custom CA, standard timeout).
+// CACertPath is always set to the potential ca_cert file in the real secret mount; if the
+// file does not exist (secret has no ca_cert key) the client falls back to system roots
+// rather than failing startup.
+func NewModelHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger *slog.Logger) (*http.Client, error) {
+	if serviceConfig == nil || serviceConfig.Sidecar == nil {
+		return nil, nil
+	}
+	mc := serviceConfig.Sidecar.Model
+	timeout := DefaultHTTPTimeout
+	if mc != nil && mc.HTTPTimeout > 0 {
+		timeout = mc.HTTPTimeout
+	}
+	caCertPath := ""
+	if mc != nil && mc.AuthSecretMountPath != "" {
+		candidate := mc.AuthSecretMountPath + "/ca_cert"
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			caCertPath = candidate
+		} else {
+			logger.Info("Model CA cert absent in secret mount, using system roots", "path", candidate)
+		}
+	}
+	insecureSkipVerify := DefaultInsecureSkipVerify
+	if mc != nil && mc.InsecureSkipVerify {
+		insecureSkipVerify = mc.InsecureSkipVerify
+	}
+	tlsConfig, err := buildTLSConfig(caCertPath, insecureSkipVerify, logger, "Model")
+	if err != nil {
+		return nil, err
+	}
+	client := newHTTPClient(timeout, tlsConfig, isOTELEnabled, logger, "Model")
+	return client, nil
+}
+
 // NewOCIHTTPClient creates an HTTP client for the OCI registry from config (TLS, timeout).
 // Registry host comes from the job spec, not this config. When Sidecar.OCI is nil, defaults
 // are used; non-nil sidecar.oci in sidecar_config.json supplies optional CA, insecure, and

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -84,15 +84,23 @@ func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *s
 			if err != nil {
 				// Signal the RoundTripper to return 400 without forwarding.
 				pr.Out.Header.Set(xModelCredError, err.Error())
-				pr.SetURL(defaultTarget)
+				pr.Out.URL.Scheme = defaultTarget.Scheme
+				pr.Out.URL.Host = defaultTarget.Host
+				pr.Out.Host = defaultTarget.Host
+				pr.Out.RequestURI = ""
 				return
 			}
 			target = resolvedTarget
 			SetAuthHeader(pr.Out, realToken)
 		}
 
-		pr.SetURL(target)
-		pr.Out.RequestURI = "" // http.Client.Do rejects non-empty RequestURI
+		// Set only scheme and host from the target — do not join the target path with the
+		// incoming path. The incoming path already contains the full API path (e.g. /v1/completions)
+		// so prepending the target's path prefix (e.g. /v1) would produce /v1/v1/completions.
+		pr.Out.URL.Scheme = target.Scheme
+		pr.Out.URL.Host = target.Host
+		pr.Out.Host = target.Host
+		pr.Out.RequestURI = ""
 		reqLog.Info("Proxying model request", "method", pr.Out.Method, "url", pr.Out.URL.String(), "headers", headersForLog(pr.Out.Header))
 	}
 

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -1,0 +1,202 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// modelRefSuffix is the value suffix that signals credential injection.
+// A Bearer token "api-key:ref" means: look up "api-key" in the real secret mount.
+const modelRefSuffix = ":ref"
+
+// modelAPIKeySuffix and modelURLSuffix are the key-naming conventions for multi-model secrets.
+const (
+	modelAPIKeySuffix = "_api-key"
+	modelURLSuffix    = "_url"
+)
+
+// xModelCredError is an internal sentinel header set by the Director when ref resolution fails.
+// The modelRoundTripper checks for it and returns 400 to the eval container instead of
+// forwarding a request with a literal ref token.
+const xModelCredError = "X-Model-Cred-Error"
+
+const globalTransactionIDHeader = "X-Global-Transaction-Id"
+
+// getOrCreateRequestID returns X-Global-Transaction-Id from req or a new UUID.
+func getOrCreateRequestID(req *http.Request) string {
+	if req != nil {
+		if id := strings.TrimSpace(req.Header.Get(globalTransactionIDHeader)); id != "" {
+			return id
+		}
+	}
+	return uuid.New().String()
+}
+
+// requestIDForRequest returns the request ID from the X-Global-Transaction-Id header,
+// generating a UUID when not present.
+func requestIDForRequest(req *http.Request) string {
+	return getOrCreateRequestID(req)
+}
+
+func loggerForRequest(logger *slog.Logger, req *http.Request) *slog.Logger {
+	return logger.With("request_id", requestIDForRequest(req))
+}
+
+// NewModelReverseProxy returns an httputil.ReverseProxy that performs model credential injection.
+//
+// Per-request behaviour:
+//  1. If the Authorization header carries a ref token (e.g. "Bearer model-1_api-key:ref"):
+//     a. The real credential is read from realSecretMountPath/model-1_api-key.
+//     b. The upstream URL is determined by reading realSecretMountPath/model-1_url
+//     (derived by replacing "_api-key" → "_url"). Falls back to defaultTarget when
+//     the URL file is absent (single-model / hf-token case).
+//  2. If resolution fails (missing file, empty value, path traversal) the proxy returns
+//     HTTP 400 to the eval container — the request is never forwarded.
+//  3. Non-ref tokens are forwarded unchanged to defaultTarget.
+func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *slog.Logger, realSecretMountPath string) *httputil.ReverseProxy {
+	rp := &httputil.ReverseProxy{
+		Transport: &modelRoundTripper{
+			inner:  &roundTripperFromClient{client: client},
+			logger: logger,
+		},
+	}
+
+	rp.Rewrite = func(pr *httputil.ProxyRequest) {
+		reqID := getOrCreateRequestID(pr.In)
+		reqLog := logger.With("request_id", reqID)
+		// Propagate the request ID to the upstream service.
+		pr.Out.Header.Set(globalTransactionIDHeader, reqID)
+
+		target := defaultTarget
+
+		authHeader := pr.In.Header.Get("Authorization")
+		if isModelRefToken(authHeader) {
+			resolvedTarget, realToken, err := resolveModelCredential(logger, reqID, authHeader, realSecretMountPath, defaultTarget)
+			if err != nil {
+				// Signal the RoundTripper to return 400 without forwarding.
+				pr.Out.Header.Set(xModelCredError, err.Error())
+				pr.SetURL(defaultTarget)
+				return
+			}
+			target = resolvedTarget
+			SetAuthHeader(pr.Out, realToken)
+		}
+
+		pr.SetURL(target)
+		pr.Out.RequestURI = "" // http.Client.Do rejects non-empty RequestURI
+		reqLog.Info("Proxying model request", "method", pr.Out.Method, "url", pr.Out.URL.String(), "headers", headersForLog(pr.Out.Header))
+	}
+
+	rp.ModifyResponse = func(resp *http.Response) error {
+		if resp.Request != nil {
+			loggerForRequest(logger, resp.Request).Info("Response from model proxy", "method", resp.Request.Method, "url", resp.Request.URL.String(), "status", resp.StatusCode)
+		}
+		return nil
+	}
+
+	rp.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
+		loggerForRequest(logger, req).Error("Error proxying model request", "method", req.Method, "url", req.URL.String(), "error", err)
+		http.Error(w, err.Error(), http.StatusBadGateway)
+	}
+
+	return rp
+}
+
+// modelRoundTripper wraps an inner RoundTripper and intercepts requests marked with the
+// xModelCredError sentinel header, returning 400 Bad Request without forwarding.
+type modelRoundTripper struct {
+	inner  http.RoundTripper
+	logger *slog.Logger
+}
+
+func (t *modelRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if errMsg := req.Header.Get(xModelCredError); errMsg != "" {
+		req.Header.Del(xModelCredError)
+		reqID := requestIDForRequest(req)
+		t.logger.Error("model credential resolution failed, returning 400", "request_id", reqID, "error", errMsg)
+		respHeader := make(http.Header)
+		respHeader.Set(globalTransactionIDHeader, reqID)
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Status:     "400 Bad Request",
+			Body:       io.NopCloser(strings.NewReader(errMsg + "\n")),
+			Header:     respHeader,
+			Request:    req,
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+		}, nil
+	}
+	return t.inner.RoundTrip(req)
+}
+
+// isModelRefToken reports whether authHeader is a Bearer ref token.
+func isModelRefToken(authHeader string) bool {
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		return false
+	}
+	return strings.HasSuffix(strings.TrimPrefix(authHeader, "Bearer "), modelRefSuffix)
+}
+
+// resolveModelCredential resolves a Bearer ref token to a (upstream URL, real credential) pair.
+//
+// Key derivation for the upstream URL:
+//   - "model-1_api-key:ref" → reads realSecretMountPath/model-1_api-key (token) and
+//     realSecretMountPath/model-1_url (URL); falls back to defaultTarget if _url absent.
+//   - "api-key:ref" / "hf-token:ref" → reads the credential file; always uses defaultTarget.
+func resolveModelCredential(logger *slog.Logger, requestID, authHeader, realSecretMountPath string, defaultTarget *url.URL) (*url.URL, string, error) {
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	key := strings.TrimSuffix(token, modelRefSuffix)
+
+	if key == "" || strings.ContainsAny(key, "/\\") {
+		return nil, "", fmt.Errorf("model ref token has invalid key %q", key)
+	}
+
+	realToken, err := readSecretFile(realSecretMountPath, key)
+	if err != nil {
+		logger.Error("failed to read model credential", "request_id", requestID, "key", key)
+		return nil, "", fmt.Errorf("credential not found for key %q", key)
+	}
+	if realToken == "" {
+		return nil, "", fmt.Errorf("credential for key %q is empty", key)
+	}
+
+	target := defaultTarget
+
+	// For multi-model keys (*_api-key), try to read the corresponding URL file.
+	if strings.HasSuffix(key, modelAPIKeySuffix) {
+		prefix := strings.TrimSuffix(key, modelAPIKeySuffix)
+		urlKey := prefix + modelURLSuffix
+		rawURL, urlErr := readSecretFile(realSecretMountPath, urlKey)
+		if urlErr == nil && rawURL != "" {
+			parsed, parseErr := url.Parse(strings.TrimSuffix(rawURL, "/"))
+			if parseErr != nil || !parsed.IsAbs() || parsed.Host == "" {
+				logger.Warn("model URL file has invalid or relative URL, using default target",
+					"request_id", requestID, "url_key", urlKey, "error", parseErr)
+			} else {
+				target = parsed
+			}
+		}
+	}
+
+	logger.Info("Resolved model ref token", "request_id", requestID, "key", key, "target_host", target.Host)
+	return target, realToken, nil
+}
+
+// readSecretFile reads and trims a single file from a Kubernetes secret mount.
+func readSecretFile(mountPath, key string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(mountPath, key))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -41,14 +41,8 @@ func getOrCreateRequestID(req *http.Request) string {
 	return uuid.New().String()
 }
 
-// requestIDForRequest returns the request ID from the X-Global-Transaction-Id header,
-// generating a UUID when not present.
-func requestIDForRequest(req *http.Request) string {
-	return getOrCreateRequestID(req)
-}
-
 func loggerForRequest(logger *slog.Logger, req *http.Request) *slog.Logger {
-	return logger.With("request_id", requestIDForRequest(req))
+	return logger.With("request_id", getOrCreateRequestID(req))
 }
 
 // NewModelReverseProxy returns an httputil.ReverseProxy that performs model credential injection.
@@ -129,7 +123,7 @@ type modelRoundTripper struct {
 func (t *modelRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if errMsg := req.Header.Get(xModelCredError); errMsg != "" {
 		req.Header.Del(xModelCredError)
-		reqID := requestIDForRequest(req)
+		reqID := getOrCreateRequestID(req)
 		t.logger.Error("model credential resolution failed, returning 400", "request_id", reqID, "error", errMsg)
 		respHeader := make(http.Header)
 		respHeader.Set(globalTransactionIDHeader, reqID)

--- a/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
@@ -1,0 +1,243 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetOrCreateRequestID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(globalTransactionIDHeader, "incoming-req-id")
+	if got := getOrCreateRequestID(req); got != "incoming-req-id" {
+		t.Fatalf("expected header value, got %q", got)
+	}
+
+	generated := getOrCreateRequestID(httptest.NewRequest(http.MethodGet, "/", nil))
+	if generated == "" {
+		t.Fatal("expected generated request ID")
+	}
+}
+
+func TestModelProxyLogsRequestID(t *testing.T) {
+	var logBuf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	target, _ := url.Parse(upstream.URL)
+	secretDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(secretDir, "api-key"), []byte("sk-real-key"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	rp := NewModelReverseProxy(target, &http.Client{}, log, secretDir)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set(globalTransactionIDHeader, "model-proxy-req-id")
+	req.Header.Set("Authorization", "Bearer api-key:ref")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if !strings.Contains(logBuf.String(), "request_id=model-proxy-req-id") {
+		t.Fatalf("logs = %q, want request_id field", logBuf.String())
+	}
+}
+
+func TestResolveModelCredentialLogsRequestID(t *testing.T) {
+	var logBuf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	secretDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(secretDir, "api-key"), []byte("sk-real-key"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	target, _ := url.Parse("https://model.example.com/v1")
+	_, _, err := resolveModelCredential(log, "resolve-req-id", "Bearer api-key:ref", secretDir, target)
+	if err != nil {
+		t.Fatalf("resolveModelCredential: %v", err)
+	}
+	if !strings.Contains(logBuf.String(), "request_id=resolve-req-id") {
+		t.Fatalf("logs = %q, want request_id field", logBuf.String())
+	}
+}
+
+func TestModelProxyReturns400OnMissingRef(t *testing.T) {
+	var logBuf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	target, _ := url.Parse(upstream.URL)
+	secretDir := t.TempDir() // no files — ref key will be missing
+
+	rp := NewModelReverseProxy(target, &http.Client{}, log, secretDir)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set(globalTransactionIDHeader, "cred-fail-req-id")
+	req.Header.Set("Authorization", "Bearer api-key:ref")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+	if got := rr.Header().Get(globalTransactionIDHeader); got != "cred-fail-req-id" {
+		t.Fatalf("response %s = %q, want cred-fail-req-id", globalTransactionIDHeader, got)
+	}
+	if !strings.Contains(logBuf.String(), "request_id=cred-fail-req-id") {
+		t.Fatalf("logs = %q, want request_id on credential failure", logBuf.String())
+	}
+}
+
+func TestModelProxySingleModelResolves(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	target, _ := url.Parse(upstream.URL)
+	secretDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(secretDir, "api-key"), []byte("sk-real-key"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer api-key:ref")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if gotAuth != "Bearer sk-real-key" {
+		t.Fatalf("expected Authorization %q, got %q", "Bearer sk-real-key", gotAuth)
+	}
+}
+
+func TestModelProxyMultiModelRoutesToCorrectUpstream(t *testing.T) {
+	var model1GotAuth, model2GotAuth string
+
+	upstream1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		model1GotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream1.Close()
+
+	upstream2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		model2GotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream2.Close()
+
+	// defaultTarget is upstream1 (also what model-1 resolves to via _url file).
+	defaultTarget, _ := url.Parse(upstream1.URL)
+	secretDir := t.TempDir()
+
+	writeFile := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(secretDir, name), []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile("model-1_api-key", "sk-model1")
+	writeFile("model-1_url", upstream1.URL)
+	writeFile("model-2_api-key", "sk-model2")
+	writeFile("model-2_url", upstream2.URL)
+
+	rp := NewModelReverseProxy(defaultTarget, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir)
+
+	// Request for model-1 should go to upstream1 with model-1's real key.
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req1.Header.Set("Authorization", "Bearer model-1_api-key:ref")
+	rr1 := httptest.NewRecorder()
+	rp.ServeHTTP(rr1, req1)
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("model-1: expected 200, got %d", rr1.Code)
+	}
+	if model1GotAuth != "Bearer sk-model1" {
+		t.Fatalf("model-1: expected auth %q, got %q", "Bearer sk-model1", model1GotAuth)
+	}
+
+	// Request for model-2 should go to upstream2 with model-2's real key.
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req2.Header.Set("Authorization", "Bearer model-2_api-key:ref")
+	rr2 := httptest.NewRecorder()
+	rp.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("model-2: expected 200, got %d", rr2.Code)
+	}
+	if model2GotAuth != "Bearer sk-model2" {
+		t.Fatalf("model-2: expected auth %q, got %q", "Bearer sk-model2", model2GotAuth)
+	}
+}
+
+func TestModelProxyNonRefTokenPassthrough(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	target, _ := url.Parse(upstream.URL)
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), t.TempDir())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sk-already-real")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if gotAuth != "Bearer sk-already-real" {
+		t.Fatalf("expected auth passed through unchanged, got %q", gotAuth)
+	}
+}
+
+func TestModelProxyReturns400OnEmptyCredential(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	target, _ := url.Parse(upstream.URL)
+	secretDir := t.TempDir()
+	// Write empty file — credential is present but empty.
+	if err := os.WriteFile(filepath.Join(secretDir, "api-key"), []byte("   "), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer api-key:ref")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty credential, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION

## What and why

<!-- What does this PR do and why? Link to related issues. --> https://redhat.atlassian.net/browse/RHOAIENG-53360

This PR implements sidecar credential injection for model auth.
The eval adapter never receives real API keys. It gets placeholder ref tokens; the sidecar intercepts, swaps in the real credential, and forwards to the model provider.

```
User creates eval job with model.auth.secret_ref = "my-secret"
                          │
                          ▼
          eval-hub inspects the model credential secret
                          │
             ┌────────────┴────────────┐
             │                         │
  Secret has api-key /       Secret has ca_cert /
  *_api-key / *_url keys     hf-token only
  (credential keys)          (passthrough keys)
             │                         │
             ▼                         ▼
   CREDENTIAL INJECTION           PASSTHROUGH
             │                         │
  - Creates ephemeral          - Real secret mounted
    internalModelRef             directly into adapter
    secret (ref tokens only)   - Model URL unchanged
  - Rewrites model URL         - No sidecar model proxy
    → sidecar proxy
  - Projected volume on
    adapter:
      api-key / *_api-key → <key>:ref
      *_url               → sidecar URL
      ca_cert             → real value  ──┐ from user secret
      hf-token            → real value  ──┘ (optional, if present)
  - Sidecar gets full real
    secret; injects real
    credential on each request
```

**Two secrets, two mounts:**

| Secret | Mounted in | Contents |
|--------|-----------|----------|
| internalModelRef (ephemeral, created by eval-hub) | Adapter only | `api-key: api-key:ref`, `model-1_api-key: model-1_api-key:ref`, `model-1_url: http://localhost:8080` — synthetic values only |
| Model credential secret (user-provided) | Sidecar (full) + Adapter (`hf-token`, `ca_cert` only via projected volume, optional) | Real keys |

**Why `hf-token` and `ca_cert` go directly to the adapter:**
- `hf-token` — HF Hub calls bypass the sidecar proxy. This PR has Model inference proxy only, HF Hub is out of scope.
- `ca_cert` — TLS certificate, not an inference credential; adapter needs the real cert for TLS verification. Mounted in adapter not to break the existing code. 

**Secret lifecycle:**
- internalModelRef secret is created before Job submission and set with a **Job owner reference** — Kubernetes GC automatically deletes it when the Job is deleted

### Auth Patterns Supported

| Pattern | Secret keys | Injection active | Sidecar model proxy |
|---------|------------|-----------------|---------------------|
| No secret (open model / SA token) | — | No | No |
| API key only | `api-key` | Yes | Yes |
| API key + CA cert (+ hf-token) | `api-key`, `ca_cert`, `hf-token` | Yes | Yes; `ca_cert`/`hf-token` projected directly to adapter |
| CA cert / hf-token only (SA + TLS) | `ca_cert`, `hf-token` | No | No; real secret mounted directly into adapter |
| Multi-model | `api-key`, `model-1_api-key`, `model-1_url`, ... | Yes | Yes; per-request URL routing via `*_url` key |

### Manual Testing (on cluster)

Below all 4 patterns validated:

| Model configured with the following| Secret has the following keys | Verified |
|------|--------|---------|
| API key + CA cert  | `api-key`, `ca_cert`, `hf-token` | Adapter gets `api-key:ref`; real `ca_cert`/`hf-token`values; sidecar injects real key |
| No auth (open model) | no secret | No model-auth mount; actual model URL in job.json for adapter|
| CA cert only (Service Account token + custom TLS) | `ca_cert` only | Real secret mounted directly to adapter; no proxy; actual model URL in job.json |
| Multi-model | `api-key`, `model-1_api-key`, `model-1_url`, `ca_cert`, `hf-token` | Adapter has both `api-key:ref`, `model-1_api-key:ref`, `model-1_url` pointing to sidecar URL, real `hf-token`/`ca_cert`, Sidecar gets the real user secret mount and injects keys/urls|




Closes #

Assisted-by: <!-- Cursor, Claude etc --> Claude

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidecar model proxy: per-job model endpoint, credential mount path, HTTP timeout, and TLS skip-verify toggle (no CA-path exposed).
  * Ephemeral model-ref secrets with selective passthrough of sensitive keys and explicit Secret lifecycle/cleanup to avoid orphans.
  * Request-ID propagation to upstreams and clearer error responses when referenced credentials are missing or invalid.

* **Tests**
  * New tests covering proxy behavior, request-ID logging, multi-model credential resolution, secret discovery, and ref-secret generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->