### PR TITLE
feat(mcp): pass model and benchmark parameters in submit_evaluation

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -97,7 +97,7 @@ When `EVALHUB_BASE_URL` is configured and the eval-hub API is reachable, the MCP
 | Tool | Parameters | Description |
 |------|------------|-------------|
 | `discover_providers` | Optional: `target_type` (`model`, `agent`, or `inference_server`); `evaluates` (array of capability tags, e.g. `safety`, `robustness` — provider must evaluate **all** listed values) | Discover evaluation providers with agent-oriented metadata: summary, usage hints, result interpretation, complementary providers, and when to use each provider. Unfiltered calls return every provider; when filters are set, only providers with agent metadata can match. |
-| `submit_evaluation` | Required: `name`, `model` (`url`, `name`, optional `auth_secret`); either `benchmarks` (list of `{id, provider_id}`) **or** `collection` (`{id}`), not both. Optional: `description`, `tags`, `experiment` (`name`, `tags`, `artifact_location`) | Submit a new evaluation job. Returns `job_id` and initial `state`. |
+| `submit_evaluation` | Required: `name`, `model` (`url`, `name`, optional `auth_secret`, optional `parameters`); either `benchmarks` (list of `{id, provider_id, optional parameters}`) **or** `collection` (`{id}`), not both. Optional: `description`, `tags`, `experiment` (`name`, `tags`, `artifact_location`) | Submit a new evaluation job. Returns `job_id` and initial `state`. |
 | `get_job_status` | Required: `job_id` | Poll job state, progress percentage, and per-benchmark status. Completed benchmarks may include `result_interpretation` and `complements` from provider metadata. |
 | `cancel_job` | Required: `job_id` | Cancel a running or pending job. Use `get_job_status` to confirm the final state. |
 

--- a/internal/evalhub_mcp/server/tools.go
+++ b/internal/evalhub_mcp/server/tools.go
@@ -37,14 +37,16 @@ type SubmitEvaluationInput struct {
 }
 
 type ModelInput struct {
-	URL        string `json:"url" jsonschema:"URL of the model inference endpoint"`
-	Name       string `json:"name" jsonschema:"Display name of the model"`
-	AuthSecret string `json:"auth_secret,omitempty" jsonschema:"Kubernetes secret reference for model authentication"`
+	URL        string         `json:"url" jsonschema:"URL of the model inference endpoint"`
+	Name       string         `json:"name" jsonschema:"Display name of the model"`
+	AuthSecret string         `json:"auth_secret,omitempty" jsonschema:"Kubernetes secret reference for model authentication"`
+	Parameters map[string]any `json:"parameters,omitempty" jsonschema:"Optional model inference parameters (e.g. temperature, max_tokens)"`
 }
 
 type BenchmarkInput struct {
-	ID         string `json:"id" jsonschema:"Benchmark identifier"`
-	ProviderID string `json:"provider_id" jsonschema:"Evaluation provider that runs this benchmark"`
+	ID         string         `json:"id" jsonschema:"Benchmark identifier"`
+	ProviderID string         `json:"provider_id" jsonschema:"Evaluation provider that runs this benchmark"`
+	Parameters map[string]any `json:"parameters,omitempty" jsonschema:"Optional benchmark-specific parameters passed to the evaluation adapter"`
 }
 
 type CollectionInput struct {
@@ -372,8 +374,9 @@ func buildJobConfig(input SubmitEvaluationInput) api.EvaluationJobConfig {
 		Name: input.Name,
 		Tags: input.Tags,
 		Model: api.ModelRef{
-			URL:  input.Model.URL,
-			Name: input.Model.Name,
+			URL:        input.Model.URL,
+			Name:       input.Model.Name,
+			Parameters: input.Model.Parameters,
 		},
 	}
 
@@ -389,6 +392,7 @@ func buildJobConfig(input SubmitEvaluationInput) api.EvaluationJobConfig {
 		config.Benchmarks = append(config.Benchmarks, api.EvaluationBenchmarkConfig{
 			Ref:        api.Ref{ID: b.ID},
 			ProviderID: b.ProviderID,
+			Parameters: b.Parameters,
 		})
 	}
 

--- a/internal/evalhub_mcp/server/tools_test.go
+++ b/internal/evalhub_mcp/server/tools_test.go
@@ -296,6 +296,68 @@ func TestSubmitEvaluationBothBenchmarksAndCollection(t *testing.T) {
 	}
 }
 
