### PR TITLE
docs(mcp): enhance MCP documentation with capabilities and examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ A separate `MetricsServer` (`internal/eval_hub/server/metrics_server.go`) serves
 
 ### MCP Server
 
-The MCP (Model Context Protocol) server exposes eval-hub functionality to AI agents. Entry point: `cmd/evalhub_mcp/main.go`.
+The MCP (Model Context Protocol) server exposes eval-hub functionality to AI agents. Entry point: `cmd/evalhub_mcp/main.go`. **MCP.md** documents deployment, authentication, and the full capabilities reference (tools including `discover_providers`, resources, prompts, and completions).
 
 ```bash
 # Run directly

--- a/MCP.md
+++ b/MCP.md
@@ -88,6 +88,76 @@ CLI flags override YAML and environment variables when set: `--auth-type`, `--tr
 
 Load a config file with `--config /path/to/config.yaml` or `~/.evalhub/config.yaml`.
 
+## MCP capabilities reference
+
+When `EVALHUB_BASE_URL` is configured and the eval-hub API is reachable, the MCP server advertises **tools**, **resources**, **prompts**, and **completions**. Without a backend, only the `evalhub://server/version` resource is available (no tools).
+
+### Tools
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `discover_providers` | Optional: `target_type` (`model`, `agent`, or `inference_server`); `evaluates` (array of capability tags, e.g. `safety`, `robustness` — provider must evaluate **all** listed values) | Discover evaluation providers with agent-oriented metadata: summary, usage hints, result interpretation, complementary providers, and when to use each provider. Unfiltered calls return every provider; when filters are set, only providers with agent metadata can match. |
+| `submit_evaluation` | Required: `name`, `model` (`url`, `name`, optional `auth_secret`); either `benchmarks` (list of `{id, provider_id}`) **or** `collection` (`{id}`), not both. Optional: `description`, `tags`, `experiment` (`name`, `tags`, `artifact_location`) | Submit a new evaluation job. Returns `job_id` and initial `state`. |
+| `get_job_status` | Required: `job_id` | Poll job state, progress percentage, and per-benchmark status. Completed benchmarks may include `result_interpretation` and `complements` from provider metadata. |
+| `cancel_job` | Required: `job_id` | Cancel a running or pending job. Use `get_job_status` to confirm the final state. |
+
+**Example — discover providers for agent safety evaluation:**
+
+```json
+{
+  "target_type": "agent",
+  "evaluates": ["safety"]
+}
+```
+
+**Example — submit with a collection:**
+
+```json
+{
+  "name": "safety-eval",
+  "model": {"url": "http://my-model:8080/v1", "name": "my-model"},
+  "collection": {"id": "safety-suite"}
+}
+```
+
+### Resources
+
+All resource URIs use the `evalhub://` scheme and return JSON.
+
+| URI | Description |
+|-----|-------------|
+| `evalhub://providers` | List evaluation providers (supports `?limit=` and `?offset=` pagination) |
+| `evalhub://providers/{id}` | Get a provider by ID |
+| `evalhub://benchmarks` | List all benchmarks |
+| `evalhub://benchmarks?label={label}` | Filter benchmarks by label (repeat `label` for multiple values) |
+| `evalhub://benchmarks/{id}` | Get a benchmark by ID |
+| `evalhub://collections` | List benchmark collections (supports `?limit=` and `?offset=`) |
+| `evalhub://collections/{id}` | Get a collection by ID |
+| `evalhub://jobs` | List evaluation jobs (supports `?limit=` and `?offset=`) |
+| `evalhub://jobs?status={status}` | Filter jobs by status: `pending`, `running`, `completed`, `failed`, `cancelled`, `partially_failed` |
+| `evalhub://jobs/{id}` | Get a job by ID (full status and per-benchmark progress) |
+| `evalhub://server/version` | Server version and build metadata (always available) |
+
+### Prompts
+
+| Prompt | Arguments | Description |
+|--------|-----------|-------------|
+| `edd_workflow` | Required: `application_type` (`rag`, `agent`, `safety`, or `classifier`) | Evaluation-Driven Development cycle (Define → Measure → Iterate) tailored to the application type |
+| `evaluate_model` | Optional: `model_url`, `benchmark_preferences` | Step-by-step model evaluation workflow (model URL, benchmark selection, experiment config, submission, monitoring) |
+| `compare_runs` | Optional: `job_ids` (comma-separated) | Compare two or more evaluation jobs: fetch results, compare metrics, summarize findings |
+
+### Completions
+
+Argument completion is available for resource template parameters (provider, benchmark, collection, and job IDs; job `status` values; benchmark `label` tags). Values are cached for 30 seconds.
+
+### Typical workflow
+
+1. Call `discover_providers` (or read `evalhub://providers`) to choose an evaluation provider.
+2. Browse `evalhub://benchmarks` or `evalhub://collections` to pick benchmarks or a collection.
+3. Call `submit_evaluation` with the model endpoint and selected benchmarks or collection.
+4. Poll with `get_job_status` until the job reaches a terminal state.
+5. Optionally use the `compare_runs` prompt to compare multiple completed jobs.
+
 ## Testing that the MCP service is functioning
 
 ### OpenShift (kube-rbac-proxy)

