### PR TITLE
fix(k8s): use foreground propagation when deleting evaluation Jobs

### DIFF
--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -89,10 +89,16 @@ func (r *K8sRuntime) RunEvaluationJob(
 	return nil
 }
 
+// jobForegroundDeleteOptions deletes Job-owned Pods before removing the Job so stuck Init
+// pods cannot outlive a background Job delete during hard_delete or orphan cleanup.
+func jobForegroundDeleteOptions() metav1.DeleteOptions {
+	propagationPolicy := metav1.DeletePropagationForeground
+	return metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}
+}
+
 func (r *K8sRuntime) DeleteEvaluationJobResources(evaluation *api.EvaluationJobResource) error {
 	namespace := resolveNamespace(string(evaluation.Resource.Tenant))
-	propagationPolicy := metav1.DeletePropagationBackground
-	deleteOptions := metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}
+	deleteOptions := jobForegroundDeleteOptions()
 
 	r.logger.Info(
 		"deleting evaluation runtime resources",
@@ -259,7 +265,7 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 			// missing ConfigMap — delete it now to prevent an orphaned, permanently-stuck job.
 			logger.Warn("configmap deleted mid-creation (race with hard_delete) — cleaning up orphaned job",
 				"namespace", createdJob.Namespace, "job", createdJob.Name, "configmap", configMap.Name)
-			if delErr := r.helper.DeleteJob(ctx, createdJob.Namespace, createdJob.Name, metav1.DeleteOptions{}); delErr != nil && !apierrors.IsNotFound(delErr) {
+			if delErr := r.helper.DeleteJob(ctx, createdJob.Namespace, createdJob.Name, jobForegroundDeleteOptions()); delErr != nil && !apierrors.IsNotFound(delErr) {
 				logger.Error("failed to delete orphaned job", "namespace", createdJob.Namespace, "name", createdJob.Name, "error", delErr)
 				return delErr
 			}


### PR DESCRIPTION
Empty DeleteOptions on Job delete leaves child Pods orphaned on Kubernetes (Init pods stuck after hard_delete races). This PR applies foreground propagation for hard_delete so the pods are removed with the Job.

Assisted-by: Cursor

## What and why

<!-- What does this PR do and why? Link to related issues. -->
https://redhat.atlassian.net/browse/RHOAIENG-70512

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of evaluation job cleanup in Kubernetes environments by updating resource deletion behavior to ensure proper cleanup, particularly during concurrent operations and edge cases that could previously result in orphaned resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->