### PR TITLE
feat: mount SA token on sidecar only; sidecar always proxies model auth

### DIFF
--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -60,21 +60,21 @@ const (
 	evalhubSATokenFile       = "token"
 	// pod namespace projected into adapter via DownwardAPI so the SDK can set X-Tenant on sidecar requests.
 	// The SA token auto-mount is disabled so the standard namespace file is absent; we expose it explicitly.
-	adapterNamespaceVolumeName = "pod-namespace"
-	adapterNamespaceFile       = "namespace"
-	modelInternalAuthVolumeName       = "model-auth-internal" // internalModelRef projected volume; mounted in adapter during credential injection
-	testDataSecretVolumeName          = "test-data-secret"
-	testDataSecretMountPath           = "/var/run/secrets/test-data"
-	serviceCABundleFile               = "service-ca.crt"
-	envMLFlowCertPathName             = "MLFLOW_TRACKING_SERVER_CERT_PATH"
-	envEvalHubModeName                = "EVALHUB_MODE"
-	envTestDataS3BucketName           = "TEST_DATA_S3_BUCKET"
-	envTestDataS3KeyName              = "TEST_DATA_S3_KEY"
-	defaultInitCPURequest             = "100m"
-	defaultInitCPULimit               = "500m"
-	defaultInitMemoryRequest          = "128Mi"
-	defaultInitMemoryLimit            = "512Mi"
-	defaultAllowPrivilegeEscalation   = false
+	adapterNamespaceVolumeName      = "pod-namespace"
+	adapterNamespaceFile            = "namespace"
+	modelInternalAuthVolumeName     = "model-auth-internal" // internalModelRef projected volume; mounted in adapter during credential injection
+	testDataSecretVolumeName        = "test-data-secret"
+	testDataSecretMountPath         = "/var/run/secrets/test-data"
+	serviceCABundleFile             = "service-ca.crt"
+	envMLFlowCertPathName           = "MLFLOW_TRACKING_SERVER_CERT_PATH"
+	envEvalHubModeName              = "EVALHUB_MODE"
+	envTestDataS3BucketName         = "TEST_DATA_S3_BUCKET"
+	envTestDataS3KeyName            = "TEST_DATA_S3_KEY"
+	defaultInitCPURequest           = "100m"
+	defaultInitCPULimit             = "500m"
+	defaultInitMemoryRequest        = "128Mi"
+	defaultInitMemoryLimit          = "512Mi"
+	defaultAllowPrivilegeEscalation = false
 	//defaultRunAsUser                = int64(1000)
 	//defaultRunAsGroup               = int64(1000)
 	labelAppKey       = "app"

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -43,7 +43,6 @@ const (
 	specSuffix                        = "-spec"
 	envMLFlowTrackingURIName          = "MLFLOW_TRACKING_URI"
 	envMLFlowWorkspaceName            = "MLFLOW_WORKSPACE"
-	envMLFlowTokenPathName            = "MLFLOW_TRACKING_TOKEN_PATH"
 	mlflowTokenVolumeName             = "mlflow-token"
 	mlflowTokenMountPath              = "/var/run/secrets/mlflow"
 	mlflowTokenFile                   = "token"
@@ -51,8 +50,18 @@ const (
 	ociCredentialsMountPath           = "/etc/evalhub/.docker/config.json"
 	ociCredentialsSubPath             = ".dockerconfigjson"
 	envOCIAuthConfigPathName          = "OCI_AUTH_CONFIG_PATH"
-	modelAuthVolumeName               = "model-auth" // real credentials secret; mounted in sidecar (injection) or adapter (direct)
+	modelAuthVolumeName               = "model-auth" // credentials secret; mounted in sidecar only
 	modelAuthMountPath                = "/var/run/secrets/model"
+	// Standard Kubernetes SA mount path; used by both the sidecar SA token volume and the
+	// adapter DownwardAPI namespace volume so the SDK finds files at the expected locations.
+	k8sSAMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+	// evalhub SA token — projected into sidecar only; pod-level auto-mount is disabled so adapter cannot see it.
+	evalhubSATokenVolumeName = "evalhub-sa-token"
+	evalhubSATokenFile       = "token"
+	// pod namespace projected into adapter via DownwardAPI so the SDK can set X-Tenant on sidecar requests.
+	// The SA token auto-mount is disabled so the standard namespace file is absent; we expose it explicitly.
+	adapterNamespaceVolumeName = "pod-namespace"
+	adapterNamespaceFile       = "namespace"
 	modelInternalAuthVolumeName       = "model-auth-internal" // internalModelRef projected volume; mounted in adapter during credential injection
 	testDataSecretVolumeName          = "test-data-secret"
 	testDataSecretMountPath           = "/var/run/secrets/test-data"
@@ -273,12 +282,13 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyNever,
-					NodeSelector:       cfg.nodeSelector,
-					InitContainers:     initContainers,
-					Containers:         containers,
-					Volumes:            jobVolumes,
-					ServiceAccountName: cfg.serviceAccountName,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					NodeSelector:                 cfg.nodeSelector,
+					InitContainers:               initContainers,
+					Containers:                   containers,
+					Volumes:                      jobVolumes,
+					ServiceAccountName:           cfg.serviceAccountName,
+					AutomountServiceAccountToken: boolPtr(false),
 				},
 			},
 		},
@@ -307,6 +317,27 @@ func buildRuntimeContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
+		// Pod namespace exposed via DownwardAPI so the adapter SDK can read it to set the
+		// X-Tenant header on sidecar requests. Pod-level SA auto-mount is disabled, so the
+		// standard /var/run/secrets/kubernetes.io/serviceaccount/namespace file is absent
+		// on the adapter; we project it explicitly via DownwardAPI instead.
+		{
+			Name: adapterNamespaceVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{{
+						DownwardAPI: &corev1.DownwardAPIProjection{
+							Items: []corev1.DownwardAPIVolumeFile{{
+								Path: adapterNamespaceFile,
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							}},
+						},
+					}},
+				},
+			},
+		},
 	}
 
 	// Build volume mounts list
@@ -325,6 +356,11 @@ func buildRuntimeContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 			Name:      terminationFileVolumeName,
 			MountPath: adapterTerminationSharedMountPath,
 		},
+		{
+			Name:      adapterNamespaceVolumeName,
+			MountPath: k8sSAMountPath,
+			ReadOnly:  true,
+		},
 	}
 
 	serviceCAConfigMap := cfg.serviceCAConfigMap
