### PR TITLE
fix: delete orphaned K8s Job when ConfigMap is removed mid-creation

### DIFF
--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -253,6 +253,17 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 		Controller: boolPtr(true),
 	}
 	if err := r.helper.SetConfigMapOwner(ctx, configMap.Namespace, configMap.Name, ownerRef); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Race: hard_delete arrived during creation and removed the ConfigMap before the
+			// owner reference could be set. The K8s Job was created but can never mount the
+			// missing ConfigMap — delete it now to prevent an orphaned, permanently-stuck job.
+			logger.Warn("configmap deleted mid-creation (race with hard_delete) — cleaning up orphaned job",
+				"namespace", createdJob.Namespace, "job", createdJob.Name, "configmap", configMap.Name)
+			if delErr := r.helper.DeleteJob(ctx, createdJob.Namespace, createdJob.Name, metav1.DeleteOptions{}); delErr != nil && !apierrors.IsNotFound(delErr) {
+				logger.Error("failed to delete orphaned job", "namespace", createdJob.Namespace, "name", createdJob.Name, "error", delErr)
+			}
+			return nil
+		}
 		logger.Error("failed to set configmap owner reference", "namespace", configMap.Namespace, "name", configMap.Name, "error", err)
 	}
 	return nil

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -261,6 +261,7 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 				"namespace", createdJob.Namespace, "job", createdJob.Name, "configmap", configMap.Name)
 			if delErr := r.helper.DeleteJob(ctx, createdJob.Namespace, createdJob.Name, metav1.DeleteOptions{}); delErr != nil && !apierrors.IsNotFound(delErr) {
 				logger.Error("failed to delete orphaned job", "namespace", createdJob.Namespace, "name", createdJob.Name, "error", delErr)
+				return delErr
 			}
 			return nil
 		}

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -842,6 +842,35 @@ func TestCreateBenchmarkResourcesDeletesOrphanedJobWhenConfigMapDeletedMidCreati
 	}
 }
 
+func TestCreateBenchmarkResourcesReturnsErrorWhenOrphanedJobDeletionFails(t *testing.T) {
+	providerID := "provider-1"
+	evaluation := sampleEvaluation(providerID)
+
+	clientset := fake.NewClientset()
+	clientset.PrependReactor("get", "configmaps", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, action.(k8stesting.GetAction).GetName())
+	})
+	clientset.PrependReactor("delete", "jobs", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+		return true, nil, fmt.Errorf("job delete failed")
+	})
+
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+		serviceConfig: &config.Config{
+			Service: &config.ServiceConfig{
+				EvalInitImage: "eval-init-image",
+			},
+		},
+	}
+
+	storage := &fakeStorage{providerConfigs: sampleProviders(providerID)}
+	err := runtime.createBenchmarkResources(context.Background(), runtime.logger, evaluation, &evaluation.Benchmarks[0], 0, storage)
+	if err == nil {
+		t.Fatal("expected error when orphaned job deletion fails, got nil")
+	}
+}
+
 func sampleProviders(providerID string) map[string]api.ProviderResource {
 	return map[string]api.ProviderResource{
 		providerID: {

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/eval-hub/eval-hub/pkg/api"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -799,6 +801,44 @@ func sampleEvaluation(providerID string) *api.EvaluationJobResource {
 				Name: "exp-1",
 			},
 		},
+	}
+}
+
+// TestCreateBenchmarkResourcesDeletesOrphanedJobWhenConfigMapDeletedMidCreation verifies
+// that when SetConfigMapOwner fails with NotFound (the ConfigMap was hard-deleted by a
+// concurrent DELETE request between Job creation and owner-reference setup), the orphaned
+// K8s Job is cleaned up so it cannot remain stuck in a permanent FailedMount loop.
+func TestCreateBenchmarkResourcesDeletesOrphanedJobWhenConfigMapDeletedMidCreation(t *testing.T) {
+	providerID := "provider-1"
+	evaluation := sampleEvaluation(providerID)
+
+	clientset := fake.NewClientset()
+	// Simulate the race: ConfigMap GET inside SetConfigMapOwner returns NotFound,
+	// as if the ConfigMap was deleted by a concurrent hard_delete after Job creation.
+	clientset.PrependReactor("get", "configmaps", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, action.(k8stesting.GetAction).GetName())
+	})
+
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+		serviceConfig: &config.Config{
+			Service: &config.ServiceConfig{
+				EvalInitImage: "eval-init-image",
+			},
+		},
+	}
+
+	storage := &fakeStorage{providerConfigs: sampleProviders(providerID)}
+	err := runtime.createBenchmarkResources(context.Background(), runtime.logger, evaluation, &evaluation.Benchmarks[0], 0, storage)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// The orphaned K8s Job must be deleted to prevent it getting stuck in FailedMount.
+	jobs := listJobsByJobID(t, clientset, evaluation.Resource.ID)
+	if len(jobs) != 0 {
+		t.Fatalf("expected orphaned job to be deleted, got %d job(s)", len(jobs))
 	}
 }
 


### PR DESCRIPTION
When `hard_delete` arrives while the create goroutine is still running, the delete handler removes the ConfigMap before SetConfigMapOwner is called. The K8s Job is then created without its ConfigMap, causing pods to loop on FailedMount until BackoffLimitExceeded and the evalhub job stays stuck in 'running' indefinitely.

If SetConfigMapOwner returns NotFound, the ConfigMap was already deleted by a concurrent hard_delete. The orphaned Job is now deleted immediately to prevent the stuck-pod loop.

## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes # https://redhat.atlassian.net/browse/RHOAIENG-68242

Assisted-by: <!-- Cursor, Claude etc --> Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes job setup reliability by handling a mid-creation race where the ConfigMap is deleted, preventing orphaned, stuck jobs and reducing downstream failures.
* **Tests**
  * Added unit test coverage for the mid-creation deletion scenario and for the case where orphaned job cleanup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->