### PR TITLE
feat(metrics): serve /metrics on dedicated port for Prometheus scraping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,9 +142,14 @@ Main function (`cmd/eval_hub/main.go`) implements graceful shutdown:
 1. Creates logger and loads service, provider, and collection config
 2. Wires storage, validator, runtime, and MLflow client
 3. Creates server with `server.NewServer(logger, serviceConfig, storage, validate, runtime, mlflowClient)`
-4. Starts server in a goroutine
-5. Waits for SIGINT/SIGTERM
-6. Gracefully shuts down with a bounded timeout
+4. If Prometheus is enabled, creates and starts a dedicated **MetricsServer** on port 9090 (configurable via `METRICS_PORT`)
+5. Starts main API server in a goroutine
+6. Waits for SIGINT/SIGTERM
+7. Gracefully shuts down metrics server, then main server, with a bounded timeout
+
+#### Metrics server
+
+A separate `MetricsServer` (`internal/eval_hub/server/metrics_server.go`) serves `/metrics` on port 9090 bound to `0.0.0.0` over plain HTTP. This allows Prometheus to scrape metrics without going through kube-rbac-proxy auth. The main API server (bound to `127.0.0.1`) does not serve `/metrics` in cluster mode. In **local mode** (`--local`), `/metrics` is dual-served on both ports for FVT test compatibility.
 
 ### MCP Server
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,7 +74,8 @@ Kubernetes **job pods** use **`sidecar_config.json`** (not the server’s main C
 
 ## Observability
 
-- **`internal/eval_hub/metrics`** — Prometheus instrumentation; **`/metrics`** on the server.
+- **`internal/eval_hub/metrics`** — Prometheus metric definitions (request counters, duration histograms). The metrics middleware wraps the main API router to record observations.
+- **`internal/eval_hub/server/metrics_server.go`** — Dedicated HTTP server for Prometheus scraping. Serves **only** `/metrics` on a separate port (default 9090, configurable via `METRICS_PORT`) bound to `0.0.0.0`. This port is cluster-internal only (no Route, no auth) so that Prometheus can scrape without going through kube-rbac-proxy. In **local mode**, `/metrics` is additionally served on the main API router for FVT compatibility.
 - **OpenTelemetry** — Optional tracing/metrics wiring from service config (`internal/eval_hub/config`, handler helpers as applicable).
 
 Logging uses **slog** with **`internal/logging`** enriching logs from the incoming request (request ID, method, URI, etc.).

--- a/Containerfile
+++ b/Containerfile
@@ -51,7 +51,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
     ./cmd/evalhub_mcp
 
 # Runtime stage
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Create user and app directory
 RUN groupadd -g 1000 evalhub && \

--- a/Containerfile
+++ b/Containerfile
@@ -76,6 +76,7 @@ USER 1000
 
 # Expose service port
 EXPOSE 8080
+EXPOSE 9090
 
 # Environment variables
 ENV PORT=8080 \

--- a/cmd/eval_hub/main.go
+++ b/cmd/eval_hub/main.go
@@ -133,9 +133,20 @@ func main() {
 		startUpFailed(serviceConfig, err, "Failed to create API server", logger)
 	}
 
+	// Create the metrics server if Prometheus is enabled
+	var metricsSrv *server.MetricsServer
+	if serviceConfig.IsPrometheusEnabled() {
+		metricsSrv = server.NewMetricsServer(logger, serviceConfig.Prometheus)
+	}
+
 	// log the start up details
+	metricsPort := 0
+	if metricsSrv != nil {
+		metricsPort = metricsSrv.GetPort()
+	}
 	logger.Info("API Server starting",
 		"server_port", srv.GetPort(),
+		"metrics_port", metricsPort,
 		"version", serviceConfig.Service.Version,
 		"build", serviceConfig.Service.Build,
 		"build_date", serviceConfig.Service.BuildDate,
@@ -150,6 +161,15 @@ func main() {
 
 	// Start config watcher to reload system providers and collections on file changes
 	watcherDone, watcherCancel := config.SetupWatcher(logger, validate, storage, args.ConfigDir)
+
+	// Start metrics server in a goroutine
+	if metricsSrv != nil {
+		go func() {
+			if err := metricsSrv.Start(); err != nil {
+				logger.Error("Metrics server failed", "error", err.Error())
+			}
+		}()
+	}
 
 	// Start server in a goroutine
 	go func() {
@@ -177,6 +197,13 @@ func main() {
 	waitForShutdown := 30 * time.Second
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), waitForShutdown)
 	defer cancel()
+
+	// shutdown the metrics server
+	if metricsSrv != nil {
+		if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
+			logger.Error("Metrics server forced to shutdown", "error", err.Error())
+		}
+	}
 
 	// shutdown the storage
 	logger.Info("Shutting down API storage...")

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,6 +32,8 @@ env_mappings:
   EVALHUB_TOKEN_CACHE_TIMEOUT: sidecar.eval_hub.token_cache_timeout
   MLFLOW_TOKEN_CACHE_TIMEOUT: sidecar.mlflow.token_cache_timeout
   SIDECAR_PORT: sidecar.port
+  METRICS_PORT: prometheus.port
+  METRICS_HOST: prometheus.host
 
 # Database configuration
 database:
@@ -54,6 +56,8 @@ otel:
   # enable_logs: true
 prometheus:
   enabled: true
+  port: 9090
+  host: "0.0.0.0"
 
 sidecar:
   base_url: http://localhost:8080  # URL for adapter/runtime to call sidecar proxy (cluster mode)

--- a/internal/eval_hub/config/prometheus.go
+++ b/internal/eval_hub/config/prometheus.go
@@ -1,5 +1,26 @@
 package config
 
+const (
+	DefaultMetricsPort = 9090
+	DefaultMetricsHost = "0.0.0.0"
+)
+
 type PrometheusConfig struct {
-	Enabled bool `mapstructure:"enabled"`
+	Enabled bool   `mapstructure:"enabled"`
+	Port    int    `mapstructure:"port,omitempty"`
+	Host    string `mapstructure:"host,omitempty"`
+}
+
+func (c *PrometheusConfig) EffectivePort() int {
+	if c == nil || c.Port <= 0 {
+		return DefaultMetricsPort
+	}
+	return c.Port
+}
+
+func (c *PrometheusConfig) EffectiveHost() string {
+	if c == nil || c.Host == "" {
+		return DefaultMetricsHost
+	}
+	return c.Host
 }

--- a/internal/eval_hub/server/metrics_server.go
+++ b/internal/eval_hub/server/metrics_server.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type MetricsServer struct {
+	httpServer *http.Server
+	port       int
+	host       string
+	logger     *slog.Logger
+}
+
+func NewMetricsServer(logger *slog.Logger, promConfig *config.PrometheusConfig) *MetricsServer {
+	port := promConfig.EffectivePort()
+	host := promConfig.EffectiveHost()
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	return &MetricsServer{
+		httpServer: &http.Server{
+			Addr:              net.JoinHostPort(host, strconv.Itoa(port)),
+			Handler:           mux,
+			ReadTimeout:       15 * time.Second,
+			ReadHeaderTimeout: 15 * time.Second,
+			WriteTimeout:      15 * time.Second,
+			IdleTimeout:       60 * time.Second,
+		},
+		port:   port,
+		host:   host,
+		logger: logger,
+	}
+}
+
+func (m *MetricsServer) Start() error {
+	m.logger.Info("Metrics server starting", "addr", m.httpServer.Addr)
+	err := m.httpServer.ListenAndServe()
+	if err == http.ErrServerClosed {
+		m.logger.Info("Metrics server closed gracefully")
+		return nil
+	}
+	return err
+}
+
+func (m *MetricsServer) Shutdown(ctx context.Context) error {
+	m.logger.Info("Shutting down metrics server...")
+	return m.httpServer.Shutdown(ctx)
+}
+
+func (m *MetricsServer) GetPort() int {
+	return m.port
+}
+
+func (m *MetricsServer) Handler() http.Handler {
+	return m.httpServer.Handler
+}

--- a/internal/eval_hub/server/metrics_server.go
+++ b/internal/eval_hub/server/metrics_server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -24,7 +25,7 @@ func NewMetricsServer(logger *slog.Logger, promConfig *config.PrometheusConfig) 
 	host := promConfig.EffectiveHost()
 
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", withRequestID(promhttp.Handler()))
 
 	return &MetricsServer{
 		httpServer: &http.Server{
@@ -39,6 +40,22 @@ func NewMetricsServer(logger *slog.Logger, promConfig *config.PrometheusConfig) 
 		host:   host,
 		logger: logger,
 	}
+}
+
+type contextKeyRequestID struct{}
+
+// withRequestID extracts X-Global-Transaction-Id from the request or generates a UUID,
+// injects it into the request context and response header, then delegates to next.
+func withRequestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := r.Header.Get(TRANSACTION_ID_HEADER)
+		if requestID == "" {
+			requestID = uuid.New().String()
+		}
+		ctx := context.WithValue(r.Context(), contextKeyRequestID{}, requestID)
+		w.Header().Set(TRANSACTION_ID_HEADER, requestID)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }
 
 func (m *MetricsServer) Start() error {

--- a/internal/eval_hub/server/metrics_server_test.go
+++ b/internal/eval_hub/server/metrics_server_test.go
@@ -1,0 +1,72 @@
+package server_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/server"
+	"github.com/eval-hub/eval-hub/internal/logging"
+)
+
+func TestMetricsServerDefaults(t *testing.T) {
+	t.Parallel()
+	t.Run("uses default port when not configured", func(t *testing.T) {
+		t.Parallel()
+		logger, _, _ := logging.NewLogger()
+		promConfig := &config.PrometheusConfig{Enabled: true}
+		srv := server.NewMetricsServer(logger, promConfig)
+		if srv.GetPort() != config.DefaultMetricsPort {
+			t.Errorf("expected default port %d, got %d", config.DefaultMetricsPort, srv.GetPort())
+		}
+	})
+
+	t.Run("uses configured port", func(t *testing.T) {
+		t.Parallel()
+		logger, _, _ := logging.NewLogger()
+		promConfig := &config.PrometheusConfig{Enabled: true, Port: 9191}
+		srv := server.NewMetricsServer(logger, promConfig)
+		if srv.GetPort() != 9191 {
+			t.Errorf("expected port 9191, got %d", srv.GetPort())
+		}
+	})
+}
+
+func TestMetricsServerHandler(t *testing.T) {
+	t.Parallel()
+	logger, _, _ := logging.NewLogger()
+	promConfig := &config.PrometheusConfig{Enabled: true}
+	srv := server.NewMetricsServer(logger, promConfig)
+	handler := srv.Handler()
+
+	t.Run("serves /metrics with Prometheus format", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "go_goroutines") {
+			t.Error("response should contain go runtime metrics")
+		}
+		if !strings.Contains(body, "# HELP") {
+			t.Error("response should contain Prometheus exposition format")
+		}
+	})
+
+	t.Run("returns 404 for non-metrics paths", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404 for /api/v1/health, got %d", w.Code)
+		}
+	})
+}