@@ -332,34 +368,6 @@ func buildRuntimeContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 	if serviceCAConfigMap != "" {
 		volumes = ensureServiceCAVolume(volumes, serviceCAConfigMap)
 		volumeMounts = ensureServiceCAMount(volumeMounts)
-	}
-
-	// Add projected ServiceAccountToken volume for MLFlow authentication.
-	// On ROSA/STS clusters, the auto-mounted SA token has the wrong audience
-	// (AWS OIDC instead of Kubernetes API), so we mint a token with the default
-	// audience that MLFlow's kubernetes-auth plugin can use for SelfSubjectAccessReview.
-	if cfg.mlflowTrackingURI != "" {
-		expSeconds := int64(3600)
-		volumes = append(volumes, corev1.Volume{
-			Name: mlflowTokenVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Projected: &corev1.ProjectedVolumeSource{
-					Sources: []corev1.VolumeProjection{
-						{
-							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-								Path:              mlflowTokenFile,
-								ExpirationSeconds: &expSeconds,
-							},
-						},
-					},
-				},
-			},
-		})
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      mlflowTokenVolumeName,
-			MountPath: mlflowTokenMountPath,
-			ReadOnly:  true,
-		})
 	}
 
 	// Add OCI credentials volume/mount when a K8s secret connection is configured.
@@ -380,20 +388,15 @@ func buildRuntimeContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 		})
 	}
 
-	// Add model auth volumes.
-	// Credential-injection path (modelInternalRefSecretName set): adapter receives a projected
-	// volume (model-auth-internal) combining the internalModelRef secret (synthetic refs) and
-	// selective keys from the model credential secret (hf-token, ca_cert with optional:true so
-	// Kubernetes silently omits absent keys). The sidecar gets the real secret separately.
-	// Direct-mount path (no injection): adapter receives the real secret directly as model-auth.
-	if cfg.modelInternalRefSecretName != "" {
+	// Add model auth volume for the adapter. The sidecar is always active when modelAuthSecretRef
+	// is set (k8s_runtime.go unconditionally redirects the adapter URL to the sidecar), so there
+	// is only one adapter path: a projected volume of passthrough keys (hf-token, ca_cert, both
+	// optional) from the real secret. When credential injection is also active
+	// (modelInternalRefSecretName set), the internalRef secret is prepended so the adapter
+	// receives the synthetic ref tokens alongside the passthrough keys.
+	if cfg.modelAuthSecretRef != "" {
 		optionalTrue := true
 		projectedSources := []corev1.VolumeProjection{
-			{
-				Secret: &corev1.SecretProjection{
-					LocalObjectReference: corev1.LocalObjectReference{Name: cfg.modelInternalRefSecretName},
-				},
-			},
 			{
 				Secret: &corev1.SecretProjection{
 					LocalObjectReference: corev1.LocalObjectReference{Name: cfg.modelAuthSecretRef},
@@ -405,6 +408,15 @@ func buildRuntimeContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 				},
 			},
 		}
+		if cfg.modelInternalRefSecretName != "" {
+			projectedSources = append([]corev1.VolumeProjection{
+				{
+					Secret: &corev1.SecretProjection{
+						LocalObjectReference: corev1.LocalObjectReference{Name: cfg.modelInternalRefSecretName},
+					},
+				},
+			}, projectedSources...)
+		}
 		volumes = append(volumes, corev1.Volume{
 			Name: modelInternalAuthVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -413,21 +425,6 @@ func buildRuntimeContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 		})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      modelInternalAuthVolumeName,
-			MountPath: modelAuthMountPath,
-			ReadOnly:  true,
-		})
-	} else if cfg.modelAuthSecretRef != "" {
-		// Direct-mount path: no credential injection; mount the real secret directly in the adapter.
-		volumes = append(volumes, corev1.Volume{
-			Name: modelAuthVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: cfg.modelAuthSecretRef,
-				},
-			},
-		})
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      modelAuthVolumeName,
 			MountPath: modelAuthMountPath,
 			ReadOnly:  true,
 		})
@@ -499,6 +496,36 @@ func buildSidecarContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 		volumeMounts = ensureServiceCAMount(volumeMounts)
 	}
 
+	// Projected ServiceAccountToken for the sidecar only.
+	// Pod-level auto-mount is disabled (AutomountServiceAccountToken=false on PodSpec) so that
+	// the adapter cannot access the SA token. The sidecar needs it to authenticate callbacks to
+	// the eval-hub API server (X-Tenant header via kube-rbac-proxy). On ROSA/STS clusters the
+	// default auto-mounted token carries the wrong audience (AWS OIDC); projecting explicitly
+	// gives us a token scoped to the Kubernetes API audience.
+	{
+		expSeconds := int64(3600)
+		volumes = append(volumes, corev1.Volume{
+			Name: evalhubSATokenVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Path:              evalhubSATokenFile,
+								ExpirationSeconds: &expSeconds,
+							},
+						},
+					},
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      evalhubSATokenVolumeName,
+			MountPath: k8sSAMountPath,
+			ReadOnly:  true,
+		})
+	}
+
 	// Add projected ServiceAccountToken volume for MLFlow authentication (sidecar proxies MLflow).
 	// On ROSA/STS clusters, the auto-mounted SA token has the wrong audience
 	// (AWS OIDC instead of Kubernetes API), so we mint a token with the default
@@ -527,9 +554,10 @@ func buildSidecarContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 		})
 	}
 
