### PR TITLE
feat(validate-configs): add configuration validation tool and CI workflow

### DIFF
--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -1,0 +1,22 @@
+name: Validate provider and collection configs
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  validate-configs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Validate bundled provider and collection YAML
+        run: go run ./cmd/validate_configs

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-mcp build-all-platforms cross-compile-mcp build-all-platforms-mcp start-service stop-service start-sidecar stop-sidecar lint test test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet update-deps generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components fvt-report docker-image-local docker-mcp-version test-mcp-build-all test-mcp-binary-info test-mcp-binary-naming test-mcp-version test-mcp-no-runtime-deps test-mcp-container-build test-mcp-container-http test-mcp-checksums test-mcp-formula-syntax test-mcp-native-smoke test-mcp-brew-install test-mcp-brew-test test-mcp-brew-uninstall test-mcp-cross-platform test-mcp-e2e test-mcp test-mcp-vscode test-help clean-mcp-wheels build-mcp-wheel build-all-mcp-wheels
+.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-mcp build-all-platforms cross-compile-mcp build-all-platforms-mcp start-service stop-service start-sidecar stop-sidecar lint validate-configs test test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet update-deps generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components fvt-report docker-image-local docker-mcp-version test-mcp-build-all test-mcp-binary-info test-mcp-binary-naming test-mcp-version test-mcp-no-runtime-deps test-mcp-container-build test-mcp-container-http test-mcp-checksums test-mcp-formula-syntax test-mcp-native-smoke test-mcp-brew-install test-mcp-brew-test test-mcp-brew-uninstall test-mcp-cross-platform test-mcp-e2e test-mcp test-mcp-vscode test-help clean-mcp-wheels build-mcp-wheel build-all-mcp-wheels
 
 GOPATH := $(shell go env GOPATH)
 GOBIN := $(shell go env GOPATH)/bin
@@ -146,6 +146,9 @@ lint: ## Lint the code (runs go vet)
 	@echo "Linting code..."
 	@go vet ./...
 	@echo "Lint complete"
+
+validate-configs: ## Validate bundled provider and collection YAML (standalone CLI, not part of build)
+	@go run ./cmd/validate_configs
 
 fmt: ## Format the code with go fmt
 	@echo "Formatting code with go fmt..."

--- a/cmd/validate_configs/main.go
+++ b/cmd/validate_configs/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
+	"github.com/eval-hub/eval-hub/internal/logging"
+)
+
+func main() {
+	configDir := flag.String("config-dir", "config", "Directory containing providers/ and collections/ subdirectories")
+	flag.Parse()
+
+	logger := logging.FallbackLogger()
+	validate := validation.NewValidator()
+
+	providers, err := config.LoadProviderConfigs(logger, validate, *configDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "provider configs: %v\n", err)
+		os.Exit(1)
+	}
+	if len(providers) == 0 {
+		fmt.Fprintln(os.Stderr, "provider configs: no providers loaded")
+		os.Exit(1)
+	}
+
+	collections, err := config.LoadCollectionConfigs(logger, validate, *configDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection configs: %v\n", err)
+		os.Exit(1)
+	}
+	if len(collections) == 0 {
+		fmt.Fprintln(os.Stderr, "collection configs: no collections loaded")
+		os.Exit(1)
+	}
+
+	providerIDs := sortedKeys(providers)
+	collectionIDs := sortedKeys(collections)
+
+	fmt.Printf("validated %d providers: %v\n", len(providers), providerIDs)
+	fmt.Printf("validated %d collections: %v\n", len(collections), collectionIDs)
+}
+
+func sortedKeys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return fmt.Sprint(keys[i]) < fmt.Sprint(keys[j])
+	})
+	return keys
+}


### PR DESCRIPTION
## What and why

Adds a standalone CLI tool (cmd/validate_configs) and a GitHub Actions workflow that validate the bundled provider and collection YAML files against the existing config.LoadProviderConfigs/config.LoadCollectionConfigs loaders and the validation.Validator.

Configuration errors in config/providers/ or config/collections/ (malformed YAML, missing required fields, invalid references) are currently only caught at server startup. This gate catches them at PR time.

The validation tool is invoked via go run in CI and make validate-configs locally , it is not compiled into the release binaries or included in the container image.

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

None, additive only. No changes to runtime behaviour or existing build targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration validation tool now validates provider and collection YAML files, displaying configuration counts and IDs upon successful validation.
  * Automatic validation triggered on pull requests via GitHub Actions.

* **Chores**
  * Added `make validate-configs` command for local configuration validation.
  * Configured GitHub Actions workflow supporting manual dispatch and main branch pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->