### PR TITLE
fix(health): bring /health under SAR, add cluster-internal /healthz for kubelet probes

### DIFF
--- a/internal/eval_hub/server/metrics_server.go
+++ b/internal/eval_hub/server/metrics_server.go
@@ -26,6 +26,7 @@ func NewMetricsServer(logger *slog.Logger, promConfig *config.PrometheusConfig) 
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", withRequestID(promhttp.Handler()))
+	mux.Handle("/healthz", withRequestID(http.HandlerFunc(handleHealthz)))
 
 	return &MetricsServer{
 		httpServer: &http.Server{
@@ -56,6 +57,12 @@ func withRequestID(next http.Handler) http.Handler {
 		w.Header().Set(TRANSACTION_ID_HEADER, requestID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"healthy"}`))
 }
 
 func (m *MetricsServer) Start() error {

--- a/internal/eval_hub/server/metrics_server_test.go
+++ b/internal/eval_hub/server/metrics_server_test.go
@@ -59,7 +59,24 @@ func TestMetricsServerHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("returns 404 for non-metrics paths", func(t *testing.T) {
+	t.Run("serves /healthz with JSON status", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", ct)
+		}
+		if body := w.Body.String(); body != `{"status":"healthy"}` {
+			t.Errorf("unexpected body: %s", body)
+		}
+	})
+
+	t.Run("returns 404 for non-registered paths", func(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
 		w := httptest.NewRecorder()


### PR DESCRIPTION
## What and why

Bring `/api/v1/health` under SAR. Add a `/healthz` endpoint on the metrics server (`0.0.0.0:8081`) for kubelet probes, which is cluster-internal.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

Kubelet probes use `/healthz` on port 8081 (cluster-internal).