-	// When credential injection is active, mount the real credentials secret in the sidecar at
-	// modelAuthMountPath. The adapter never sees this volume.
-	if cfg.modelInternalRefSecretName != "" && cfg.modelAuthSecretRef != "" {
+	// Mount the real credentials secret in the sidecar whenever model auth is configured.
+	// The sidecar needs it for ca_cert TLS and (in the credential-injection path) for
+	// resolving ref tokens. The adapter never sees this volume.
+	if cfg.modelAuthSecretRef != "" {
 		volumes = append(volumes, corev1.Volume{
 			Name: modelAuthVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -727,12 +755,6 @@ func buildEnvVars(cfg *jobConfig) []corev1.EnvVar {
 		})
 		seen[envMLFlowTrackingURIName] = true
 
-		// Token path points to the projected ServiceAccountToken volume
-		env = append(env, corev1.EnvVar{
-			Name:  envMLFlowTokenPathName,
-			Value: mlflowTokenMountPath + "/" + mlflowTokenFile,
-		})
-		seen[envMLFlowTokenPathName] = true
 	}
 	if cfg.mlflowWorkspace != "" {
 		env = append(env, corev1.EnvVar{

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -590,6 +590,10 @@ func TestBuildJobWithS3TestDataSkipsEmptyNormalizedKey(t *testing.T) {
 	}
 }
 
+// TestBuildJobWithModelAuthSecret verifies that when only modelAuthSecretRef is set (sidecar-proxy
+// path, SA token auth), the adapter receives a projected volume with passthrough keys only
+// (hf-token, ca_cert, both optional). There is no direct-mount path — the sidecar is always
+// active when model auth is configured.
 func TestBuildJobWithModelAuthSecret(t *testing.T) {
 	cfg := &jobConfig{
 		jobID:              "job-auth",
@@ -608,42 +612,52 @@ func TestBuildJobWithModelAuthSecret(t *testing.T) {
 		t.Fatalf("buildJob returned error: %v", err)
 	}
 
-	var foundVolume bool
-	for _, v := range job.Spec.Template.Spec.Volumes {
-		if v.Name == modelAuthVolumeName {
-			foundVolume = true
-			if v.VolumeSource.Secret == nil {
-				t.Fatalf("expected secret volume source for %s", modelAuthVolumeName)
-			}
-			if v.VolumeSource.Secret.SecretName != "model-auth-secret" {
-				t.Fatalf("expected secret name %q, got %q", "model-auth-secret", v.VolumeSource.Secret.SecretName)
-			}
+	// Adapter must have the projected passthrough volume, not the raw secret volume.
+	var foundVolume *corev1.Volume
+	for i := range job.Spec.Template.Spec.Volumes {
+		if job.Spec.Template.Spec.Volumes[i].Name == modelInternalAuthVolumeName {
+			foundVolume = &job.Spec.Template.Spec.Volumes[i]
+			break
 		}
 	}
-	if !foundVolume {
-		t.Fatalf("expected volume %s to be present", modelAuthVolumeName)
+	if foundVolume == nil {
+		t.Fatalf("expected projected volume %s on adapter", modelInternalAuthVolumeName)
+	}
+	if foundVolume.VolumeSource.Projected == nil {
+		t.Fatalf("expected projected volume source for %s", modelInternalAuthVolumeName)
+	}
+	if len(foundVolume.VolumeSource.Projected.Sources) != 1 {
+		t.Fatalf("expected exactly 1 projected source (passthrough only), got %d", len(foundVolume.VolumeSource.Projected.Sources))
+	}
+	src := foundVolume.VolumeSource.Projected.Sources[0]
+	if src.Secret == nil || src.Secret.Name != "model-auth-secret" {
+		t.Fatalf("expected projected source from real secret %q, got %+v", "model-auth-secret", src)
+	}
+	if src.Secret.Optional == nil || !*src.Secret.Optional {
+		t.Fatal("expected passthrough projection to be optional:true")
 	}
 
 	container := job.Spec.Template.Spec.Containers[0]
 	var foundMount bool
 	for _, m := range container.VolumeMounts {
-		if m.Name == modelAuthVolumeName {
+		if m.Name == modelInternalAuthVolumeName {
 			foundMount = true
 			if m.MountPath != modelAuthMountPath {
 				t.Fatalf("expected mount path %q, got %q", modelAuthMountPath, m.MountPath)
 			}
 			if !m.ReadOnly {
-				t.Fatalf("expected mount to be read-only")
+				t.Fatal("expected mount to be read-only")
 			}
 		}
 	}
 	if !foundMount {
-		t.Fatalf("expected volume mount %s to be present", modelAuthVolumeName)
+		t.Fatalf("expected volume mount %s to be present on adapter", modelInternalAuthVolumeName)
 	}
 
-	for _, e := range container.Env {
-		if e.Name == "MODEL_AUTH_API_KEY_PATH" || e.Name == "MODEL_AUTH_CA_CERT_PATH" {
-			t.Fatalf("expected no model auth env vars, found %s", e.Name)
+	// Raw secret volume must not be mounted on the adapter container (it belongs to the sidecar).
+	for _, m := range container.VolumeMounts {
+		if m.Name == modelAuthVolumeName {
+			t.Fatalf("unexpected raw secret mount %s on adapter container; direct-mount path is gone", modelAuthVolumeName)
 		}
 	}
 }
@@ -835,5 +849,126 @@ func TestBuildJobNoNodeSelectorWhenAbsent(t *testing.T) {
 	}
 	if len(job.Spec.Template.Spec.NodeSelector) != 0 {
 		t.Errorf("expected empty NodeSelector, got %v", job.Spec.Template.Spec.NodeSelector)
+	}
+}
+
+// TestBuildJobSATokenSidecarOnly verifies that:
+//   - pod-level AutomountServiceAccountToken is explicitly disabled
+//   - the evalhub-sa-token projected volume exists on the pod and is mounted in the sidecar
+//   - the adapter container has no evalhub-sa-token mount
+//   - the adapter has the pod-namespace DownwardAPI volume mounted at k8sSAMountPath
+func TestBuildJobSATokenSidecarOnly(t *testing.T) {
+	cfg := &jobConfig{
+		jobID:          "sa-token-job",
+		resourceGUID:   "guid-sa",
+		benchmarkIndex: 0,
+		namespace:      "default",
+		providerID:     "p",
+		benchmarkID:    "b",
+		adapterImage:   "adapter:latest",
+		defaultEnv:     []api.EnvVar{},
+	}
+	job, err := buildJob(cfg)
+	if err != nil {
+		t.Fatalf("buildJob: %v", err)
+	}
+
+	// Pod must disable auto-mount so SA token is not injected into adapter.
+	if job.Spec.Template.Spec.AutomountServiceAccountToken == nil || *job.Spec.Template.Spec.AutomountServiceAccountToken {
+		t.Fatal("expected AutomountServiceAccountToken=false on PodSpec")
+	}
+
+	// Pod volumes must contain the evalhub-sa-token projected volume.
+	var foundPodVolume bool
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if v.Name == evalhubSATokenVolumeName {
+			foundPodVolume = true
+			if v.VolumeSource.Projected == nil {
+				t.Fatal("evalhub-sa-token volume must be a projected volume")
+			}
+			hasSAToken := false
+			for _, src := range v.VolumeSource.Projected.Sources {
+				if src.ServiceAccountToken != nil {
+					hasSAToken = true
+				}
+			}
+			if !hasSAToken {
+				t.Fatal("evalhub-sa-token projected volume must contain a ServiceAccountToken source")
+			}
+		}
+	}
+	if !foundPodVolume {
+		t.Fatalf("expected pod volume %q", evalhubSATokenVolumeName)
+	}
+
+	// Sidecar must mount evalhub-sa-token at the standard SA token path.
+	sidecar := findContainer(job.Spec.Template.Spec.InitContainers, sidecarContainerName)
+	if sidecar == nil {
+		t.Fatal("sidecar init container not found")
+	}
+	var foundSidecarMount bool
+	for _, m := range sidecar.VolumeMounts {
+		if m.Name == evalhubSATokenVolumeName {
+			foundSidecarMount = true
+			if m.MountPath != k8sSAMountPath {
+				t.Errorf("sidecar SA token mount path: got %q, want %q", m.MountPath, k8sSAMountPath)
+			}
+			if !m.ReadOnly {
+				t.Error("sidecar SA token mount must be read-only")
+			}
+		}
+	}
+	if !foundSidecarMount {
+		t.Fatalf("sidecar must mount %q", evalhubSATokenVolumeName)
+	}
+
+	// Adapter must NOT mount evalhub-sa-token.
+	adapter := findContainer(job.Spec.Template.Spec.Containers, adapterContainerName)
+	if adapter == nil {
+		t.Fatal("adapter container not found")
+	}
+	for _, m := range adapter.VolumeMounts {
+		if m.Name == evalhubSATokenVolumeName {
+			t.Fatalf("adapter must not have %q volume mount", evalhubSATokenVolumeName)
+		}
+	}
+
+	// Adapter must have the pod-namespace DownwardAPI volume mounted at k8sSAMountPath
+	// so the SDK can read the namespace file to set X-Tenant on sidecar requests.
+	var foundNamespaceVolume bool
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if v.Name == adapterNamespaceVolumeName {
+			foundNamespaceVolume = true
+			if v.VolumeSource.Projected == nil {
+				t.Fatal("pod-namespace volume must be a projected volume")
+			}
+			hasDownwardAPI := false
+			for _, src := range v.VolumeSource.Projected.Sources {
+				if src.DownwardAPI != nil {
+					hasDownwardAPI = true
+				}
+			}
+			if !hasDownwardAPI {
+				t.Fatal("pod-namespace projected volume must contain a DownwardAPI source")
+			}
+		}
+	}
+	if !foundNamespaceVolume {
+		t.Fatalf("expected pod-namespace DownwardAPI volume %q on pod", adapterNamespaceVolumeName)
+	}
+	var foundNamespaceMount bool
+	for _, m := range adapter.VolumeMounts {
+		if m.Name == adapterNamespaceVolumeName {
+			foundNamespaceMount = true
+			if m.MountPath != k8sSAMountPath {
+				t.Errorf("adapter namespace mount path: got %q, want %q", m.MountPath, k8sSAMountPath)
+			}
+			if !m.ReadOnly {
+				t.Error("adapter namespace mount must be read-only")
+			}
+		}
+	}
+	if !foundNamespaceMount {
+		t.Fatalf("adapter must mount %q at %q", adapterNamespaceVolumeName, k8sSAMountPath)
 	}
 }

--- a/internal/eval_hub/runtimes/k8s/job_config.go
+++ b/internal/eval_hub/runtimes/k8s/job_config.go
@@ -65,7 +65,7 @@ type jobConfig struct {
 	ociCredentialsSecret       string
 	modelAuthSecretRef         string // user's real credentials secret mounted only in sidecar
 	modelInternalRefSecretName string // ephemeral internalModelRef secret mounted in adapter; empty when credential injection is not active
-	modelTargetURL             string // real model URL forwarded by the sidecar model proxy; cleared when hasCredentialKeys=false
+	modelTargetURL             string // real model URL forwarded by the sidecar model proxy; always set when model auth is configured
 	sidecarResources           corev1.ResourceRequirements
 	testDataS3                 s3TestDataConfig
 	testDataInitImage          string
@@ -167,7 +167,7 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 
 	// modelInternalRefSecretName is set in createBenchmarkResources after inspectModelSecret
 	// confirms proxy-injectable keys. modelTargetURL starts as the model URL when model auth
-	// is configured; cleared in createBenchmarkResources for passthrough-only secrets.
+	// is configured; the sidecar model proxy is always active when model auth is set.
 	modelInternalRefSecretName := ""
 	modelTargetURL := ""
 	if modelAuthSecretRef != "" {

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -210,10 +210,12 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 		"service_ca_configmap", jobConfig.serviceCAConfigMap,
 		"eval_hub_url", jobConfig.evalHubURL,
 	)
-	// Inspect the model credential secret once to decide the auth path. Proxy-injectable keys
-	// (api-key, *_api-key, *_url) activate credential injection — the adapter receives the
-	// ephemeral internalModelRef secret and the sidecar proxies model calls. Passthrough-only
-	// secrets (hf-token/ca_cert) mount directly in the adapter without a ref secret or model proxy.
+	// Inspect the model credential secret once to decide the auth path.
+	// The sidecar model proxy is always started when model.auth is set — it handles SA token
+	// injection for unauthenticated adapter requests, ca_cert TLS, and ref-token resolution.
+	// Proxy-injectable keys (api-key, *_api-key, *_url) additionally activate credential
+	// injection: the adapter receives the ephemeral internalModelRef secret and sends a
+	// ref token that the sidecar resolves to the real credential.
 	var secretInfo modelSecretInfo
 	if jobConfig.modelAuthSecretRef != "" {
 		secretInfo, err = inspectModelSecret(ctx, jobConfig.namespace, jobConfig.modelAuthSecretRef, r.helper)
@@ -221,13 +223,14 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 			logger.Error("kubernetes model secret inspect error", "benchmark_id", benchmarkID, "error", err)
 			return fmt.Errorf("job %s benchmark %s: reading model auth secret: %w", evaluation.Resource.ID, benchmarkID, err)
 		}
+		// Always redirect the adapter through the sidecar model proxy when auth is configured.
+		// This ensures SA token injection and ca_cert TLS are applied even when the secret
+		// contains only ca_cert (no proxy-injectable api-key keys).
+		jobConfig.jobSpec.Model.URL = jobConfig.sidecarBaseURL
 		if secretInfo.hasCredentialKeys {
 			jobConfig.modelInternalRefSecretName = buildK8sName(jobConfig.jobID, jobConfig.resourceGUID, "-model-ref")
-			jobConfig.jobSpec.Model.URL = jobConfig.sidecarBaseURL
 		} else {
-			// passthrough-only (e.g. ca_cert only): clear modelTargetURL so sidecar gets no model proxy config
-			jobConfig.modelTargetURL = ""
-			logger.Info("model credential secret has no proxy-injectable keys; disabling credential injection")
+			logger.Info("model credential secret has no proxy-injectable keys; sidecar proxy active for SA token")
 		}
 	}
 	// Build sidecar config after inspectModelSecret so modelTargetURL reflects the final state.

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -522,6 +522,10 @@ func TestIsModelCredentialKey(t *testing.T) {
 	}
 }
 
+// TestCreateBenchmarkResourcesPassthroughOnlyModelAuth verifies that when the model credential
+// secret contains only ca_cert (SA token auth, no api-key), the sidecar proxy is still started:
+// the adapter URL is redirected to the sidecar, the sidecar gets the real secret mount for TLS,
+// and no internalModelRef ephemeral secret is created (no ref token needed).
 func TestCreateBenchmarkResourcesPassthroughOnlyModelAuth(t *testing.T) {
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)
@@ -553,38 +557,78 @@ func TestCreateBenchmarkResourcesPassthroughOnlyModelAuth(t *testing.T) {
 
 	jobs := listJobsByJobID(t, clientset, evaluation.Resource.ID)
 	job := jobs[0]
-	container := job.Spec.Template.Spec.Containers[0]
 
-	for _, volume := range job.Spec.Template.Spec.Volumes {
-		if volume.Name == modelAuthVolumeName && volume.VolumeSource.Projected != nil {
-			t.Fatal("expected passthrough-only secret to use direct secret mount, not projected ref volume")
-		}
-	}
-	for _, mount := range job.Spec.Template.Spec.InitContainers[0].VolumeMounts {
-		if mount.Name == modelAuthVolumeName {
-			t.Fatal("expected no sidecar real-secret mount when credential injection is disabled")
-		}
-	}
-
+	// No internalModelRef ephemeral secret — no proxy-injectable api-key in the secret.
 	secrets, err := clientset.CoreV1().Secrets("default").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("list secrets: %v", err)
 	}
 	for _, s := range secrets.Items {
 		if strings.Contains(s.Name, "-model-ref") {
-			t.Fatalf("expected no ephemeral ref secret, found %q", s.Name)
+			t.Fatalf("expected no ephemeral ref secret for ca_cert-only auth, found %q", s.Name)
 		}
 	}
 
+	// Adapter must have a projected passthrough volume (for hf-token/ca_cert) but it must
+	// contain only ONE source — the real secret with selective optional keys. It must NOT
+	// include a second source for an internalRef secret (no api-key was injected).
+	var passthroughVolume *corev1.Volume
+	for i := range job.Spec.Template.Spec.Volumes {
+		if job.Spec.Template.Spec.Volumes[i].Name == modelInternalAuthVolumeName {
+			passthroughVolume = &job.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	if passthroughVolume == nil {
+		t.Fatal("expected adapter to have passthrough volume (hf-token/ca_cert) in sidecar-proxy path")
+	}
+	if passthroughVolume.Projected == nil {
+		t.Fatal("expected passthrough volume to be a projected volume")
+	}
+	if len(passthroughVolume.Projected.Sources) != 1 {
+		t.Fatalf("expected exactly 1 projected source (real secret passthrough), got %d", len(passthroughVolume.Projected.Sources))
+	}
+	src := passthroughVolume.Projected.Sources[0]
+	if src.Secret == nil {
+		t.Fatal("expected projected source to be a Secret source")
+	}
+	if src.Secret.Name != "tls-only-creds" {
+		t.Fatalf("expected projected source to name real secret %q, got %q", "tls-only-creds", src.Secret.Name)
+	}
+	// Must NOT reference an internalRef secret (no ephemeral secret was created).
+	if src.Secret.Optional == nil || !*src.Secret.Optional {
+		t.Fatal("expected passthrough secret projection to be optional:true")
+	}
+
+	// Sidecar must have the real secret mounted (for ca_cert TLS and SA token injection).
+	var foundSidecarMount bool
+	for _, init := range job.Spec.Template.Spec.InitContainers {
+		if init.Name != sidecarContainerName {
+			continue
+		}
+		for _, m := range init.VolumeMounts {
+			if m.Name == modelAuthVolumeName {
+				foundSidecarMount = true
+			}
+		}
+	}
+	if !foundSidecarMount {
+		t.Fatal("expected sidecar to have real secret mount for ca_cert TLS")
+	}
+
+	// job.json model URL must be redirected to the sidecar (not the direct model URL),
+	// so the sidecar proxy handles SA token injection and TLS.
 	cmName := job.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.Name
 	cm, err := clientset.CoreV1().ConfigMaps("default").Get(context.Background(), cmName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get configmap: %v", err)
 	}
-	if !strings.Contains(cm.Data["job.json"], "https://model.example.com/v1") {
-		t.Fatalf("expected job.json to keep direct model URL, got %s", cm.Data["job.json"])
+	if strings.Contains(cm.Data["job.json"], "https://model.example.com/v1") {
+		t.Fatalf("expected job.json model URL to be redirected to sidecar, not direct model URL")
 	}
-	_ = container
+	if !strings.Contains(cm.Data["job.json"], "localhost") {
+		t.Fatalf("expected job.json model URL to point to sidecar (localhost), got: %s", cm.Data["job.json"])
+	}
 }
 
 func TestCreateBenchmarkResourcesAddsInitContainerForS3TestData(t *testing.T) {

--- a/internal/eval_runtime_sidecar/handlers/model.go
+++ b/internal/eval_runtime_sidecar/handlers/model.go
@@ -46,7 +46,7 @@ func newModelProxy(config *config.Config, logger *slog.Logger) (*httputil.Revers
 		secretMountPath = ModelAuthSecretMountPathDefault
 	}
 
-	rp := proxy.NewModelReverseProxy(target, modelHTTPClient, logger, secretMountPath)
+	rp := proxy.NewModelReverseProxy(target, modelHTTPClient, logger, secretMountPath, ServiceAccountTokenPathDefault)
 	logger.Info("Model credential-injection proxy enabled", "url", targetURL)
 	return rp, nil
 }

--- a/internal/eval_runtime_sidecar/proxy/auth.go
+++ b/internal/eval_runtime_sidecar/proxy/auth.go
@@ -31,6 +31,7 @@ var (
 	evalHubCachedToken atomic.Pointer[TokenWithExpiry]
 	mlflowCachedToken  atomic.Pointer[TokenWithExpiry]
 	ociCachedToken     atomic.Pointer[TokenWithExpiry]
+	modelSACachedToken atomic.Pointer[TokenWithExpiry]
 )
 
 // getTokenPointer returns the cache slot for a known proxy target, or nil if the endpoint is not cacheable.
@@ -42,6 +43,8 @@ func getTokenPointer(targetEndpoint string) *atomic.Pointer[TokenWithExpiry] {
 		return &mlflowCachedToken
 	case "oci":
 		return &ociCachedToken
+	case "model-sa":
+		return &modelSACachedToken
 	default:
 		return nil
 	}

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -15,7 +15,7 @@ import (
 )
 
 // modelRefSuffix is the value suffix that signals credential injection.
-// A Bearer token "api-key:ref" means: look up "api-key" in the real secret mount.
+// A Bearer token "api-key:ref" means: look up "api-key" in the secret cache.
 const modelRefSuffix = ":ref"
 
 // modelAPIKeySuffix and modelURLSuffix are the key-naming conventions for multi-model secrets.
@@ -47,16 +47,25 @@ func loggerForRequest(logger *slog.Logger, req *http.Request) *slog.Logger {
 
 // NewModelReverseProxy returns an httputil.ReverseProxy that performs model credential injection.
 //
+// All credential files under secretMountPath are read once at construction time into an
+// in-memory cache. The mount is a static Kubernetes secret volume — files do not change
+// for the pod's lifetime — so per-request file reads are unnecessary.
+//
 // Per-request behaviour:
 //  1. If the Authorization header carries a ref token (e.g. "Bearer model-1_api-key:ref"):
-//     a. The real credential is read from realSecretMountPath/model-1_api-key.
-//     b. The upstream URL is determined by reading realSecretMountPath/model-1_url
-//     (derived by replacing "_api-key" → "_url"). Falls back to defaultTarget when
-//     the URL file is absent (single-model / hf-token case).
-//  2. If resolution fails (missing file, empty value, path traversal) the proxy returns
-//     HTTP 400 to the eval container — the request is never forwarded.
-//  3. Non-ref tokens are forwarded unchanged to defaultTarget.
-func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *slog.Logger, realSecretMountPath string) *httputil.ReverseProxy {
+//     a. The credential is looked up from the in-memory cache by key name.
+//     b. The upstream URL is looked up from the cache under model-1_url; falls back to
+//     defaultTarget when absent (single-model case).
+//  2. If resolution fails (key not in cache, path traversal) the proxy returns HTTP 400
+//     to the eval container — the request is never forwarded.
+//  3. If no Authorization header is present, the SA token from saTokenPath is injected as
+//     a Bearer token. This covers SA-token-authenticated models: the adapter has no access
+//     to the SA token (pod-level auto-mount is disabled), so the sidecar injects it on
+//     its behalf.
+//  4. Non-ref, non-empty tokens are forwarded unchanged to defaultTarget.
+func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *slog.Logger, secretMountPath, saTokenPath string) *httputil.ReverseProxy {
+	secretCache := loadSecretCache(secretMountPath, logger)
+
 	rp := &httputil.ReverseProxy{
 		Transport: &modelRoundTripper{
 			inner:  &roundTripperFromClient{client: client},
@@ -74,7 +83,7 @@ func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *s
 
 		authHeader := pr.In.Header.Get("Authorization")
 		if isModelRefToken(authHeader) {
-			resolvedTarget, realToken, err := resolveModelCredential(logger, reqID, authHeader, realSecretMountPath, defaultTarget)
+			resolvedTarget, realToken, err := resolveModelCredential(logger, reqID, authHeader, secretCache, defaultTarget)
 			if err != nil {
 				// Signal the RoundTripper to return 400 without forwarding.
 				pr.Out.Header.Set(xModelCredError, err.Error())
@@ -86,6 +95,19 @@ func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *s
 			}
 			target = resolvedTarget
 			SetAuthHeader(pr.Out, realToken)
+		} else if isBearerEmpty(authHeader) {
+			// No usable Authorization from adapter (absent or empty Bearer value). The adapter
+			// cannot read the SA token because pod-level auto-mount is disabled. Inject it here
+			// so SA-token-authenticated model endpoints receive a valid Bearer token.
+			if tok := resolveEvalHubOrMLflowToken(reqLog, AuthTokenInput{
+				TargetEndpoint: "model-sa",
+				AuthTokenPath:  saTokenPath,
+			}); tok != "" {
+				SetAuthHeader(pr.Out, tok)
+				reqLog.Info("Injected SA token for model request (no Authorization from adapter)")
+			} else {
+				reqLog.Warn("SA token injection skipped: token unavailable", "path", saTokenPath)
+			}
 		}
 
 		// Set only scheme and host from the target — do not join the target path with the
@@ -149,13 +171,64 @@ func isModelRefToken(authHeader string) bool {
 	return strings.HasSuffix(strings.TrimPrefix(authHeader, "Bearer "), modelRefSuffix)
 }
 
-// resolveModelCredential resolves a Bearer ref token to a (upstream URL, real credential) pair.
+// isBearerEmpty reports whether authHeader carries no usable token.
+//
+// Returns true when the header is absent, is exactly "Bearer" (Go's HTTP parser
+// strips the trailing space from "Bearer " sent by Python's requests library when
+// OPENAI_API_KEY=""), or is "Bearer " with a whitespace-only value.
+func isBearerEmpty(authHeader string) bool {
+	if authHeader == "" || authHeader == "Bearer" {
+		return true
+	}
+	if strings.HasPrefix(authHeader, "Bearer ") {
+		return strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer ")) == ""
+	}
+	return false
+}
+
+// loadSecretCache reads all files in mountPath into a map at proxy startup.
+// The model secret mount is static for the pod's lifetime, so this avoids
+// per-request file reads. Returns an empty map if mountPath is empty or unreadable.
+func loadSecretCache(mountPath string, logger *slog.Logger) map[string]string {
+	cache := make(map[string]string)
+	if mountPath == "" {
+		return cache
+	}
+	entries, err := os.ReadDir(mountPath)
+	if err != nil {
+		logger.Warn("model secret mount unreadable; credential resolution will fail for ref tokens", "path", mountPath, "error", err)
+		return cache
+	}
+	for _, e := range entries {
+		// Skip directories and Kubernetes secret mount internals (..data, ..2024_... symlinks).
+		if e.IsDir() || strings.HasPrefix(e.Name(), "..") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(mountPath, e.Name()))
+		if err != nil {
+			logger.Warn("skipping unreadable secret file", "file", e.Name(), "error", err)
+			continue
+		}
+		if v := strings.TrimSpace(string(data)); v != "" {
+			cache[e.Name()] = v
+		}
+	}
+	keys := make([]string, 0, len(cache))
+	for k := range cache {
+		keys = append(keys, k)
+	}
+	logger.Info("Loaded model secret cache", "path", mountPath, "keys", keys)
+	return cache
+}
+
+// resolveModelCredential resolves a Bearer ref token to a (upstream URL, credential) pair
+// using the pre-loaded in-memory secret cache.
 //
 // Key derivation for the upstream URL:
-//   - "model-1_api-key:ref" → reads realSecretMountPath/model-1_api-key (token) and
-//     realSecretMountPath/model-1_url (URL); falls back to defaultTarget if _url absent.
-//   - "api-key:ref" / "hf-token:ref" → reads the credential file; always uses defaultTarget.
-func resolveModelCredential(logger *slog.Logger, requestID, authHeader, realSecretMountPath string, defaultTarget *url.URL) (*url.URL, string, error) {
+//   - "model-1_api-key:ref" → looks up "model-1_api-key" (token) and "model-1_url" (URL)
+//     in secretCache; falls back to defaultTarget when the URL key is absent.
+//   - "api-key:ref" → looks up the credential; always uses defaultTarget.
+func resolveModelCredential(logger *slog.Logger, requestID, authHeader string, secretCache map[string]string, defaultTarget *url.URL) (*url.URL, string, error) {
 	token := strings.TrimPrefix(authHeader, "Bearer ")
 	key := strings.TrimSuffix(token, modelRefSuffix)
 
@@ -163,9 +236,9 @@ func resolveModelCredential(logger *slog.Logger, requestID, authHeader, realSecr
 		return nil, "", fmt.Errorf("model ref token has invalid key %q", key)
 	}
 
-	realToken, err := readSecretFile(realSecretMountPath, key)
-	if err != nil {
-		logger.Error("failed to read model credential", "request_id", requestID, "key", key)
+	realToken, ok := secretCache[key]
+	if !ok {
+		logger.Error("model credential not found in cache", "request_id", requestID, "key", key)
 		return nil, "", fmt.Errorf("credential not found for key %q", key)
 	}
 	if realToken == "" {
@@ -174,15 +247,14 @@ func resolveModelCredential(logger *slog.Logger, requestID, authHeader, realSecr
 
 	target := defaultTarget
 
-	// For multi-model keys (*_api-key), try to read the corresponding URL file.
+	// For multi-model keys (*_api-key), look up the corresponding URL entry.
 	if strings.HasSuffix(key, modelAPIKeySuffix) {
 		prefix := strings.TrimSuffix(key, modelAPIKeySuffix)
 		urlKey := prefix + modelURLSuffix
-		rawURL, urlErr := readSecretFile(realSecretMountPath, urlKey)
-		if urlErr == nil && rawURL != "" {
+		if rawURL, exists := secretCache[urlKey]; exists && rawURL != "" {
 			parsed, parseErr := url.Parse(strings.TrimSuffix(rawURL, "/"))
 			if parseErr != nil || !parsed.IsAbs() || parsed.Host == "" {
-				logger.Warn("model URL file has invalid or relative URL, using default target",
+				logger.Warn("model URL in secret cache is invalid, using default target",
 					"request_id", requestID, "url_key", urlKey, "error", parseErr)
 			} else {
 				target = parsed
@@ -192,13 +264,4 @@ func resolveModelCredential(logger *slog.Logger, requestID, authHeader, realSecr
 
 	logger.Info("Resolved model ref token", "request_id", requestID, "key", key, "target_host", target.Host)
 	return target, realToken, nil
-}
-
-// readSecretFile reads and trims a single file from a Kubernetes secret mount.
-func readSecretFile(mountPath, key string) (string, error) {
-	data, err := os.ReadFile(filepath.Join(mountPath, key))
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(data)), nil
 }

--- a/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
@@ -348,7 +348,7 @@ func TestIsBearerEmpty(t *testing.T) {
 		want   bool
 	}{
 		{"", true},
-		{"Bearer", true},  // Go HTTP parser strips trailing space from "Bearer " sent by Python requests
+		{"Bearer", true}, // Go HTTP parser strips trailing space from "Bearer " sent by Python requests
 		{"Bearer ", true},
 		{"Bearer  ", true},
 		{"Bearer \t", true},

--- a/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
@@ -41,7 +41,7 @@ func TestModelProxyLogsRequestID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rp := NewModelReverseProxy(target, &http.Client{}, log, secretDir)
+	rp := NewModelReverseProxy(target, &http.Client{}, log, secretDir, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set(globalTransactionIDHeader, "model-proxy-req-id")
@@ -67,7 +67,8 @@ func TestResolveModelCredentialLogsRequestID(t *testing.T) {
 	}
 
 	target, _ := url.Parse("https://model.example.com/v1")
-	_, _, err := resolveModelCredential(log, "resolve-req-id", "Bearer api-key:ref", secretDir, target)
+	cache := loadSecretCache(secretDir, log)
+	_, _, err := resolveModelCredential(log, "resolve-req-id", "Bearer api-key:ref", cache, target)
 	if err != nil {
 		t.Fatalf("resolveModelCredential: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestModelProxyReturns400OnMissingRef(t *testing.T) {
 	target, _ := url.Parse(upstream.URL)
 	secretDir := t.TempDir() // no files — ref key will be missing
 
-	rp := NewModelReverseProxy(target, &http.Client{}, log, secretDir)
+	rp := NewModelReverseProxy(target, &http.Client{}, log, secretDir, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set(globalTransactionIDHeader, "cred-fail-req-id")
@@ -121,7 +122,7 @@ func TestModelProxySingleModelResolves(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir)
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Authorization", "Bearer api-key:ref")
@@ -166,7 +167,7 @@ func TestModelProxyMultiModelRoutesToCorrectUpstream(t *testing.T) {
 	writeFile("model-2_api-key", "sk-model2")
 	writeFile("model-2_url", upstream2.URL)
 
-	rp := NewModelReverseProxy(defaultTarget, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir)
+	rp := NewModelReverseProxy(defaultTarget, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, "")
 
 	// Request for model-1 should go to upstream1 with model-1's real key.
 	req1 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
@@ -202,7 +203,7 @@ func TestModelProxyNonRefTokenPassthrough(t *testing.T) {
 	defer upstream.Close()
 
 	target, _ := url.Parse(upstream.URL)
-	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), t.TempDir())
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), t.TempDir(), "")
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Authorization", "Bearer sk-already-real")
@@ -230,7 +231,7 @@ func TestModelProxyReturns400OnEmptyCredential(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir)
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Authorization", "Bearer api-key:ref")
@@ -239,5 +240,157 @@ func TestModelProxyReturns400OnEmptyCredential(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for empty credential, got %d", rr.Code)
+	}
+}
+
+// TestModelProxySATokenInjectedWhenNoAuth verifies that when the adapter sends no Authorization
+// header, the sidecar injects the SA token as a Bearer token before forwarding to the model.
+func TestModelProxySATokenInjectedWhenNoAuth(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	saTokenDir := t.TempDir()
+	saTokenPath := filepath.Join(saTokenDir, "token")
+	if err := os.WriteFile(saTokenPath, []byte("sa-token-from-sidecar"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	target, _ := url.Parse(upstream.URL)
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), t.TempDir(), saTokenPath)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	// No Authorization header set — simulates adapter with no SA token access.
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if gotAuth != "Bearer sa-token-from-sidecar" {
+		t.Fatalf("expected SA token injected, got %q", gotAuth)
+	}
+}
+
+// TestModelProxySATokenInjectedWhenBareBearer verifies that "Authorization: Bearer" (no
+// trailing space — what Go's HTTP parser stores when Python sends "Bearer ") triggers SA
+// token injection. This is the primary on-wire form when OPENAI_API_KEY is unset.
+func TestModelProxySATokenInjectedWhenBareBearer(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	saTokenDir := t.TempDir()
+	saTokenPath := filepath.Join(saTokenDir, "token")
+	if err := os.WriteFile(saTokenPath, []byte("sa-token-from-sidecar"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	target, _ := url.Parse(upstream.URL)
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), t.TempDir(), saTokenPath)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/completions", nil)
+	// Go HTTP parser strips trailing space: Python's "Bearer " arrives as "Bearer".
+	req.Header.Set("Authorization", "Bearer")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if gotAuth != "Bearer sa-token-from-sidecar" {
+		t.Fatalf("expected SA token injected for bare Bearer, got %q", gotAuth)
+	}
+}
+
+// TestModelProxySATokenInjectedWhenEmptyBearer verifies that "Authorization: Bearer " (empty
+// Bearer value, sent by lm-eval when OPENAI_API_KEY is unset) is treated as absent auth and
+// the SA token is injected. This is the real SA-token-auth path from the adapter.
+func TestModelProxySATokenInjectedWhenEmptyBearer(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	saTokenDir := t.TempDir()
+	saTokenPath := filepath.Join(saTokenDir, "token")
+	if err := os.WriteFile(saTokenPath, []byte("sa-token-from-sidecar"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	target, _ := url.Parse(upstream.URL)
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), t.TempDir(), saTokenPath)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer ") // lm-eval sends this when OPENAI_API_KEY=""
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if gotAuth != "Bearer sa-token-from-sidecar" {
+		t.Fatalf("expected SA token injected for empty Bearer, got %q", gotAuth)
+	}
+}
+
+func TestIsBearerEmpty(t *testing.T) {
+	cases := []struct {
+		header string
+		want   bool
+	}{
+		{"", true},
+		{"Bearer", true},  // Go HTTP parser strips trailing space from "Bearer " sent by Python requests
+		{"Bearer ", true},
+		{"Bearer  ", true},
+		{"Bearer \t", true},
+		{"Bearer sk-real", false},
+		{"Bearer api-key:ref", false},
+		{"Token abc", false},
+	}
+	for _, tc := range cases {
+		if got := isBearerEmpty(tc.header); got != tc.want {
+			t.Errorf("isBearerEmpty(%q) = %v, want %v", tc.header, got, tc.want)
+		}
+	}
+}
+
+// TestModelProxySATokenNotInjectedWhenAuthPresent verifies that an explicit Authorization
+// header from the adapter is forwarded unchanged even when a SA token path is configured.
+func TestModelProxySATokenNotInjectedWhenAuthPresent(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	saTokenDir := t.TempDir()
+	saTokenPath := filepath.Join(saTokenDir, "token")
+	if err := os.WriteFile(saTokenPath, []byte("sa-token-should-not-be-used"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	target, _ := url.Parse(upstream.URL)
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), t.TempDir(), saTokenPath)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sk-explicit-key")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if gotAuth != "Bearer sk-explicit-key" {
+		t.Fatalf("expected explicit auth forwarded unchanged, got %q", gotAuth)
 	}
 }


### PR DESCRIPTION
**SA Token Sidecar-Only Mounting**
- Disabled pod-level SA token auto-mount (AutomountServiceAccountToken: false) so the adapter cannot access the SA token
- Sidecar gets a projected evalhub-sa-token volume at the standard Kubernetes SA path 
- Adapter gets a DownwardAPI pod-namespace volume at the same path exposing only the namespace file, so the SDK can set X-Tenant on sidecar requests without seeing the SA token

**Sidecar Model Proxy Always Active When Auth Is Configured**
- Sidecar model proxy was previously skipped for passthrough-only secrets (ca_cert/hf-token); now unconditionally started whenever model.auth.secret_ref is set
- Adapter URL always redirected to localhost:8080; real model URL stored in sidecarConfig.Model.URL
- Real credentials secret always mounted in sidecar (not just when credential injection is active); direct-mount path to adapter removed

**SA Token Injection in Model Proxy**
- When adapter sends no Authorization (or empty Bearer/Bearer ), sidecar injects the SA token as Bearer <token> before forwarding — covers SA-token-authenticated models where the adapter has no token access
- Added modelSACachedToken cache slot using the same atomic.Pointer[TokenWithExpiry] pattern as eval-hub and mlflow tokens
- Handles Python requests quirk where Bearer (trailing space) arrives as Bearer at Go's HTTP parser — both treated as absent auth

**Model Secret Cache at Proxy Startup**
- All files under /var/run/secrets/model read once at proxy construction into an in-memory map[string]string; eliminates per-request file I/O for the pod's lifetime
- Kubernetes internal entries (..data, ..2024_... symlinks) skipped; loaded key names logged at startup

**Adapter Model Auth Volume Restructured**
- Adapter always receives a projected model-auth-internal volume (never a raw secret mount) when modelAuthSecretRef is set
- With api-key (credential injection active): internalRef secret prepended with synthetic :ref tokens, followed by real secret with optional:true for passthrough keys
- Without api-key (passthrough-only): projected volume contains only the real secret with optional:true

**MLflow Token Removed from Adapter**
- MLFLOW_TRACKING_TOKEN_PATH env var and mlflow projected token volume removed from adapter; sidecar already proxies all MLflow calls on its behalf

## What and why

<!-- What does this PR do and why? Link to related issues. -->
https://redhat.atlassian.net/browse/RHOAIENG-70469

Closes #

Assisted-by: <!-- Cursor, Claude etc -->

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually
Below are the different scenarios I had tested.
  SNo | Model Auth Config | Secret Keys | Adapter job.json URL | Sidecar sidecar_config.json | Adapter /var/run/secrets/model | MLflow in Adapter | Result
    -- | -- | -- | -- | -- | -- | -- | --
    1 | SA token + ca_cert | ca_cert (passthrough only) | localhost:8080 | Real model URL + auth_secret_mount_path | ca_cert (real value) | Not mounted | ✅ Passed
    2 | api-key + ca_cert + hf-token | api-key, ca_cert, hf-token | localhost:8080 | Real model URL + auth_secret_mount_path | api-key → api-key:ref, ca_cert/hf-token real values | Not mounted | ✅ Passed
    3 | No auth (open model) | None | Real model URL | No model section | Not mounted | Not mounted | ✅ Passed
    4 | Multi-model | api-key, ca_cert, hf-token, model-1_api-key, model-1_url | localhost:8080 | Real model URL + auth_secret_mount_path | api-key, model-1_api-key, model-1_url masked; ca_cert/hf-token real | Not mounted | ✅ Passed


## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model access handling so authenticated requests can continue through the sidecar more reliably.
  * Added support for automatic token use when a request has no usable authorization header.

* **Bug Fixes**
  * Fixed Kubernetes job setup so the sidecar gets the needed token access while the main container does not.
  * Improved secret handling for model credentials, including safer projected mounts and better support for partial credential sets.
  * Requests now route through the sidecar more consistently when model authentication is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->