### PR TITLE
fix: bump Go to 1.26.4 to fix 3 stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/eval-hub/eval-hub
 
-go 1.26.3
+go 1.26.4
 
-// toolchain go1.26.3
+// toolchain go1.26.4
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1


### PR DESCRIPTION
## Summary

- Bumps Go version from 1.26.3 to 1.26.4 in `go.mod` to fix 3 standard library CVEs identified by `govulncheck`
- All Go module dependencies (228 total) are already at patched versions with no known CVEs
- npm audit reports 0 vulnerabilities; all overrides in `package.json` are at current, safe versions

## CVEs Fixed

| CVE | Package | Severity | Description |
|-----|---------|----------|-------------|
| [CVE-2026-42507](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` | Moderate | Arbitrary input included in errors without escaping — attacker can inject misleading content into logs/output |
| [CVE-2026-42504](https://pkg.go.dev/vuln/GO-2026-5038) | `mime` | Moderate (DoS) | Quadratic complexity in `WordDecoder.DecodeHeader` — crafted MIME headers cause excessive CPU |
| [CVE-2026-27145](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` | Moderate (DoS) | Quadratic hostname parsing in certificate verification — large DNS SAN lists cause excessive CPU even for untrusted certs |

All 3 vulnerabilities were confirmed as **called** in the compiled binary via `govulncheck -mode binary`.

## go-toolset Note

**Go 1.26.4 is not yet available in `registry.access.redhat.com/ubi9/go-toolset`** — the latest published tag is `1.26.3`. The Containerfile uses `go-toolset:1.26` (floating tag), which will automatically resolve to 1.26.4 once Red Hat publishes the updated image. Until then, container builds will continue using Go 1.26.3.

Local builds with `GOTOOLCHAIN=auto` will automatically download and use Go 1.26.4.

## Other Scan Results

- **Go module dependencies:** All 228 modules are at versions with no known CVEs (verified via govulncheck and manual cross-referencing against vuln.go.dev)
- **npm dependencies:** `npm audit` reports 0 vulnerabilities. All `package.json` overrides (postcss, lodash, ws, protobufjs, dompurify, etc.) are at their latest safe versions

## Test plan

- [x] `go build ./...` passes with Go 1.26.4
- [x] `make fmt lint` passes
- [x] `make test` — pre-existing MLFlow integration test failures (requires MLFlow server, unrelated to this change); all other tests pass
- [x] `go mod tidy` produces no changes beyond the version bump
- [x] Pre-commit hooks pass

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->