### PR TITLE
feat(mlflow): handle race conditions with mlflow

### DIFF
--- a/internal/eval_hub/mlflow/mlflow.go
+++ b/internal/eval_hub/mlflow/mlflow.go
@@ -188,35 +188,17 @@ func GetOrCreateExperimentID(mlflowClient *mlflowclient.Client, jobConfig *api.E
 		return "", "", serviceerrors.NewServiceError(messages.MLFlowRequestFailed, "Error", err.Error())
 	}
 
-	mlflowExperiment, err := mlflowClient.GetExperimentByName(jobConfig.Experiment.Name)
-	if err != nil {
-		if !mlflowclient.IsResourceDoesNotExistError(err) {
-			// This is some other error than "resource does not exist" so report it as an error
-			return "", "", serviceerrors.NewServiceError(messages.MLFlowRequestFailed, "Error", err.Error())
-		}
-	}
-
-	if mlflowExperiment != nil && mlflowExperiment.Experiment.LifecycleStage == "active" && mlflowExperiment.Experiment.ExperimentID != "" {
-		mlflowClient.GetLogger().Info("Found active experiment", "experiment_name", jobConfig.Experiment.Name, "experiment_id", mlflowExperiment.Experiment.ExperimentID)
-		// we found an active experiment with the given name so return the ID
-		return mlflowExperiment.Experiment.ExperimentID, mlflowClient.GetExperimentsURL(), nil
-	}
-
-	// There is a possibility that the experiment was created between the get and the create
-	// but we do not consider this worth taking into account as it is very unlikely to happen.
-
-	// create a new experiment as we did not find an active experiment with the given name
 	tags := injectEvaluationJobTags(jobId, jobConfig)
 	req := mlflowclient.CreateExperimentRequest{
 		Name:             jobConfig.Experiment.Name,
 		ArtifactLocation: jobConfig.Experiment.ArtifactLocation,
 		Tags:             tags,
 	}
-	resp, err := mlflowClient.CreateExperiment(&req)
+	mlflowExperiment, err := mlflowClient.GetOrCreateExperiment(&req)
 	if err != nil {
 		return "", "", serviceerrors.NewServiceError(messages.MLFlowRequestFailed, "Error", err.Error())
 	}
 
-	mlflowClient.GetLogger().Info("Created new experiment", "experiment_name", jobConfig.Experiment.Name, "experiment_id", resp.ExperimentID)
-	return resp.ExperimentID, mlflowClient.GetExperimentsURL(), nil
+	mlflowClient.GetLogger().Info("Resolved experiment", "experiment_name", jobConfig.Experiment.Name, "experiment_id", mlflowExperiment.Experiment.ExperimentID)
+	return mlflowExperiment.Experiment.ExperimentID, mlflowClient.GetExperimentsURL(), nil
 }