+func TestSubmitEvaluationParameters(t *testing.T) {
+	t.Parallel()
+
+	var captured api.EvaluationJobConfig
+	client := &mockToolClient{
+		createJobFn: func(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error) {
+			captured = config
+			return &api.EvaluationJobResource{
+				Resource: api.EvaluationResource{
+					Resource: api.Resource{ID: "job-params"},
+				},
+				Status: &api.EvaluationJobStatus{
+					EvaluationJobState: api.EvaluationJobState{State: api.OverallStatePending},
+				},
+				EvaluationJobConfig: config,
+			}, nil
+		},
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	callToolJSON[SubmitEvaluationOutput](t, ctx, cs, "submit_evaluation", map[string]any{
+		"name": "params-eval",
+		"model": map[string]any{
+			"url":  "http://model:8080",
+			"name": "test-model",
+			"parameters": map[string]any{
+				"temperature": 0.7,
+				"max_tokens":  1024,
+			},
+		},
+		"benchmarks": []map[string]any{
+			{
+				"id":          "mmlu",
+				"provider_id": "unitxt",
+				"parameters": map[string]any{
+					"num_fewshot": 5,
+				},
+			},
+		},
+	})
+
+	if captured.Model.Parameters == nil {
+		t.Fatal("expected model parameters to be passed through")
+	}
+	if captured.Model.Parameters["temperature"] != 0.7 {
+		t.Errorf("model temperature = %v, want 0.7", captured.Model.Parameters["temperature"])
+	}
+	if captured.Model.Parameters["max_tokens"] != float64(1024) {
+		t.Errorf("model max_tokens = %v, want 1024", captured.Model.Parameters["max_tokens"])
+	}
+	if len(captured.Benchmarks) != 1 {
+		t.Fatalf("expected 1 benchmark, got %d", len(captured.Benchmarks))
+	}
+	if captured.Benchmarks[0].Parameters == nil {
+		t.Fatal("expected benchmark parameters to be passed through")
+	}
+	if captured.Benchmarks[0].Parameters["num_fewshot"] != float64(5) {
+		t.Errorf("benchmark num_fewshot = %v, want 5", captured.Benchmarks[0].Parameters["num_fewshot"])
+	}
+}
+
 func TestSubmitEvaluationExperimentConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/evalhub_mcp/server/tools_test.go
+++ b/internal/evalhub_mcp/server/tools_test.go
@@ -358,6 +358,52 @@ func TestSubmitEvaluationParameters(t *testing.T) {
 	}
 }
 
+func TestSubmitEvaluationWithoutParameters(t *testing.T) {
+	t.Parallel()
+
+	var captured api.EvaluationJobConfig
+	client := &mockToolClient{
+		createJobFn: func(config api.EvaluationJobConfig) (*api.EvaluationJobResource, error) {
+			captured = config
+			return &api.EvaluationJobResource{
+				Resource: api.EvaluationResource{
+					Resource: api.Resource{ID: "job-no-params"},
+				},
+				Status: &api.EvaluationJobStatus{
+					EvaluationJobState: api.EvaluationJobState{State: api.OverallStatePending},
+				},
+				EvaluationJobConfig: config,
+			}, nil
+		},
+	}
+
+	ctx, cs := connectWithTools(t, client)
+
+	out := callToolJSON[SubmitEvaluationOutput](t, ctx, cs, "submit_evaluation", map[string]any{
+		"name": "no-params-eval",
+		"model": map[string]any{
+			"url":  "http://model:8080",
+			"name": "test-model",
+		},
+		"benchmarks": []map[string]any{
+			{"id": "mmlu", "provider_id": "unitxt"},
+		},
+	})
+
+	if out.JobID != "job-no-params" {
+		t.Errorf("job_id = %q, want %q", out.JobID, "job-no-params")
+	}
+	if len(captured.Model.Parameters) > 0 {
+		t.Errorf("model parameters = %v, want nil or empty", captured.Model.Parameters)
+	}
+	if len(captured.Benchmarks) != 1 {
+		t.Fatalf("expected 1 benchmark, got %d", len(captured.Benchmarks))
+	}
+	if len(captured.Benchmarks[0].Parameters) > 0 {
+		t.Errorf("benchmark parameters = %v, want nil or empty", captured.Benchmarks[0].Parameters)
+	}
+}
+
 func TestSubmitEvaluationExperimentConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add optional `parameters` to the `submit_evaluation` MCP tool for both `model` and each entry in `benchmarks`
- Forward those maps through `buildJobConfig` into `EvaluationJobConfig`, matching the REST API
- Document the new fields in MCP.md and add unit test coverage

## Test plan
- [x] `go test -v ./internal/evalhub_mcp/server/... -run TestSubmitEvaluation`
- [x] `make fmt lint`
- [x] Pre-commit hooks passed on commit


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation jobs now support optional parameters for models and benchmarks, enabling customization of inference settings and benchmark-specific configurations directly during job submission.

* **Documentation**
  * Updated MCP `submit_evaluation` tool documentation to reflect new optional parameters support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->