--- a/internal/eval_hub/server/server.go
+++ b/internal/eval_hub/server/server.go
@@ -419,11 +419,13 @@ func (s *Server) setupRoutes() (http.Handler, error) {
 
 	s.setupDocsRoutes(h, router)
 
-	// Prometheus metrics endpoint
+	// Prometheus metrics endpoint: in cluster mode, /metrics is served by the
+	// dedicated MetricsServer on a separate port. In local mode, also serve it
+	// here for development convenience and FVT compatibility.
 	prometheusEnabled := s.serviceConfig.IsPrometheusEnabled()
-	if prometheusEnabled {
+	if prometheusEnabled && s.serviceConfig.Service.LocalMode {
 		router.Handle("/metrics", promhttp.Handler())
-		s.logger.Info("Registered API", "pattern", "/metrics")
+		s.logger.Info("Registered API (local mode)", "pattern", "/metrics")
 	}
 
 	// Enable CORS in local mode only (for development/testing)


### PR DESCRIPTION
## What and why

EvalHub metrics need to be automatically discoverable by the OpenShift platform monitoring stack (RHAISTRAT-1507). Currently `/metrics` is served on the same port and loopback address as the API, behind kube-rbac-proxy, which prevents Prometheus from scraping because it cannot supply the required Bearer token + RBAC auth.

This PR adds a standalone HTTP metrics server on port 9090 bound to `0.0.0.0` so that Prometheus can scrape `/metrics` directly without auth. The main API remains on `127.0.0.1` behind kube-rbac-proxy. The metrics port is cluster-internal only (no Route).

In local mode, `/metrics` is dual-served on both ports for FVT compatibility.

Closes #

Ref: RHAISTRAT-1507

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Changes

- **`internal/eval_hub/config/prometheus.go`** — Added `Port`/`Host` fields with `EffectivePort()` (default 9090) and `EffectiveHost()` (default `0.0.0.0`) accessors
- **`internal/eval_hub/server/metrics_server.go`** — New dedicated HTTP server serving only `/metrics` via `promhttp.Handler()` with hardened timeouts
- **`internal/eval_hub/server/server.go`** — `/metrics` on main router only in local mode
- **`cmd/eval_hub/main.go`** — Metrics server lifecycle (create, start in goroutine, graceful shutdown)
- **`config/config.yaml`** — Added `prometheus.port`, `prometheus.host`, and `METRICS_PORT`/`METRICS_HOST` env mappings
- **`Containerfile`** — Added `EXPOSE 9090`
- **`ARCHITECTURE.md`**, **`AGENTS.md`** — Documented metrics server architecture and lifecycle

## Testing

- [x] Tests added or updated
- [x] Tested manually

New unit tests in `metrics_server_test.go` covering defaults, custom port, handler response format, and 404 for non-metrics paths. FVT (`metrics.feature`) passes unchanged via local-mode dual-serve.

## Breaking changes

None. The main API port and behaviour are unchanged. The metrics port is additive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dedicated Prometheus metrics server now runs on port 9090 (configurable)
  * In local mode, metrics are additionally served on the main API server for compatibility

* **Configuration**
  * New metrics server port and host configuration options added

* **Documentation**
  * Updated deployment and observability documentation for metrics server setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->