--- a/internal/eval_hub/mlflow/mlflow_test.go
+++ b/internal/eval_hub/mlflow/mlflow_test.go
@@ -295,6 +295,9 @@ func TestGetOrCreateExperimentID(t *testing.T) {
 		if !foundJobTag {
 			t.Fatal("expected evaluation_job_id tag on create request")
 		}
+		if getCalls != 2 {
+			t.Fatalf("getCalls = %d, want 2", getCalls)
+		}
 	})
 
 	t.Run("non-404 get error", func(t *testing.T) {

--- a/internal/eval_hub/mlflow/mlflow_test.go
+++ b/internal/eval_hub/mlflow/mlflow_test.go
@@ -245,10 +245,22 @@ func TestGetOrCreateExperimentID(t *testing.T) {
 	t.Run("creates experiment when missing", func(t *testing.T) {
 		t.Parallel()
 		var createBody mlflowclient.CreateExperimentRequest
+		var getCalls int
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
 			case "/api/2.0/mlflow/experiments/get-by-name":
-				http.Error(w, `{"error_code":"RESOURCE_DOES_NOT_EXIST","message":"not found"}`, http.StatusNotFound)
+				getCalls++
+				if getCalls == 1 {
+					http.Error(w, `{"error_code":"RESOURCE_DOES_NOT_EXIST","message":"not found"}`, http.StatusNotFound)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(mlflowclient.GetExperimentResponse{
+					Experiment: mlflowclient.Experiment{
+						ExperimentID:   "new-exp",
+						Name:           "demo",
+						LifecycleStage: "active",
+					},
+				})
 			case "/api/2.0/mlflow/experiments/create":
 				if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
 					t.Errorf("decode create body: %v", err)

--- a/pkg/mlflowclient/experiments.go
+++ b/pkg/mlflowclient/experiments.go
@@ -1,0 +1,47 @@
+package mlflowclient
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetOrCreateExperiment returns an active experiment by name, creating it when missing.
+// Idempotent when concurrent callers race to create the same experiment.
+func (c *Client) GetOrCreateExperiment(req *CreateExperimentRequest) (*GetExperimentResponse, error) {
+	if c == nil {
+		return nil, fmt.Errorf("mlflow client is nil")
+	}
+	if req == nil || strings.TrimSpace(req.Name) == "" {
+		return nil, fmt.Errorf("create experiment request is nil or missing name")
+	}
+	name := strings.TrimSpace(req.Name)
+
+	resp, err := c.GetExperimentByName(name)
+	if err == nil {
+		if isActiveExperiment(resp) {
+			return resp, nil
+		}
+	} else if !IsResourceDoesNotExistError(err) {
+		return nil, err
+	}
+
+	_, createErr := c.CreateExperiment(req)
+	if createErr != nil && !IsResourceAlreadyExistsError(createErr) {
+		return nil, createErr
+	}
+
+	resp, err = c.GetExperimentByName(name)
+	if err != nil {
+		return nil, err
+	}
+	if !isActiveExperiment(resp) {
+		return nil, fmt.Errorf("experiment %q is not active after create", name)
+	}
+	return resp, nil
+}
+
+func isActiveExperiment(resp *GetExperimentResponse) bool {
+	return resp != nil &&
+		resp.Experiment.LifecycleStage == "active" &&
+		resp.Experiment.ExperimentID != ""
+}

--- a/pkg/mlflowclient/experiments.go
+++ b/pkg/mlflowclient/experiments.go
@@ -15,6 +15,8 @@ func (c *Client) GetOrCreateExperiment(req *CreateExperimentRequest) (*GetExperi
 		return nil, fmt.Errorf("create experiment request is nil or missing name")
 	}
 	name := strings.TrimSpace(req.Name)
+	normalizedReq := *req
+	normalizedReq.Name = name
 
 	resp, err := c.GetExperimentByName(name)
 	if err == nil {
@@ -25,7 +27,7 @@ func (c *Client) GetOrCreateExperiment(req *CreateExperimentRequest) (*GetExperi
 		return nil, err
 	}
 
-	_, createErr := c.CreateExperiment(req)
+	_, createErr := c.CreateExperiment(&normalizedReq)
 	if createErr != nil && !IsResourceAlreadyExistsError(createErr) {
 		return nil, createErr
 	}

--- a/pkg/mlflowclient/experiments_test.go
+++ b/pkg/mlflowclient/experiments_test.go
@@ -1,0 +1,122 @@
+package mlflowclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetOrCreateExperiment(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns existing active experiment", func(t *testing.T) {
+		t.Parallel()
+		var createCalls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case endpointExperimentsGetByNameBase:
+				_ = json.NewEncoder(w).Encode(GetExperimentResponse{
+					Experiment: Experiment{
+						ExperimentID:   "exp-1",
+						Name:           "demo",
+						LifecycleStage: "active",
+					},
+				})
+			case endpointExperimentsCreate:
+				createCalls++
+				http.NotFound(w, r)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithContext(t.Context())
+		resp, err := client.GetOrCreateExperiment(&CreateExperimentRequest{Name: "demo"})
+		if err != nil {
+			t.Fatalf("GetOrCreateExperiment() = %v", err)
+		}
+		if resp.Experiment.ExperimentID != "exp-1" {
+			t.Fatalf("ExperimentID = %q, want exp-1", resp.Experiment.ExperimentID)
+		}
+		if createCalls != 0 {
+			t.Fatalf("createCalls = %d, want 0", createCalls)
+		}
+	})
+
+	t.Run("creates experiment when missing", func(t *testing.T) {
+		t.Parallel()
+		var getCalls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case endpointExperimentsGetByNameBase:
+				getCalls++
+				if getCalls == 1 {
+					http.Error(w, `{"error_code":"RESOURCE_DOES_NOT_EXIST"}`, http.StatusNotFound)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(GetExperimentResponse{
+					Experiment: Experiment{
+						ExperimentID:   "new-exp",
+						Name:           "demo",
+						LifecycleStage: "active",
+					},
+				})
+			case endpointExperimentsCreate:
+				_ = json.NewEncoder(w).Encode(CreateExperimentResponse{ExperimentID: "new-exp"})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithContext(t.Context())
+		resp, err := client.GetOrCreateExperiment(&CreateExperimentRequest{Name: "demo"})
+		if err != nil {
+			t.Fatalf("GetOrCreateExperiment() = %v", err)
+		}
+		if resp.Experiment.ExperimentID != "new-exp" {
+			t.Fatalf("ExperimentID = %q, want new-exp", resp.Experiment.ExperimentID)
+		}
+	})
+
+	t.Run("create races with RESOURCE_ALREADY_EXISTS", func(t *testing.T) {
+		t.Parallel()
+		var getCalls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case endpointExperimentsGetByNameBase:
+				getCalls++
+				if getCalls == 1 {
+					http.Error(w, `{"error_code":"RESOURCE_DOES_NOT_EXIST"}`, http.StatusNotFound)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(GetExperimentResponse{
+					Experiment: Experiment{
+						ExperimentID:   "race-exp",
+						Name:           "demo",
+						LifecycleStage: "active",
+					},
+				})
+			case endpointExperimentsCreate:
+				http.Error(w, `{"error_code":"RESOURCE_ALREADY_EXISTS"}`, http.StatusBadRequest)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		client := NewClient(srv.URL).WithContext(t.Context())
+		resp, err := client.GetOrCreateExperiment(&CreateExperimentRequest{Name: "demo"})
+		if err != nil {
+			t.Fatalf("GetOrCreateExperiment() = %v", err)
+		}
+		if resp.Experiment.ExperimentID != "race-exp" {
+			t.Fatalf("ExperimentID = %q, want race-exp", resp.Experiment.ExperimentID)
+		}
+		if getCalls != 2 {
+			t.Fatalf("getCalls = %d, want 2", getCalls)
+		}
+	})
+}

--- a/pkg/mlflowclient/workspaces.go
+++ b/pkg/mlflowclient/workspaces.go
@@ -146,7 +146,8 @@ func (c *Client) EnsureWorkspace() error {
 		return nil
 	}
 	if IsResourceAlreadyExistsError(err) {
-		return nil
+		_, getErr := c.GetWorkspace(name)
+		return getErr
 	}
 	return err
 }

--- a/pkg/mlflowclient/workspaces_test.go
+++ b/pkg/mlflowclient/workspaces_test.go
@@ -203,10 +203,16 @@ func TestEnsureWorkspace_edgeCases(t *testing.T) {
 
 	t.Run("create races with RESOURCE_ALREADY_EXISTS", func(t *testing.T) {
 		t.Parallel()
+		var getCalls int
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case r.Method == http.MethodGet && r.URL.Path == "/api/3.0/mlflow/workspaces/race-ws":
-				http.Error(w, `{"error_code":"RESOURCE_DOES_NOT_EXIST"}`, http.StatusNotFound)
+				getCalls++
+				if getCalls == 1 {
+					http.Error(w, `{"error_code":"RESOURCE_DOES_NOT_EXIST"}`, http.StatusNotFound)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(GetWorkspaceResponse{Workspace: Workspace{Name: "race-ws"}})
 			case r.Method == http.MethodPost && r.URL.Path == "/api/3.0/mlflow/workspaces":
 				http.Error(w, `{"error_code":"RESOURCE_ALREADY_EXISTS"}`, http.StatusBadRequest)
 			default:
@@ -218,6 +224,9 @@ func TestEnsureWorkspace_edgeCases(t *testing.T) {
 		client := NewClient(srv.URL).WithContext(t.Context()).WithWorkspacesSupport(true).WithWorkspace("race-ws")
 		if err := client.EnsureWorkspace(); err != nil {
 			t.Fatalf("EnsureWorkspace() = %v", err)
+		}
+		if getCalls != 2 {
+			t.Fatalf("getCalls = %d, want 2", getCalls)
 		}
 	})
 }


### PR DESCRIPTION
## What and why

- Added GetOrCreateExperiment method to the mlflowclient package, which retrieves an active experiment by name or creates it if it doesn't exist, handling concurrent creation scenarios.
- Updated the GetOrCreateExperimentID function to utilize the new method, simplifying the experiment retrieval logic.
- Introduced comprehensive unit tests for GetOrCreateExperiment, covering various scenarios including existing experiments and race conditions during creation.
- Enhanced existing tests in mlflow_test.go to validate the new behavior and ensure robustness.

Assisted-by: Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of experiment creation when concurrent requests attempt to create the same experiment simultaneously.
  * Enhanced workspace creation to properly validate resources after handling race conditions, ensuring accurate status reporting.
  * Strengthened MLflow integration reliability through better handling of resource creation edge cases.

* **Tests**
  * Added comprehensive test coverage for concurrent experiment creation scenarios and workspace race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->