### PR TITLE
fix(mlflow): send X-MLFLOW-WORKSPACE header on GetWorkspace requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,7 +461,7 @@ DOCKER_BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 DOCKER ?= podman
 
 docker-image-local: ## Build the eval-hub Docker image locally from Containerfile
-	$(DOCKER) build -f Containerfile \
+	$(DOCKER) build -f Containerfile $(if $(DOCKER_PLATFORM),--platform $(DOCKER_PLATFORM)) \
 		--build-arg "BUILD_DATE=$(DOCKER_BUILD_DATE)" \
 		--build-arg "GIT_HASH=$(GIT_HASH)" \
 		-t "$(DOCKER_IMAGE_LOCAL)" .

--- a/pkg/mlflowclient/client.go
+++ b/pkg/mlflowclient/client.go
@@ -200,7 +200,7 @@ func (c *Client) doRequest(method, endpoint string, body any) ([]byte, error) {
 	return c.doRequestInternal(method, endpoint, body, true)
 }
 
-// doRequestWithoutWorkspace performs a global MLflow API request (workspace management).
+// doRequestWithoutWorkspace performs an MLflow API request without the X-MLFLOW-WORKSPACE header.
 func (c *Client) doRequestWithoutWorkspace(method, endpoint string, body any) ([]byte, error) {
 	return c.doRequestInternal(method, endpoint, body, false)
 }

--- a/pkg/mlflowclient/workspaces.go
+++ b/pkg/mlflowclient/workspaces.go
@@ -85,7 +85,7 @@ func (c *Client) GetWorkspace(name string) (*Workspace, error) {
 		return nil, fmt.Errorf("workspace name is empty")
 	}
 
-	respBody, err := c.doRequestWithoutWorkspace(http.MethodGet, workspaceEndpoint(name), nil)
+	respBody, err := c.doRequest(http.MethodGet, workspaceEndpoint(name), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (c *Client) GetWorkspace(name string) (*Workspace, error) {
 	return &resp.Workspace, nil
 }
 
-// CreateWorkspace creates a workspace. Workspace management APIs do not use X-MLFLOW-WORKSPACE.
+// CreateWorkspace creates a workspace without the X-MLFLOW-WORKSPACE header (global operation).
 func (c *Client) CreateWorkspace(req *CreateWorkspaceRequest) (*Workspace, error) {
 	if c == nil {
 		return nil, fmt.Errorf("mlflow client is nil")

--- a/pkg/mlflowclient/workspaces_test.go
+++ b/pkg/mlflowclient/workspaces_test.go
@@ -222,6 +222,67 @@ func TestEnsureWorkspace_edgeCases(t *testing.T) {
 	})
 }
 
+func TestWorkspaceMgmtAPIsIncludeHeader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GetWorkspace sends header when workspaces enabled", func(t *testing.T) {
+		t.Parallel()
+		headerCh := make(chan string, 1)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			headerCh <- r.Header.Get("X-MLFLOW-WORKSPACE")
+			_ = json.NewEncoder(w).Encode(GetWorkspaceResponse{Workspace: Workspace{Name: "my-ws"}})
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithWorkspacesSupport(true).WithWorkspace("my-ws")
+		_, err := client.GetWorkspace("my-ws")
+		if err != nil {
+			t.Fatalf("GetWorkspace() = %v", err)
+		}
+		if got := <-headerCh; got != "my-ws" {
+			t.Fatalf("X-MLFLOW-WORKSPACE = %q, want %q", got, "my-ws")
+		}
+	})
+
+	t.Run("GetWorkspace omits header when workspaces disabled", func(t *testing.T) {
+		t.Parallel()
+		headerCh := make(chan string, 1)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			headerCh <- r.Header.Get("X-MLFLOW-WORKSPACE")
+			_ = json.NewEncoder(w).Encode(GetWorkspaceResponse{Workspace: Workspace{Name: "my-ws"}})
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithWorkspacesSupport(false)
+		_, err := client.GetWorkspace("my-ws")
+		if err != nil {
+			t.Fatalf("GetWorkspace() = %v", err)
+		}
+		if got := <-headerCh; got != "" {
+			t.Fatalf("X-MLFLOW-WORKSPACE = %q, want empty", got)
+		}
+	})
+
+	t.Run("CreateWorkspace omits header even when workspaces enabled", func(t *testing.T) {
+		t.Parallel()
+		headerCh := make(chan string, 1)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			headerCh <- r.Header.Get("X-MLFLOW-WORKSPACE")
+			_ = json.NewEncoder(w).Encode(GetWorkspaceResponse{Workspace: Workspace{Name: "new-ws"}})
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithWorkspacesSupport(true).WithWorkspace("my-ws")
+		_, err := client.CreateWorkspace(&CreateWorkspaceRequest{Name: "new-ws"})
+		if err != nil {
+			t.Fatalf("CreateWorkspace() = %v", err)
+		}
+		if got := <-headerCh; got != "" {
+			t.Fatalf("X-MLFLOW-WORKSPACE = %q, want empty", got)
+		}
+	})
+}
+
 func TestGetWorkspace_validation(t *testing.T) {
 	t.Parallel()
 	var c *Client


### PR DESCRIPTION


## What and why

Some MLflow deployments require the workspace header on workspace management APIs. `GetWorkspace` now uses `doRequest` so the header is included when workspacesEnabled is true. CreateWorkspace remains headerless as it is a global operation.

Closes # https://redhat.atlassian.net/browse/RHOAIENG-67990

Assisted-by:  Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

```
make test-all
make test-all-coverage

cd tests/mlflow/
make test-godog-server
MLFLOW_ENABLE_WORKSPACES=true make test-godog-server
```

### Evaluations with experiments now successful - Available in MFLOW UI
<img width="1444" height="807" alt="Screenshot 2026-06-12 at 11 28 33 AM" src="https://github.com/user-attachments/assets/0dae2a65-2dcb-40f9-90fd-10180c93a1ea" />
<img width="1262" height="449" alt="Screenshot 2026-06-12 at 11 28 12 AM" src="https://github.com/user-attachments/assets/6abfb92a-bf10-49ac-a5a8-a6c6e0a413d5" />
<img width="689" height="806" alt="Screenshot 2026-06-12 at 11 27 31 AM" src="https://github.com/user-attachments/assets/44023827-202d-4bf2-9ddd-bb0806f513a4" />


## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace lookup operations now correctly include workspace identification headers when workspaces support is enabled.

* **Chores**
  * Docker build command now supports conditional platform specification for multi-platform compatibility.

* **Tests**
  * Added comprehensive test coverage for workspace management API header behavior across different configuration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->