--- a/python-mcp/README.md
+++ b/python-mcp/README.md
@@ -11,6 +11,10 @@ runtime required at execution time.
 pip install eval-hub-mcp
 ```
 
+## Capabilities
+
+With `EVALHUB_BASE_URL`, `EVALHUB_TOKEN`, and `EVALHUB_TENANT` configured, the server exposes MCP **tools** (`discover_providers`, `submit_evaluation`, `get_job_status`, `cancel_job`), **resources** (`evalhub://providers`, `evalhub://benchmarks`, `evalhub://collections`, `evalhub://jobs`, and more), and **prompts** (`edd_workflow`, `evaluate_model`, `compare_runs`). See [MCP.md](../MCP.md) in the eval-hub repository for the full reference.
+
 ## Usage
 
 ```bash

--- a/tests/mcp/CLAUDE_CODE_INTEGRATION.md
+++ b/tests/mcp/CLAUDE_CODE_INTEGRATION.md
@@ -96,6 +96,7 @@ What evalhub tools are available?
 
 | Tool | Parameters | Description |
 |---|---|---|
+| `discover_providers` | optional: `target_type` (`model`, `agent`, `inference_server`); `evaluates` (array of capability tags — provider must match all) | Discover providers with summaries, hints, and complementary suggestions |
 | `submit_evaluation` | `name`;<br><br>**`model`**: `url`, `name`, optional `auth_secret`;<br><br>either **`benchmarks`**: non-empty list of `{id, provider_id}` **or** **`collection`**: `{id}` (collection id from eval-hub; shipped defaults include e.g. `leaderboard-v2`);<br><br>optional: `description`, `tags`, `experiment` | Submit an evaluation job |
 | `cancel_job` | `job_id` | Cancel or hard-delete a running job |
 | `get_job_status` | `job_id` | Poll status of a submitted job (includes progress info) |
@@ -192,7 +193,7 @@ claude mcp list
 Run the same verification steps as stdio transport:
 
 - [ ] Resources accessible (`evalhub://providers`, `evalhub://benchmarks`, `evalhub://server/version`, etc.)
-- [ ] Tools accessible and functional (`submit_evaluation`, `cancel_job`, `get_job_status`)
+- [ ] Tools accessible and functional (`discover_providers`, `submit_evaluation`, `cancel_job`, `get_job_status`)
 - [ ] Prompts accessible (`edd_workflow`, `evaluate_model`, `compare_runs`)
 - [ ] Autocompletion works for parameterized resource URIs
 

--- a/tests/mcp/vscode/VSCODE_CURSOR_TEST_PLAN.md
+++ b/tests/mcp/vscode/VSCODE_CURSOR_TEST_PLAN.md
@@ -221,7 +221,8 @@ Add to Cursor MCP config:
 
 | ID | Priority | Test Case | Steps | Expected Result | VS Code | Cursor |
 |----|----------|-----------|-------|-----------------|---------|--------|
-| TOOL-01 | P0 | Tool discovery | Open MCP tools panel in client. | All 3 tools visible: `submit_evaluation`, `cancel_job`, `get_job_status`. Each has parameter schema, description, and examples. | [ ] | [ ] |
+| TOOL-01 | P0 | Tool discovery | Open MCP tools panel in client. | All 4 tools visible: `discover_providers`, `submit_evaluation`, `cancel_job`, `get_job_status`. Each has parameter schema, description, and examples. | [ ] | [ ] |
+| TOOL-01a | P1 | discover_providers | Ask agent: "What evaluation providers are available for agent safety?" | Tool invoked with optional filters. Returns provider summaries with hints and complementary suggestions. | [ ] | [ ] |
 | TOOL-02 | P0 | submit_evaluation — basic | Ask agent: "Submit an evaluation using benchmark X against model endpoint Y" | Tool invoked with correct params. Job submitted. Job ID returned. | [ ] | [ ] |
 | TOOL-03 | P1 | submit_evaluation — with collection | Ask agent: "Run collection Z against model endpoint Y" | Tool invoked with collection reference. Job created successfully. | [ ] | [ ] |
 | TOOL-04 | P1 | submit_evaluation — full params | Ask agent to submit with name, description, tags, and experiment config. | All optional fields passed through. Job created with metadata visible in backend. | [ ] | [ ] |


### PR DESCRIPTION
## What and why

- Updated AGENTS.md to reference MCP.md for deployment and authentication details.
- Expanded MCP.md to include a comprehensive capabilities reference, detailing available tools, resources, prompts, and completions.
- Added examples for using the `discover_providers` and `submit_evaluation` tools.
- Updated README.md in python-mcp to summarize MCP capabilities and link to detailed documentation.

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [x] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive MCP capabilities reference documenting available tools, resources, and typical workflows.

* **New Features**
  * Introduced discover_providers tool for exploring available evaluation providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->