### PR TITLE
fix: use PullIfNotPresent for adapter and init containers 

### DIFF
--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -215,7 +215,7 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 		{
 			Name:            adapterContainerName,
 			Image:           cfg.adapterImage,
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         buildContainerCommand(cfg.entrypoint),
 			Env:             adapterEnvVars,
 			Resources:       resources,
@@ -549,7 +549,7 @@ func initContainerVolumesAndMounts(cfg *jobConfig) ([]corev1.Container, []corev1
 		initContainers = append(initContainers, corev1.Container{
 			Name:            initContainerName,
 			Image:           initImage,
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{initCommand},
 			Resources:       initResources,
 			Env: []corev1.EnvVar{


### PR DESCRIPTION
Evaluation job pods had imagePullPolicy: Always on the adapter and test-data init containers, causing unnecessary image pull checks on every benchmark run even when the image was already present on the node. Changed both to PullIfNotPresent.

## What and why

<!-- What does this PR do and why? Link to related issues. --> 

Closes # https://redhat.atlassian.net/browse/RHOAIENG-67052

Assisted-by: <!-- Cursor, Claude etc --> Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized container image caching behavior to reuse previously pulled images when available, reducing unnecessary re-pulls and improving job startup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->