### PR TITLE
test(fvt): use disconnected-aware tokenizer for OOB toxicity collection

### DIFF
--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -424,45 +424,7 @@ Feature: Evaluation Jobs
  # This test uses gated HuggingFace datasets (toxigen, truthfulqa_mc1, bigbench_hhh_alignment_multiple_choice) which require authentication.
   Scenario: Verify Evaluation Jobs Can Use OOB Collections - toxicity-and-ethical-principles
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "test-evaluation-job-oob-collection",
-        "collection": {
-          "id": "toxicity-and-ethical-principles",
-          "benchmarks": [
-            {
-              "id": "toxigen",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "limit": 5
-              }
-            },
-            {
-              "id": "truthfulqa_mc1",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "limit": 3
-              }
-            },
-            {
-              "id": "bigbench_hhh_alignment_multiple_choice",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "limit": 1
-              }
-            }
-          ]
-        },
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_toxicity.jsonnet"
     Then the response code should be 202
     And the response should contain the value "toxicity-and-ethical-principles" at path "$.collection.id"
     And I wait for the evaluation job status to be "completed"

--- a/tests/features/jsonnet_test.go
+++ b/tests/features/jsonnet_test.go
@@ -594,6 +594,68 @@ func TestEvaluateEvaluationJobJsonnetWithCollectionId(t *testing.T) {
 	}
 }
 
+func TestEvaluateOobCollectionJobJsonnetDisconnectedAware(t *testing.T) {
+	connectedEnv := map[string]string{
+		"MODEL_URL":             "http://model.example/v1",
+		"MODEL_NAME":            "test-model",
+		"MODEL_AUTH_SECRET_REF": "secret",
+		"ENVIRONMENT_ID":        "connected",
+	}
+	disconnectedEnv := map[string]string{
+		"MODEL_URL":               "http://model.example/v1",
+		"MODEL_NAME":              "test-model",
+		"MODEL_AUTH_SECRET_REF":   "secret",
+		"ENVIRONMENT_ID":          "disconnected",
+		"TEST_DATA_S3_BUCKET":     "mlpipeline",
+		"TEST_DATA_S3_KEY":        "offline",
+		"TEST_DATA_S3_SECRET_REF": "minio-test",
+	}
+	cases := []struct {
+		file           string
+		wantCollection string
+		minBenchmarks  int
+	}{
+		{"evaluation_job_oob_toxicity.jsonnet", "toxicity-and-ethical-principles", 3},
+	}
+	for _, disconnected := range []bool{false, true} {
+		mode := "connected"
+		baseEnv := connectedEnv
+		if disconnected {
+			mode = "disconnected"
+			baseEnv = disconnectedEnv
+		}
+		for _, tc := range cases {
+			name := mode + "/" + tc.file
+			t.Run(name, func(t *testing.T) {
+				sc := &scenarioConfig{
+					values:            map[string]string{},
+					jsonnetHarnessEnv: baseEnv,
+				}
+				out, err := sc.evaluateJsonnetFile(jsonnetPayloadFilePath(t, tc.file))
+				if err != nil {
+					t.Fatalf("evaluateJsonnetFile(%s): %v", tc.file, err)
+				}
+				var job struct {
+					Collection struct {
+						ID         string                    `json:"id"`
+						Benchmarks []jsonnetBenchmarkPayload `json:"benchmarks"`
+					} `json:"collection"`
+				}
+				if err := json.Unmarshal([]byte(out), &job); err != nil {
+					t.Fatalf("unmarshal %s: %v\noutput: %s", tc.file, err, out)
+				}
+				if job.Collection.ID != tc.wantCollection {
+					t.Errorf("collection.id = %q, want %q", job.Collection.ID, tc.wantCollection)
+				}
+				if len(job.Collection.Benchmarks) < tc.minBenchmarks {
+					t.Fatalf("collection.benchmarks = %d, want at least %d", len(job.Collection.Benchmarks), tc.minBenchmarks)
+				}
+				assertJsonnetBenchmarksDisconnectedAware(t, tc.file, job.Collection.Benchmarks, disconnected)
+			})
+		}
+	}
+}
+
 type jsonnetTestDataRef struct {
 	S3 struct {
 		Bucket    string `json:"bucket"`

--- a/tests/features/test_data/evaluation_job_oob_toxicity.jsonnet
+++ b/tests/features/test_data/evaluation_job_oob_toxicity.jsonnet
@@ -1,0 +1,7 @@
+local test = import 'test.libsonnet';
+
+test.oobCollectionJob('toxicity-and-ethical-principles', [
+  test.benchmark('toxigen', 'lm_evaluation_harness', { limit: 5 }),
+  test.benchmark('truthfulqa_mc1', 'lm_evaluation_harness', { limit: 3 }),
+  test.benchmark('bigbench_hhh_alignment_multiple_choice', 'lm_evaluation_harness', { limit: 1 }),
+])

--- a/tests/features/test_data/jsonnet/test.libsonnet
+++ b/tests/features/test_data/jsonnet/test.libsonnet
@@ -61,6 +61,17 @@ local harness = std.parseJson(std.extVar('harness'));
   // Default benchmark for evaluation_job.jsonnet (disconnected vs connected FVT).
   defaultBenchmark():: $.arcEasyBenchmark({}),
 
+  // OOB collection job with per-benchmark overrides (disconnected-aware tokenizer + test_data_ref).
+  oobCollectionJob(collectionId, benchmarks)::
+    {
+      name: 'test-evaluation-job-oob-collection',
+      collection: {
+        id: collectionId,
+        benchmarks: benchmarks,
+      },
+      model: $.model(),
+    },
+
   // Default evaluation job model block used across many scenarios.
   model()::
     local secretRef = $.env('MODEL_AUTH_SECRET_REF', '');


### PR DESCRIPTION
Move the toxicity-and-ethical-principles OOB job payload to jsonnet so disconnected runs pass /test_data/tokenizer and test_data_ref like other cluster FVT scenarios.

Assisted-by: Cursor

## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to support Jsonnet-based configuration for evaluation jobs
  * Added test coverage for out-of-band collection evaluation with toxicity and ethical principles benchmarks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->