### PR TITLE
docs(examples): add end-to-end LLM evaluation notebook for OpenShift

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,9 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: ^docs/.*\.(html|json)$
+        exclude: (\.ipynb$|^docs/.*\.(html|json)$)
       - id: end-of-file-fixer
-        exclude: ^docs/.*\.(html|json)$
+        exclude: (\.ipynb$|^docs/.*\.(html|json)$)
       - id: check-yaml
         args: [--allow-multiple-documents]
       - id: check-json

--- a/examples/end_to_end_llm_evaluation_on_openshift.ipynb
+++ b/examples/end_to_end_llm_evaluation_on_openshift.ipynb
@@ -1,0 +1,1120 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# End-to-End LLM Evaluation on OpenShift: Benchmarks, MLflow, and OCI Exports\n\nThis notebook walks through running an LLM evaluation on an OpenShift cluster using the **`eval-hub-sdk[client]`** Python SDK. It covers tracking experiment results in MLflow and exporting evaluation artifacts to an OCI-compatible registry. By the end, you will have:\n\n1. Connected to an EvalHub instance using the **`eval-hub-sdk[client]`** Python client\n2. Submitted an evaluation job using the **lm_evaluation_harness** provider with the **arc_easy** benchmark\n3. Logged experiment results to **MLflow**\n4. Exported evaluation artifacts to an **OCI-compatible registry**\n\n## Prerequisites\n\n### Cluster Requirements\n\n- An OpenShift cluster with **EvalHub deployed**. See the [deployment guide](https://eval-hub.github.io/deployment/openshift-setup/) for setup instructions.\n- An LLM model endpoint accessible from the cluster, with its API key and CA certificate stored as a Kubernetes secret in the tenant namespace. See [model authentication](https://eval-hub.github.io/guides/model-authentication/) for details.\n- **MLflow** installed and configured with EvalHub. This is required for experiment tracking.\n- An **OCI-compatible registry** (e.g., Quay.io) for exporting result artifacts. See the [quickstart guide](https://eval-hub.github.io/getting-started/quickstart/#export-results-to-oci-registry).\n\n### Notebook Environment\n\nInstall the required Python packages:\n```bash\npip install \"eval-hub-sdk[client]\" \"oras\"\n```\n\n## Gather Connection Details\n\nThe values below are specific to your cluster. For example, assuming EvalHub is deployed in namespace `prabhu` and there is a service account `dataplane-sa` in the `dataplane` namespace:\n\n```bash\nexport EVALHUB_TENANT=\"dataplane\"\nexport TENANT_SA=\"dataplane-sa\"\nexport EVALHUB_SERVICE_NS=\"prabhu\"\n```\n\nGenerate a short-lived service account token:\n```bash\noc create token \"${TENANT_SA}\" -n \"${EVALHUB_TENANT}\" --duration=1h\n```\n\nGet the EvalHub route URL:\n```bash\necho \"https://$(oc get route evalhub -n \"${EVALHUB_SERVICE_NS}\" -o jsonpath='{.spec.host}')\"\n```\n\nSee the [multi-tenancy overview](https://eval-hub.github.io/architecture/multi-tenancy/#overview) for more details on tenants and service accounts."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "## Configure Connection\n",
+    "\n",
+    "Fill in the values below with the connection details gathered above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EvalHub service URL (from `oc get route`)\n",
+    "# e.g.\n",
+    "# evalhub_url = \"https://evalhub-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com\"\n",
+    "evalhub_url = \"...\"\n",
+    "\n",
+    "# Tenant namespace\n",
+    "# e.g.\n",
+    "# evalhub_tenant = \"dataplane\"\n",
+    "evalhub_tenant = \"...\"\n",
+    "\n",
+    "# Service account token (from `oc create token`)\n",
+    "evalhub_token = \"...\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import the EvalHub SDK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evalhub import (\n",
+    "    SyncEvalHubClient,\n",
+    "    JobSubmissionRequest,\n",
+    "    BenchmarkConfig,\n",
+    "    ModelConfig,\n",
+    "    JobStatus,\n",
+    "    ExperimentConfig,\n",
+    "    ExperimentTag,\n",
+    ")\n",
+    "from evalhub.models.api import ModelAuth"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect to EvalHub\n",
+    "\n",
+    "Create a client and verify the service is reachable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "TLS verification disabled - skipping CA bundle detection\n",
+      "TLS verification disabled (insecure mode)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ EvalHub is healthy: healthy\n",
+      "  Version: unknown\n",
+      "  Uptime: 0.0s\n"
+     ]
+    }
+   ],
+   "source": [
+    "client = SyncEvalHubClient(\n",
+    "    base_url=evalhub_url,\n",
+    "    auth_token=evalhub_token,\n",
+    "    insecure=True,\n",
+    "    tenant=evalhub_tenant,\n",
+    ")\n",
+    "try:\n",
+    "    # Check health\n",
+    "    health = client.health()\n",
+    "    print(f\"✓ EvalHub is healthy: {health['status']}\")\n",
+    "    print(f\"  Version: {health.get('version', 'unknown')}\")\n",
+    "    print(f\"  Uptime: {health.get('uptime_seconds', 0):.1f}s\")\n",
+    "except Exception as e:\n",
+    "    print(f\"✗ Failed to connect: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List Available Providers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Found 8 providers:\n",
+      "  - lm_evaluation_harness: LM Evaluation Harness\n",
+      "  - lighteval: Lighteval\n",
+      "  - guidellm: GuideLLM\n",
+      "  - garak: Garak\n",
+      "  - afc721e4-2cd9-4c93-8d9f-4379682f5792: SWE-bench\n",
+      "  - aebfd3ff-5d83-455b-afe6-6f5794f3876e: SWE-bench\n",
+      "  - 6c6c3340-c87a-4e0c-bb05-7256a536b207: SWE-bench\n",
+      "  - 370be638-8aa9-4e72-b384-feccb81579e8: SWE-bench\n"
+     ]
+    }
+   ],
+   "source": [
+    "providers = client.providers.list()\n",
+    "print(f\"✓ Found {len(providers)} providers:\")\n",
+    "for provider in providers:\n",
+    "    print(f\"  - {provider.resource.id}: {provider.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List Benchmarks for `lm_evaluation_harness`\n",
+    "\n",
+    "Query the available benchmarks under the provider we will use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "✓ Found 188 benchmarks for lm_evaluation_harness:\n",
+      "  - arc_easy: Basic science Q&A\n",
+      "  - AraDiCE_boolq_lev: Yes/no question answering (Levantine Arabic)\n",
+      "  - blimp: Grammar & syntax judgment\n",
+      "  - blimp_anaphor_gender_agreement: Pronoun gender matching\n",
+      "  - blimp_animate_subject_trans: Animacy constraints on verbs\n",
+      "  - blimp_coordinate_structure_constraint_complex_left_branch: Complex sentence structure\n",
+      "  - blimp_determiner_noun_agreement_2: Determiner-noun number agreement\n",
+      "  - blimp_determiner_noun_agreement_with_adj_2: Agreement across adjectives (variant 2)\n",
+      "  - blimp_determiner_noun_agreement_with_adjective_1: Agreement across adjectives (variant 1)\n",
+      "  - blimp_existential_there_object_raising: Existential construction (object)\n",
+      "  - blimp_existential_there_subject_raising: Existential construction (subject)\n",
+      "  - blimp_intransitive: Verb argument structure\n",
+      "  - blimp_irregular_plural_subject_verb_agreement_1: Irregular plural agreement\n",
+      "  - blimp_left_branch_island_simple_question: Question formation constraints\n",
+      "  - blimp_npi_present_2: Negative word licensing\n",
+      "  - blimp_passive_1: Passive voice understanding\n",
+      "  - AraDiCE_ArabicMMLU_egy: Academic knowledge (Egyptian Arabic)\n",
+      "  - AraDiCE_ArabicMMLU_high_humanities_history_lev: History knowledge (high school, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_high_humanities_philosophy_egy: Philosophy knowledge (high school, Egyptian)\n",
+      "  - AraDiCE_ArabicMMLU_high_language_arabic-language_lev: Arabic language proficiency (high school, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_lev: Academic knowledge (Levantine Arabic)\n",
+      "  - AraDiCE_ArabicMMLU_middle_humanities_islamic-studies_egy: Islamic studies knowledge (middle school, Egyptian)\n",
+      "  - AraDiCE_ArabicMMLU_middle_language_arabic-language_lev: Arabic language proficiency (middle school, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_na_humanities_islamic-studies_egy: Islamic studies knowledge (general, Egyptian)\n",
+      "  - AraDiCE_ArabicMMLU_na_language_arabic-language-general_lev: General Arabic proficiency (Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_na_other_driving-test_egy: Driving test knowledge (Egyptian Arabic)\n",
+      "  - AraDiCE_ArabicMMLU_na_other_general-knowledge_lev: General knowledge trivia (Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_primary_humanities_islamic-studies_egy: Islamic studies knowledge (primary, Egyptian)\n",
+      "  - AraDiCE_ArabicMMLU_primary_language_arabic-language_lev: Arabic language basics (primary, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_univ_other_management_egy: Business management knowledge (university, Egyptian)\n",
+      "  - AraDiCE_openbookqa_eng: Open-book science reasoning (English)\n",
+      "  - arabic_leaderboard_arabic_mt_boolq: Yes/no comprehension in Arabic\n",
+      "  - arabic_leaderboard_arabic_mt_boolq_light: Yes/no comprehension in Arabic (light)\n",
+      "  - arabic_mt_boolq_light: Yes/no comprehension (Arabic MT, light)\n",
+      "  - leaderboard_bbh_salient_translation_error_detection: Translation error detection\n",
+      "  - aclue_ancient_chinese_culture: Ancient Chinese cultural knowledge\n",
+      "  - african_flores: African language translation quality\n",
+      "  - afrixnli-irokobench: Cross-lingual inference (African languages)\n",
+      "  - afrixnli_amh_prompt_2: Textual inference in Amharic (p2)\n",
+      "  - afrixnli_amh_prompt_5: Textual inference in Amharic (p5)\n",
+      "  - afrixnli_en_direct_ewe: Textual inference in Ewe\n",
+      "  - afrixnli_en_direct_ibo: Textual inference in Igbo\n",
+      "  - afrixnli_en_direct_lug: Textual inference in Luganda\n",
+      "  - afrixnli_en_direct_sot: Textual inference in Sesotho\n",
+      "  - afrixnli_en_direct_wol: Textual inference in Wolof\n",
+      "  - afrixnli_en_direct_zul: Textual inference in Zulu\n",
+      "  - AraDiCE_ArabicMMLU_primary_stem_math_egy: Primary math skills (Egyptian Arabic)\n",
+      "  - arabic_leaderboard_arabic_mmlu_college_mathematics_light: College math in Arabic (light)\n",
+      "  - arabic_leaderboard_arabic_mmlu_high_school_mathematics: High school math in Arabic\n",
+      "  - cmmlu_college_mathematics: College math in Chinese\n",
+      "  - cmmlu_high_school_mathematics: High school math in Chinese\n",
+      "  - global_mmlu_full_am_high_school_mathematics: High school math in Amharic\n",
+      "  - global_mmlu_full_ar_high_school_mathematics: High school math in Arabic\n",
+      "  - global_mmlu_full_bn_high_school_mathematics: High school math in Bengali\n",
+      "  - global_mmlu_full_cs_high_school_mathematics: High school math in Czech\n",
+      "  - global_mmlu_full_de_high_school_mathematics: High school math in German\n",
+      "  - global_mmlu_full_el_high_school_mathematics: High school math in Greek\n",
+      "  - global_mmlu_full_en_high_school_mathematics: High school math in English\n",
+      "  - global_mmlu_full_es_high_school_mathematics: High school math in Spanish\n",
+      "  - global_mmlu_full_fa_high_school_mathematics: High school math in Persian\n",
+      "  - global_mmlu_full_fil_high_school_mathematics: High school math in Filipino\n",
+      "  - AraDiCE_piqa_lev: Physical intuition in Levantine Arabic\n",
+      "  - AraDiCE_winogrande_eng: Pronoun resolution (English, AraDiCE)\n",
+      "  - arabic_leaderboard_arabic_mt_copa: Cause & effect reasoning in Arabic\n",
+      "  - arabic_leaderboard_arabic_mt_copa_light: Cause & effect reasoning in Arabic (light)\n",
+      "  - arabic_leaderboard_arabic_mt_hellaswag: Activity completion in Arabic\n",
+      "  - arabic_leaderboard_arabic_mt_hellaswag_light: Activity completion in Arabic (light)\n",
+      "  - arabic_leaderboard_arabic_mt_piqa: Physical intuition in Arabic\n",
+      "  - arabic_leaderboard_arabic_mt_piqa_light: Physical intuition in Arabic (light)\n",
+      "  - arabic_mt_hellaswag: Activity completion (Arabic MT)\n",
+      "  - arabic_mt_piqa: Physical intuition (Arabic MT)\n",
+      "  - copa_ar: Cause & effect reasoning (Arabic)\n",
+      "  - copal_id_colloquial: Cause & effect reasoning (colloquial Indonesian)\n",
+      "  - darijahellaswag: Activity completion in Moroccan Arabic\n",
+      "  - egyhellaswag: Activity completion in Egyptian Arabic\n",
+      "  - hellaswag_ar: Activity completion in Standard Arabic\n",
+      "  - arabic_leaderboard_arabic_mt_race: Passage comprehension in Arabic\n",
+      "  - arabic_leaderboard_arabic_mt_race_light: Passage comprehension in Arabic (light)\n",
+      "  - arabic_mt_race_light: Passage comprehension (Arabic MT, light)\n",
+      "  - blimp_drop_argument: Implicit argument understanding\n",
+      "  - bigbench_gre_reading_comprehension_multiple_choice: Graduate-level passage analysis\n",
+      "  - eus_reading: Reading comprehension in Basque\n",
+      "  - longbench_qasper: Long-document Q&A (scientific papers)\n",
+      "  - qasper_freeform: Open-ended scientific paper Q&A\n",
+      "  - ruler_qa_squad: Long-context extractive Q&A\n",
+      "  - scrolls_qasper: Long-document comprehension (SCROLLS)\n",
+      "  - AraDiCE_ArabicMMLU_high_social-science_economics_egy: Economics knowledge (high school, Egyptian)\n",
+      "  - AraDiCE_ArabicMMLU_high_social-science_geography_lev: Geography knowledge (high school, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_high_stem_computer-science_egy: Computer science knowledge (high school, Egyptian)\n",
+      "  - AraDiCE_ArabicMMLU_high_stem_physics_lev: Physics knowledge (high school, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_middle_social-science_civics_egy: Civics knowledge (middle school, Egyptian)\n",
+      "  - AraDiCE_ArabicMMLU_middle_social-science_economics_lev: Economics knowledge (middle school, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_middle_social-science_social-science_egy: Social science knowledge (middle school, Egyptian)\n",
+      "  - AraDiCE_ArabicMMLU_middle_stem_computer-science_lev: Computer science knowledge (middle school, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_primary_social-science_geography_egy: Geography basics (primary, Egyptian)\n",
+      "  - AraDiCE_ArabicMMLU_primary_social-science_social-science_lev: Social science basics (primary, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_primary_stem_natural-science_lev: Natural science basics (primary, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_univ_social-science_accounting_lev: Accounting knowledge (university, Levantine)\n",
+      "  - AraDiCE_ArabicMMLU_univ_social-science_political-science_egy: Political science knowledge (university, Egyptian)\n",
+      "  - AraDiCE_ArabicMMLU_univ_stem_computer-science_lev: Computer science knowledge (university, Levantine)\n",
+      "  - arabic_leaderboard_arabic_mmlu_college_biology_light: College biology in Arabic (light)\n",
+      "  - agieval_logiqa_zh: Formal logic (Chinese civil service)\n",
+      "  - bbh: Hard multi-step reasoning\n",
+      "  - bbh_cot_fewshot: Hard reasoning with worked examples\n",
+      "  - bbh_cot_fewshot_causal_judgement: Causal responsibility judgment (5-shot)\n",
+      "  - bbh_cot_fewshot_dyck_languages: Bracket matching & parsing (5-shot)\n",
+      "  - bbh_cot_fewshot_hyperbaton: Adjective order judgment (5-shot)\n",
+      "  - bbh_cot_fewshot_logical_deduction_three_objects: Ordering puzzle — 3 objects (5-shot)\n",
+      "  - bbh_cot_fewshot_navigate: Spatial navigation tracking (5-shot)\n",
+      "  - bbh_cot_fewshot_reasoning_about_colored_objects: Object attribute reasoning (5-shot)\n",
+      "  - bbh_cot_fewshot_snarks: Sarcasm detection (5-shot)\n",
+      "  - bbh_cot_fewshot_tracking_shuffled_objects_five_objects: Object position tracking — 5 items (5-shot)\n",
+      "  - bbh_cot_fewshot_web_of_lies: Truth-value chain evaluation (5-shot)\n",
+      "  - bbh_cot_zeroshot: Hard reasoning without examples\n",
+      "  - bbh_cot_zeroshot_causal_judgement: Causal responsibility judgment (zero-shot)\n",
+      "  - bbh_cot_zeroshot_dyck_languages: Bracket matching & parsing (zero-shot)\n",
+      "  - arabic_leaderboard_arabic_mmlu_anatomy: Human anatomy knowledge in Arabic\n",
+      "  - arabic_leaderboard_arabic_mmlu_clinical_knowledge: Clinical medicine knowledge in Arabic\n",
+      "  - arabic_leaderboard_arabic_mmlu_medical_genetics: Medical genetics knowledge in Arabic\n",
+      "  - arabic_leaderboard_arabic_mmlu_professional_medicine: Professional medicine in Arabic\n",
+      "  - cmmlu_professional_medicine: Professional medicine in Chinese\n",
+      "  - cmmlu_traditional_chinese_medicine: Traditional Chinese medicine\n",
+      "  - global_mmlu_full_am_anatomy: Human anatomy in Amharic\n",
+      "  - global_mmlu_full_am_clinical_knowledge: Clinical medicine in Amharic\n",
+      "  - global_mmlu_full_am_medical_genetics: Medical genetics in Amharic\n",
+      "  - global_mmlu_full_am_professional_medicine: Professional medicine in Amharic\n",
+      "  - global_mmlu_full_ar_anatomy: Human anatomy in Arabic\n",
+      "  - global_mmlu_full_ar_clinical_knowledge: Clinical medicine in Arabic\n",
+      "  - global_mmlu_full_ar_medical_genetics: Medical genetics in Arabic\n",
+      "  - global_mmlu_full_ar_professional_medicine: Professional medicine in Arabic\n",
+      "  - global_mmlu_full_bn_anatomy: Human anatomy in Bengali\n",
+      "  - lambada_openai: Final word prediction (English)\n",
+      "  - lambada_openai_mt_en: Final word prediction (English MT)\n",
+      "  - lambada_openai_mt_it: Final word prediction (Italian)\n",
+      "  - lambada_openai_mt_stablelm_es: Final word prediction (Spanish)\n",
+      "  - lambada_openai_mt_stablelm_nl: Final word prediction (Dutch)\n",
+      "  - lambada_standard_cloze_yaml: Cloze-style word prediction\n",
+      "  - paloma_wikitext_103: Wikipedia text modeling (Paloma)\n",
+      "  - pile_arxiv: Academic paper modeling\n",
+      "  - pile_freelaw: Legal document modeling\n",
+      "  - pile_hackernews: Tech discussion modeling\n",
+      "  - pile_openwebtext2: Web text modeling\n",
+      "  - pile_ubuntu-irc: Technical chat modeling\n",
+      "  - pile_youtubesubtitles: Spoken language modeling\n",
+      "  - wikitext: Wikipedia article modeling\n",
+      "  - careqa_open_perplexity: Healthcare Q&A text modeling\n",
+      "  - AraDiCE_truthfulqa_mc1_lev: Truthfulness test (Levantine Arabic, MC)\n",
+      "  - metabench_truthfulqa_permute: Truthfulness under answer reordering\n",
+      "  - nortruthfulqa_gen_nno_p0: Truthful generation (Norwegian Nynorsk, p0)\n",
+      "  - nortruthfulqa_gen_nno_p3: Truthful generation (Norwegian Nynorsk, p3)\n",
+      "  - nortruthfulqa_gen_nob_p1: Truthful generation (Norwegian Bokmål, p1)\n",
+      "  - nortruthfulqa_gen_nob_p4: Truthful generation (Norwegian Bokmål, p4)\n",
+      "  - nortruthfulqa_mc_nno_p2: Truthfulness test (Norwegian Nynorsk, MC)\n",
+      "  - nortruthfulqa_mc_nob_p0: Truthfulness test (Norwegian Bokmål, MC, p0)\n",
+      "  - nortruthfulqa_mc_nob_p3: Truthfulness test (Norwegian Bokmål, MC, p3)\n",
+      "  - tinyTruthfulQA: Quick truthfulness check\n",
+      "  - truthfulqa-multi_gen_ca: Truthful generation (Catalan)\n",
+      "  - truthfulqa-multi_gen_eu: Truthful generation (Basque)\n",
+      "  - truthfulqa-multi_mc1_en: Truthfulness test (English, single answer)\n",
+      "  - truthfulqa-multi_mc1_gl: Truthfulness test (Galician, single answer)\n",
+      "  - truthfulqa-multi_mc2_es: Truthfulness test (Spanish, multi-answer)\n",
+      "  - bigbench_code_line_description_multiple_choice: Code line explanation\n",
+      "  - ceval-valid_college_programming: Programming concepts (Chinese)\n",
+      "  - code2text_javascript: JavaScript code summarization\n",
+      "  - code2text_ruby: Ruby code summarization\n",
+      "  - humaneval: Python function generation\n",
+      "  - humaneval_instruct: Python function generation (chat format)\n",
+      "  - mbpp: Basic Python problem solving\n",
+      "  - leaderboard_ifeval: Precise instruction adherence\n",
+      "  - leaderboard_bbh: Hard multi-step reasoning (leaderboard)\n",
+      "  - leaderboard_gpqa: Expert-level science questions\n",
+      "  - leaderboard_mmlu_pro: Graduate-level multidomain reasoning\n",
+      "  - leaderboard_musr: Long-narrative logical reasoning\n",
+      "  - leaderboard_math_hard: Advanced competition math\n",
+      "  - bbq: Ambiguity & social bias Q&A\n",
+      "  - crows_pairs_english: Social bias & stereotyping detection\n",
+      "  - ethics_cm: Commonsense moral judgment\n",
+      "  - toxigen: Implicit toxicity detection\n",
+      "  - truthfulqa_mc1: Misconception resistance (multiple choice)\n",
+      "  - bigbench_hhh_alignment_multiple_choice: Helpfulness, honesty & harmlessness (HHH)\n",
+      "  - winogender: Gender bias in pronoun resolution\n",
+      "  - gsm8k_platinum_cot_llama: GSM8k-Platinum (CoT, Llama chat format)\n",
+      "  - mmlu_cot_llama: MMLU with chain-of-thought (Llama chat format)\n",
+      "  - ifeval: Instruction Following Evaluation (IFEval)\n",
+      "  - mrcr: Multi-step Retrieval and Comprehension Reasoning (MRCR — 1 needle)\n",
+      "  - mrcr_2needle: MRCR — 2-needle retrieval\n",
+      "  - mrcr_4needle: MRCR — 4-needle retrieval\n",
+      "  - mrcr_8needle: MRCR — 8-needle retrieval\n"
+     ]
+    }
+   ],
+   "source": [
+    "provider_id = \"lm_evaluation_harness\"\n",
+    "benchmarks = client.benchmarks.list(provider_id=provider_id)\n",
+    "print(f\"\\n✓ Found {len(benchmarks)} benchmarks for {provider_id}:\")\n",
+    "for benchmark in benchmarks:\n",
+    "    print(f\"  - {benchmark.id}: {benchmark.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure the Model\n",
+    "\n",
+    "Provide the URL, name, and Kubernetes secret for the model you want to evaluate. The secret must exist in the tenant namespace and contain the API key (and optionally a CA certificate). See the [model authentication guide](https://eval-hub.github.io/guides/model-authentication/#scenario-1-api-key-and-ca-certificate) for how to create one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# e.g.\n",
+    "# model_url = \"https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1\"\n",
+    "# model_secret = \"vllm-llama-api-key\"\n",
+    "# model_name = \"meta-llama/Llama-3.2-1B-Instruct\"\n",
+    "\n",
+    "model_url = \"...\"\n",
+    "model_secret = \"...\"\n",
+    "model_name = \"...\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Submit an Evaluation Job\n",
+    "\n",
+    "Configure and submit a job that runs the `arc_easy` benchmark using `lm_evaluation_harness`, logs results to MLflow, and exports artifacts to an OCI registry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this is the benchmark id, you can find it from the list of benchmarks above\n",
+    "benchmark_id = \"arc_easy\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `lm_evaluation_harness` framework requires a tokenizer. Here we use `google/flan-t5-small` — replace it with a tokenizer appropriate for your model if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tokenizer_model = \"google/flan-t5-small\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The job name of your choice\n",
+    "job_name = \"my-ev-job1\"\n",
+    "\n",
+    "# The MLFlow experiment name of your choice\n",
+    "mlflow_experiment_name = \"my-exp1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure OCI Export\n",
+    "\n",
+    "To export result artifacts to an OCI registry, create a `docker-registry` secret with write access to the target repository and make it available in the tenant namespace. See the [OCI export documentation](https://eval-hub.github.io/getting-started/quickstart/#export-results-to-oci-registry) for details.\n",
+    "\n",
+    "```bash\n",
+    "oc create secret docker-registry my-oci-creds \\\n",
+    "    --docker-server=quay.io \\\n",
+    "    --docker-username=<username> \\\n",
+    "    --docker-password=<password> \\\n",
+    "    --namespace <tenant-namespace>\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oci_registry_url = \"quay.io\"\n",
+    "\n",
+    "# e.g.\n",
+    "# oci_registry_repo = \"gnaulak/testp1/eval-results\"\n",
+    "# oci_registry_secret = \"my-oci-creds-b\"\n",
+    "\n",
+    "oci_registry_repo = \"...\"\n",
+    "oci_registry_secret = \"...\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evalhub import EvaluationExports, EvaluationExportsOCI, OCIConnectionConfig, OCICoordinates\n",
+    "\n",
+    "job_request = JobSubmissionRequest(\n",
+    "    name=job_name,\n",
+    "    model=ModelConfig(\n",
+    "        url=model_url, name=model_name, auth=ModelAuth(secret_ref=model_secret)\n",
+    "    ),\n",
+    "    benchmarks=[\n",
+    "        BenchmarkConfig(\n",
+    "            id=benchmark_id,\n",
+    "            provider_id=provider_id,\n",
+    "            parameters={\n",
+    "                \"num_examples\": 5,\n",
+    "                \"tokenizer\": tokenizer_model,\n",
+    "            },\n",
+    "        )\n",
+    "    ],\n",
+    "    experiment=ExperimentConfig(\n",
+    "        name=mlflow_experiment_name,\n",
+    "        tags=[\n",
+    "            ExperimentTag(key=\"env\", value=\"dev\"),\n",
+    "        ],\n",
+    "    ),\n",
+    "    exports=EvaluationExports(\n",
+    "        oci=EvaluationExportsOCI(\n",
+    "            coordinates=OCICoordinates(\n",
+    "                oci_host=oci_registry_url,\n",
+    "                oci_repository=oci_registry_repo,\n",
+    "            ),\n",
+    "            k8s=OCIConnectionConfig(\n",
+    "                connection=oci_registry_secret,\n",
+    "            ),\n",
+    "        )\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "job = client.jobs.submit(job_request)\n",
+    "submitted_job_id = job.id\n",
+    "print(f\"✓ Job submitted successfully\")\n",
+    "print(f\"  Job ID: {submitted_job_id}\")\n",
+    "print(f\"  State: {job.state}\")\n",
+    "print(f\"  Created: {job.resource.created_at}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "✓ Current job state: JobStatus.PENDING\n",
+      "  Message: Evaluation job created\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check status\n",
+    "updated_job = client.jobs.get(submitted_job_id)\n",
+    "print(f\"\\n✓ Current job state: {updated_job.state}\")\n",
+    "if updated_job.status and updated_job.status.message:\n",
+    "    print(f\"  Message: {updated_job.status.message.message}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wait for the Job to Complete\n",
+    "\n",
+    "Poll the job status until it reaches `COMPLETED` or `FAILED`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "✓ Current job state: JobStatus.PENDING\n",
+      "\n",
+      "✓ Current job state: JobStatus.PENDING\n",
+      "\n",
+      "✓ Current job state: JobStatus.RUNNING\n",
+      "\n",
+      "✓ Current job state: JobStatus.RUNNING\n",
+      "✓ Job completed successfully\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "while updated_job.state not in (JobStatus.COMPLETED, JobStatus.FAILED):\n",
+    "    print(f\"\\n✓ Current job state: {updated_job.state}\")\n",
+    "    time.sleep(5)\n",
+    "    updated_job = client.jobs.get(submitted_job_id)\n",
+    "\n",
+    "if updated_job.state == JobStatus.FAILED:\n",
+    "    if updated_job.status and updated_job.status.message:\n",
+    "        print(f\"Job failed: {updated_job.status.message.message}\")\n",
+    "    else:\n",
+    "        print(\"Job failed: Unknown\")\n",
+    "else:\n",
+    "    print(f\"✓ Job completed successfully\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect the Completed Job\n",
+    "\n",
+    "Dump the full job object to see all fields including status, results, experiment metadata, and export details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"resource\": {\n",
+      "    \"id\": \"5db449a4-5bc0-4ba7-8106-aaa20e3019f7\",\n",
+      "    \"tenant\": \"dataplane\",\n",
+      "    \"created_at\": \"2026-06-16T05:19:47.705471Z\",\n",
+      "    \"updated_at\": \"2026-06-16T05:20:09.516827Z\",\n",
+      "    \"mlflow_experiment_id\": \"2\",\n",
+      "    \"message\": null\n",
+      "  },\n",
+      "  \"status\": {\n",
+      "    \"state\": \"completed\",\n",
+      "    \"message\": {\n",
+      "      \"message\": \"Evaluation job is completed\",\n",
+      "      \"message_code\": \"evaluation_job_updated\"\n",
+      "    },\n",
+      "    \"benchmarks\": [\n",
+      "      {\n",
+      "        \"id\": \"arc_easy\",\n",
+      "        \"provider_id\": \"lm_evaluation_harness\",\n",
+      "        \"benchmark_index\": 0,\n",
+      "        \"status\": \"completed\",\n",
+      "        \"error_message\": null,\n",
+      "        \"started_at\": null,\n",
+      "        \"completed_at\": \"2026-06-16T05:20:07.643559Z\"\n",
+      "      }\n",
+      "    ]\n",
+      "  },\n",
+      "  \"results\": {\n",
+      "    \"benchmarks\": [\n",
+      "      {\n",
+      "        \"id\": \"arc_easy\",\n",
+      "        \"provider_id\": \"lm_evaluation_harness\",\n",
+      "        \"benchmark_index\": 0,\n",
+      "        \"metrics\": {\n",
+      "          \"acc\": 0.2,\n",
+      "          \"acc_norm\": 0.2,\n",
+      "          \"acc_norm_stderr\": 0.20000000000000004,\n",
+      "          \"acc_stderr\": 0.20000000000000004\n",
+      "        },\n",
+      "        \"artifacts\": {\n",
+      "          \"evalhub.env_card\": {\n",
+      "            \"aggregate_results\": {},\n",
+      "            \"autograder_bias\": {},\n",
+      "            \"capture_completeness\": 0.15,\n",
+      "            \"confidence_intervals\": {},\n",
+      "            \"cpu_model\": \"x86_64\",\n",
+      "            \"custom\": {},\n",
+      "            \"k8s_pod_labels\": {},\n",
+      "            \"k8s_resource_limits\": {},\n",
+      "            \"key_packages\": {\n",
+      "              \"lm_eval\": \"0.4.8\",\n",
+      "              \"torch\": \"2.6.0\",\n",
+      "              \"transformers\": \"4.48.0\"\n",
+      "            },\n",
+      "            \"os_info\": \"Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34\",\n",
+      "            \"per_task_results\": {},\n",
+      "            \"python_version\": \"3.11.13\",\n",
+      "            \"scorer_ids\": []\n",
+      "          },\n",
+      "          \"oci_digest\": \"sha256:e50fdf9d0b643efb8325e077c92cf6ab4fb0a14625718a120975d86390024e98\",\n",
+      "          \"oci_reference\": \"quay.io/gnaulak/testp1/eval-results:evalhub-9ffbfa2a10f1a273deb1df678f1ac70cda1962ca89b62d049de3428cfeb4948a@sha256:e50fdf9d0b643efb8325e077c92cf6ab4fb0a14625718a120975d86390024e98\"\n",
+      "        },\n",
+      "        \"mlflow_run_id\": \"e8f8926ec4de44bcaa5d7c9141cb9e6b\",\n",
+      "        \"logs_path\": null\n",
+      "      }\n",
+      "    ],\n",
+      "    \"mlflow_experiment_url\": \"https://mlflow.opendatahub.svc.cluster.local:8443/api/2.0/mlflow/experiments\"\n",
+      "  },\n",
+      "  \"name\": \"my-ev-job1\",\n",
+      "  \"description\": null,\n",
+      "  \"tags\": [],\n",
+      "  \"model\": {\n",
+      "    \"url\": \"https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1\",\n",
+      "    \"name\": \"meta-llama/Llama-3.2-1B-Instruct\",\n",
+      "    \"auth\": {\n",
+      "      \"secret_ref\": \"vllm-llama-api-key\"\n",
+      "    }\n",
+      "  },\n",
+      "  \"benchmarks\": [\n",
+      "    {\n",
+      "      \"id\": \"arc_easy\",\n",
+      "      \"provider_id\": \"lm_evaluation_harness\",\n",
+      "      \"parameters\": {\n",
+      "        \"num_examples\": 5,\n",
+      "        \"tokenizer\": \"google/flan-t5-small\"\n",
+      "      },\n",
+      "      \"test_data_ref\": null\n",
+      "    }\n",
+      "  ],\n",
+      "  \"collection\": null,\n",
+      "  \"experiment\": {\n",
+      "    \"name\": \"my-exp1\",\n",
+      "    \"tags\": [\n",
+      "      {\n",
+      "        \"key\": \"env\",\n",
+      "        \"value\": \"dev\"\n",
+      "      }\n",
+      "    ],\n",
+      "    \"artifact_location\": null\n",
+      "  },\n",
+      "  \"exports\": {\n",
+      "    \"oci\": {\n",
+      "      \"coordinates\": {\n",
+      "        \"oci_host\": \"quay.io\",\n",
+      "        \"oci_repository\": \"gnaulak/testp1/eval-results\",\n",
+      "        \"oci_tag\": null,\n",
+      "        \"oci_subject\": null,\n",
+      "        \"annotations\": {}\n",
+      "      },\n",
+      "      \"k8s\": {\n",
+      "        \"connection\": \"my-oci-creds-b\"\n",
+      "      }\n",
+      "    }\n",
+      "  },\n",
+      "  \"queue\": null\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(updated_job.model_dump_json(indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Benchmark Metrics\n",
+    "\n",
+    "Extract the metrics returned by the `arc_easy` benchmark."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Benchmark metrics:\", updated_job.results.benchmarks[0].metrics)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### MLflow Run ID\n",
+    "\n",
+    "The evaluation results are also logged to MLflow. Use the run ID below to find the run in the MLflow UI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'e8f8926ec4de44bcaa5d7c9141cb9e6b'"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "updated_job.results.benchmarks[0].mlflow_run_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The MLflow experiment `my-exp1` (the name we provided) with this run ID will be visible in the MLflow UI under the tenant's workspace."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Verify OCI Registry Export\n",
+    "\n",
+    "The evaluation artifacts were exported to the OCI registry. Let's verify by fetching the OCI manifest and inspecting the contents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'quay.io/gnaulak/testp1/eval-results:evalhub-9ffbfa2a10f1a273deb1df678f1ac70cda1962ca89b62d049de3428cfeb4948a@sha256:e50fdf9d0b643efb8325e077c92cf6ab4fb0a14625718a120975d86390024e98'"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oci_reference = updated_job.results.benchmarks[0].artifacts[\"oci_reference\"]\n",
+    "oci_reference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OCI registry credentials for verification (used by the oras client below)\n",
+    "# e.g.\n",
+    "# oci_username = \"<oci-username>\"\n",
+    "# oci_password = \"<oci-password>\"\n",
+    "oci_username = \"...\"\n",
+    "oci_password = \"...\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Manifest:\n",
+      "{\n",
+      "  \"schemaVersion\": 2,\n",
+      "  \"mediaType\": \"application/vnd.oci.image.manifest.v1+json\",\n",
+      "  \"artifactType\": \"application/vnd.eval-hub.github.io\",\n",
+      "  \"config\": {\n",
+      "    \"mediaType\": \"application/vnd.oci.image.config.v1+json\",\n",
+      "    \"size\": 299,\n",
+      "    \"digest\": \"sha256:978ec14d5e685db5e2035705ad1589f1b40f8a72fd9d218fe0d363a1f445db1b\"\n",
+      "  },\n",
+      "  \"layers\": [\n",
+      "    {\n",
+      "      \"mediaType\": \"application/vnd.oci.image.layer.v1.tar+gzip\",\n",
+      "      \"size\": 1146,\n",
+      "      \"digest\": \"sha256:40bb1706f33b8b559a430fcb38e468c8960ffd3d7f0fc2f0427318b9a95293f5\",\n",
+      "      \"annotations\": {\n",
+      "        \"olot.layer.content.name\": \"results_5db449a4-5bc0-4ba7-8106-aaa20e3019f7.json\"\n",
+      "      }\n",
+      "    }\n",
+      "  ],\n",
+      "  \"annotations\": {\n",
+      "    \"io.github.eval-hub.job_id\": \"5db449a4-5bc0-4ba7-8106-aaa20e3019f7\",\n",
+      "    \"io.github.eval-hub.benchmark_id\": \"arc_easy\",\n",
+      "    \"io.github.eval-hub.provider_id\": \"lm_evaluation_harness\",\n",
+      "    \"org.opencontainers.image.created\": \"2026-06-16T05:20:07.650508+00:00\",\n",
+      "    \"io.github.eval-hub.benchmark\": \"arc_easy\",\n",
+      "    \"io.github.eval-hub.model\": \"meta-llama/Llama-3.2-1B-Instruct\"\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import oras.client\n",
+    "import json\n",
+    "import tempfile\n",
+    "import os\n",
+    "\n",
+    "oras_client = oras.client.OrasClient()\n",
+    "oras_client.login(\n",
+    "    hostname=\"quay.io\",\n",
+    "    username=oci_username,\n",
+    "    password=oci_password,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# get manifest from oci_reference\n",
+    "manifest = oras_client.get_manifest(oci_reference)\n",
+    "print(f\"\\nManifest:\\n{json.dumps(manifest, indent=2)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pull and Inspect Artifact Contents\n",
+    "\n",
+    "Pull the OCI artifact and extract the evaluation results JSON from the tarball."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pulled 1 files:\n",
+      "\n",
+      "--- sha256:40bb1706f33b8b559a430fcb38e468c8960ffd3d7f0fc2f0427318b9a95293f5 ---\n",
+      "{\n",
+      "  \"id\": \"5db449a4-5bc0-4ba7-8106-aaa20e3019f7\",\n",
+      "  \"benchmark_id\": \"arc_easy\",\n",
+      "  \"benchmark_index\": 0,\n",
+      "  \"model_name\": \"meta-llama/Llama-3.2-1B-Instruct\",\n",
+      "  \"results\": [\n",
+      "    {\n",
+      "      \"metric_name\": \"acc\",\n",
+      "      \"metric_value\": 0.2,\n",
+      "      \"metric_type\": \"float\",\n",
+      "      \"confidence_interval\": null,\n",
+      "      \"num_samples\": null,\n",
+      "      \"metadata\": {}\n",
+      "    },\n",
+      "    {\n",
+      "      \"metric_name\": \"acc_stderr\",\n",
+      "      \"metric_value\": 0.20000000000000004,\n",
+      "      \"metric_type\": \"float\",\n",
+      "      \"confidence_interval\": null,\n",
+      "      \"num_samples\": null,\n",
+      "      \"metadata\": {}\n",
+      "    },\n",
+      "    {\n",
+      "      \"metric_name\": \"acc_norm\",\n",
+      "      \"metric_value\": 0.2,\n",
+      "      \"metric_type\": \"float\",\n",
+      "      \"confidence_interval\": null,\n",
+      "      \"num_samples\": null,\n",
+      "      \"metadata\": {}\n",
+      "    },\n",
+      "    {\n",
+      "      \"metric_name\": \"acc_norm_stderr\",\n",
+      "      \"metric_value\": 0.20000000000000004,\n",
+      "      \"metric_type\": \"float\",\n",
+      "      \"confidence_interval\": null,\n",
+      "      \"num_samples\": null,\n",
+      "      \"metadata\": {}\n",
+      "    }\n",
+      "  ],\n",
+      "  \"overall_score\": 0.2,\n",
+      "  \"num_examples_evaluated\": 5,\n",
+      "  \"duration_seconds\": 6.113710641860962,\n",
+      "  \"completed_at\": \"2026-06-16T05:20:07.643559Z\",\n",
+      "  \"evaluation_metadata\": {\n",
+      "    \"lmeval_version\": \"unknown\",\n",
+      "    \"framework\": \"lm-evaluation-harness\",\n",
+      "    \"config\": {\n",
+      "      \"model\": \"local-completions\",\n",
+      "      \"model_args\": {\n",
+      "        \"model\": \"meta-llama/Llama-3.2-1B-Instruct\",\n",
+      "        \"base_url\": \"http://localhost:8080/v1/completions\",\n",
+      "        \"tokenizer_backend\": \"huggingface\",\n",
+      "        \"tokenizer\": \"google/flan-t5-small\",\n",
+      "        \"tokenized_requests\": false,\n",
+      "        \"num_concurrent\": 1,\n",
+      "        \"batch_size\": 1,\n",
+      "        \"timeout\": 300,\n",
+      "        \"verify_certificate\": \"/run/secrets/model/..2026_06_16_05_19_48.3496704805/ca_cert\"\n",
+      "      },\n",
+      "      \"batch_size\": null,\n",
+      "      \"batch_sizes\": [],\n",
+      "      \"device\": \"cpu\",\n",
+      "      \"use_cache\": null,\n",
+      "      \"limit\": 5,\n",
+      "      \"bootstrap_iters\": 100000,\n",
+      "      \"gen_kwargs\": null,\n",
+      "      \"random_seed\": 42,\n",
+      "      \"numpy_seed\": 42,\n",
+      "      \"torch_seed\": 42,\n",
+      "      \"fewshot_seed\": 1234\n",
+      "    },\n",
+      "    \"job_spec\": {\n",
+      "      \"id\": \"5db449a4-5bc0-4ba7-8106-aaa20e3019f7\",\n",
+      "      \"provider_id\": \"lm_evaluation_harness\",\n",
+      "      \"benchmark_id\": \"arc_easy\",\n",
+      "      \"benchmark_index\": 0,\n",
+      "      \"model\": {\n",
+      "        \"url\": \"http://localhost:8080\",\n",
+      "        \"name\": \"meta-llama/Llama-3.2-1B-Instruct\",\n",
+      "        \"auth\": {\n",
+      "          \"secret_ref\": \"vllm-llama-api-key\"\n",
+      "        }\n",
+      "      },\n",
+      "      \"parameters\": {\n",
+      "        \"tokenizer\": \"google/flan-t5-small\"\n",
+      "      },\n",
+      "      \"callback_url\": \"http://localhost:8080\",\n",
+      "      \"num_examples\": 5,\n",
+      "      \"experiment_name\": \"my-exp1\",\n",
+      "      \"tags\": [\n",
+      "        {\n",
+      "          \"key\": \"env\",\n",
+      "          \"value\": \"dev\"\n",
+      "        }\n",
+      "      ],\n",
+      "      \"exports\": {\n",
+      "        \"oci\": {\n",
+      "          \"coordinates\": {\n",
+      "            \"oci_host\": \"quay.io\",\n",
+      "            \"oci_repository\": \"gnaulak/testp1/eval-results\",\n",
+      "            \"oci_tag\": null,\n",
+      "            \"oci_subject\": null,\n",
+      "            \"annotations\": {}\n",
+      "          }\n",
+      "        }\n",
+      "      }\n",
+      "    }\n",
+      "  },\n",
+      "  \"oci_artifact\": null,\n",
+      "  \"mlflow_run_id\": null,\n",
+      "  \"eval_card\": null,\n",
+      "  \"env_card\": null\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tarfile\n",
+    "\n",
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    pulled = oras_client.pull(target=oci_reference, outdir=tmpdir)\n",
+    "    print(f\"Pulled {len(pulled)} files:\")\n",
+    "\n",
+    "    for filepath in pulled:\n",
+    "        print(f\"\\n--- {os.path.basename(filepath)} ---\")\n",
+    "        actual_path = os.path.join(tmpdir, os.path.basename(filepath))\n",
+    "        if not os.path.exists(actual_path):\n",
+    "            for f in os.listdir(tmpdir):\n",
+    "                actual_path = os.path.join(tmpdir, f)\n",
+    "                break\n",
+    "\n",
+    "        if tarfile.is_tarfile(actual_path):\n",
+    "            with tarfile.open(actual_path, \"r:gz\") as tar:\n",
+    "                for member in tar.getmembers():\n",
+    "                    f = tar.extractfile(member)\n",
+    "                    if f:\n",
+    "                        content = f.read().decode(\"utf-8\")\n",
+    "                        print(f\"\\n  [{member.name}]\")\n",
+    "                        try:\n",
+    "                            parsed = json.loads(content)\n",
+    "                            print(json.dumps(parsed, indent=2))\n",
+    "                        except json.JSONDecodeError:\n",
+    "                            print(content)\n",
+    "        else:\n",
+    "            with open(actual_path, \"r\") as f:\n",
+    "                content = f.read()\n",
+    "                try:\n",
+    "                    parsed = json.loads(content)\n",
+    "                    print(json.dumps(parsed, indent=2))\n",
+    "                except json.JSONDecodeError:\n",
+    "                    print(content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clean Up\n",
+    "\n",
+    "Delete the evaluation job and close the client connection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# run this cell to delete the job with hard_delete=True\n",
+    "client.jobs.cancel(submitted_job_id, hard_delete=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Close the client\n",
+    "client.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.12.12)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## What and why

Add a sample notebook: "End-to-End LLM Evaluation on OpenShift: Benchmarks, MLflow, and OCI Exports"

Closes #  https://redhat.atlassian.net/browse/RHOAIENG-67569

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [x] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit hooks configuration to standardize code quality check exclusion patterns, now including Jupyter notebook files alongside existing HTML and JSON document exclusions.

* **Documentation**
  * Added a new comprehensive end-to-end example notebook demonstrating LLM evaluation workflows on OpenShift clusters, covering SDK client setup, service configuration, job submission and status monitoring, result collection, and artifact export to OCI-compatible registries with authentication management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->