### PR TITLE
fix: update npm dependency overrides for postcss and dompurify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,9 +1349,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "overrides": {
     "semver": "7.7.4",
-    "postcss": "8.5.14",
+    "postcss": "8.5.15",
     "ws": "7.5.11",
     "js-yaml": "4.2.0",
     "@opentelemetry/core": "2.8.0",
@@ -15,7 +15,7 @@
     "tmp": "0.2.7",
     "protobufjs": "7.6.4",
     "lodash": "4.18.1",
-    "dompurify": "3.4.10",
+    "dompurify": "3.4.11",
     "@cucumber/cucumber": {
       "minimatch": "3.1.4",
       "brace-expansion": "1.1.13"


### PR DESCRIPTION
## Summary

- Update npm dependency overrides to latest patch versions:
  - `postcss`: 8.5.14 → 8.5.15
  - `dompurify`: 3.4.10 → 3.4.11
- Regenerated `package-lock.json` via `npm install`
- Verified documentation build (`make documentation`) succeeds with no changes to docs output

## Go Standard Library CVEs (pending go-toolset update)

Three Go standard library vulnerabilities were identified by `govulncheck`, all fixed in Go 1.26.4:

| CVE | Package | Severity | Description |
|-----|---------|----------|-------------|
| [CVE-2026-42507](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` | Medium | Arbitrary inputs included in errors without escaping |
| [CVE-2026-42504](https://pkg.go.dev/vuln/GO-2026-5038) | `mime` | Medium | Quadratic complexity in `WordDecoder.DecodeHeader` |
| [CVE-2026-27145](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` | Medium | Inefficient candidate hostname parsing |

**Go 1.26.4 is not yet available in `registry.access.redhat.com/ubi9/go-toolset`** (latest available is 1.26.3). Per project policy, the `go.mod` version cannot be updated until go-toolset supports the target version. The `Containerfile` uses `go-toolset:1.26` which will automatically pick up 1.26.4 when it becomes available. A follow-up PR should update `go.mod` to `go 1.26.4` once go-toolset publishes the image.

## npm Dependency Scan

- `npm audit` reports **0 vulnerabilities**
- All existing overrides are at CVE-patched versions
- All transitive dependencies resolve to fixed versions
- No new CVE-fixing overrides required

## Test plan

- [x] `npm install` succeeds with 0 vulnerabilities
- [x] `npm audit` reports 0 vulnerabilities
- [x] `make documentation` succeeds with no doc output changes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to newer patch versions to keep the tooling up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->