### PR TITLE
fix(tests): update evaluation job feature files and suppport optional queue

### DIFF
--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -105,7 +105,7 @@ Feature: Evaluation Jobs
 
   Scenario: Evaluation job with multiple benchmarks from same provider
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_multiple_benchmark.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_multiple_benchmark.json"
     Then the response code should be 202
     And the response should contain the value "pending" at path "$.status.state"
     And the response should contain the value "evaluation_job_created" at path "$.status.message.message_code"
@@ -292,11 +292,11 @@ Feature: Evaluation Jobs
     When I send a POST request to "/api/v1/evaluations/collections" with body "file:/collection.json"
     Then the response code should be 201
     And the "resource.id" field in the response should be saved as "value:collection_id"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_mlflow_collection_shared_job1.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_mlflow_collection_shared_job1.json"
     Then the response code should be 202
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:exp_id"
     And the "resource.id" field in the response should be saved as "value:exp_job1_id"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_mlflow_collection_shared_job2.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_mlflow_collection_shared_job2.json"
     Then the response code should be 202
     And the response should contain the value "{{value:exp_id}}" at path "$.resource.mlflow_experiment_id"
     And the "resource.id" field in the response should be saved as "value:exp_job2_id"
@@ -394,7 +394,7 @@ Feature: Evaluation Jobs
  # This test uses gated HuggingFace datasets (toxigen, truthfulqa_mc1, bigbench_hhh_alignment_multiple_choice) which require authentication.
   Scenario: Verify Evaluation Jobs Can Use OOB Collections - toxicity-and-ethical-principles
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_toxicity.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_toxicity.json"
     Then the response code should be 202
     And the response should contain the value "toxicity-and-ethical-principles" at path "$.collection.id"
     And I wait for the evaluation job status to be "completed"
@@ -621,29 +621,29 @@ Feature: Evaluation Jobs
 
   Scenario: Multiple jobs can reference different OOB collection
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_ref_safety_fairness_job1.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_ref_safety_fairness_job1.json"
     Then the response code should be 202
     And the response should contain the value "safety-and-fairness-v1" at path "$.collection.id"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_ref_toxicity_job2.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_ref_toxicity_job2.json"
     Then the response code should be 202
     And the response should contain the value "toxicity-and-ethical-principles" at path "$.collection.id"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_ref_leaderboard_job3.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_ref_leaderboard_job3.json"
     Then the response code should be 202
     And the response should contain the value "leaderboard-v2" at path "$.collection.id"
 
   Scenario: Multiple jobs can reference same OOB collection
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_ref_safety_same1.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_ref_safety_same1.json"
     Then the response code should be 202
     And the response should contain the value "safety-and-fairness-v1" at path "$.collection.id"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_ref_safety_same2.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_ref_safety_same2.json"
     Then the response code should be 202
     And the response should contain the value "safety-and-fairness-v1" at path "$.collection.id"
 
   @mlflow
   Scenario: Create an evaluation job with MLflow experiment and OOB collection
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_mlflow_oob_leaderboard.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_mlflow_oob_leaderboard.json"
     Then the response code should be 202
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
     Then the response code should be 200
@@ -1006,7 +1006,7 @@ Feature: Evaluation Jobs
   # This scenario requires HuggingFace authentication for all 3 benchmarks to run
   Scenario: Create evaluation job with queue and collection
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_kueue_oob_toxicity.jsonnet"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_kueue_oob_toxicity.json"
     Then the response code should be 202
     And the response should contain the value "kueue" at path "$.queue.kind"
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.queue.name"
@@ -1023,44 +1023,8 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Create evaluation job with queue and MLflow experiment
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}"
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 10,
-              "num_fewshot": 3,
-              "limit": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "{{mlflow:my-test-experiment}}",
-          "tags": [
-            {
-              "key": "environment",
-              "value": "test"
-            }
-          ]
-        },
-        "name": "test-evaluation-job-with-kueue-and-mlflow",
-        "queue": {
-          "kind": "kueue",
-          "name": "{{env:QUEUE_NAME|user-queue}}"
-        },
-        "tags": [
-          "environment"
-        ]
-      }
-      """
+    And queue is enabled for payloads
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
     Then the response code should be 202
     And the response should contain the value "kueue" at path "$.queue.kind"
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.queue.name"

--- a/tests/features/gpu_step_definitions_test.go
+++ b/tests/features/gpu_step_definitions_test.go
@@ -382,8 +382,8 @@ func setupGPUTestEnvironment(namespace string) error {
 }
 
 func gpuFTBaseURL() string {
-	if api != nil && api.baseURL != nil {
-		return strings.TrimRight(api.baseURL.String(), "/")
+	if apiFeat != nil && apiFeat.baseURL != nil {
+		return strings.TrimRight(apiFeat.baseURL.String(), "/")
 	}
 	if u := os.Getenv("SERVER_URL"); u != "" {
 		return strings.TrimRight(u, "/")
@@ -411,8 +411,8 @@ func gpuFTAuthToken(tenant string) (string, error) {
 }
 
 func gpuFTHTTPClient() *http.Client {
-	if api != nil && api.client != nil {
-		return api.client
+	if apiFeat != nil && apiFeat.client != nil {
+		return apiFeat.client
 	}
 	return &http.Client{Timeout: 30 * time.Second}
 }
@@ -486,7 +486,7 @@ func providerHasGPUTag(tags []string) bool {
 */
 
 func deleteGPUTestProvidersAPI(headers map[string]string) error {
-	if api == nil {
+	if apiFeat == nil {
 		return fmt.Errorf("API feature not initialized")
 	}
 	if len(gpuTestProviderIDs) == 0 {
@@ -554,7 +554,7 @@ func createGPUTestProviderViaAPI(headers map[string]string, bodyFile string) (st
 
 // createGPUTestProviders registers GPU test providers via the EvalHub providers API.
 func createGPUTestProviders(namespace string) error {
-	if api == nil {
+	if apiFeat == nil {
 		return fmt.Errorf("API feature not initialized")
 	}
 

--- a/tests/features/jsonnet_test.go
+++ b/tests/features/jsonnet_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/eval-hub/eval-hub/pkg/api"
 	"github.com/google/go-jsonnet"
 )
 
@@ -15,6 +17,7 @@ type jsonnetHarness struct {
 	Env           map[string]string `json:"env"`
 	Values        map[string]string `json:"values"`
 	MlflowEnabled bool              `json:"mlflow_enabled"`
+	QueueEnabled  bool              `json:"queue_enabled"`
 	Disconnected  bool              `json:"disconnected"`
 }
 
@@ -70,11 +73,16 @@ func (tc *scenarioConfig) jsonnetHarnessJSON() (string, error) {
 	if tc.jsonnetMlflowEnabled != nil {
 		mlflowEnabled = *tc.jsonnetMlflowEnabled
 	}
+	queueEnabled := false
+	if tc.jsonnetQueueEnabled != nil {
+		queueEnabled = *tc.jsonnetQueueEnabled
+	}
 	disconnected := strings.Contains(strings.ToLower(env["ENVIRONMENT_ID"]), "disconnected")
 	harness := jsonnetHarness{
 		Env:           env,
 		Values:        values,
 		MlflowEnabled: mlflowEnabled,
+		QueueEnabled:  queueEnabled,
 		Disconnected:  disconnected,
 	}
 	encoded, err := json.Marshal(harness)
@@ -539,6 +547,87 @@ func TestEvaluateEvaluationJobJsonnetConnected(t *testing.T) {
 	}
 	if b.TestDataRef != nil {
 		t.Errorf("test_data_ref = %+v, want nil", b.TestDataRef.S3)
+	}
+}
+
+func TestEvaluateEvaluationJobJsonnetWithQueue(t *testing.T) {
+	queueJobJson := `
+	{
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}"
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 10,
+              "num_fewshot": 3,
+              "limit": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "name": "test-evaluation-job",
+        "queue": {
+          "kind": "kueue",
+          "name": "{{env:QUEUE_NAME|user-queue}}"
+        },
+        "tags": [
+          "environment"
+        ]
+      }`
+	queueOn := true
+	tc := &scenarioConfig{
+		values: map[string]string{},
+		jsonnetHarnessEnv: map[string]string{
+			"MODEL_NAME": "{{env:MODEL_NAME|test}}",
+			"MODEL_URL":  "{{env:MODEL_URL|http://test.com}}",
+		},
+		jsonnetQueueEnabled: &queueOn,
+	}
+	path, err := filepath.Abs(filepath.Join(testDataRoot(), "evaluation_job.jsonnet"))
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	out, err := tc.evaluateJsonnetFile(path)
+	if err != nil {
+		t.Fatalf("evaluateJsonnetFile: %v", err)
+	}
+	outJob := api.EvaluationJobConfig{}
+	err = json.Unmarshal([]byte(out), &outJob)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	queueJob := api.EvaluationJobConfig{}
+	err = json.Unmarshal([]byte(queueJobJson), &queueJob)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(outJob, queueJob) {
+		if !reflect.DeepEqual(outJob.Name, queueJob.Name) {
+			t.Errorf("name = %+v, want %+v", outJob.Name, queueJob.Name)
+		}
+		if !reflect.DeepEqual(outJob.Description, queueJob.Description) {
+			t.Errorf("description = %+v, want %+v", outJob.Description, queueJob.Description)
+		}
+		if !reflect.DeepEqual(outJob.Model, queueJob.Model) {
+			t.Errorf("model = %+v, want %+v", outJob.Model, queueJob.Model)
+		}
+		if !reflect.DeepEqual(outJob.Benchmarks, queueJob.Benchmarks) {
+			t.Errorf("benchmarks = %+v, want %+v", outJob.Benchmarks, queueJob.Benchmarks)
+		}
+		if !reflect.DeepEqual(outJob.Experiment, queueJob.Experiment) {
+			t.Errorf("experiment = %+v, want %+v", outJob.Experiment, queueJob.Experiment)
+		}
+		if !reflect.DeepEqual(outJob.Queue, queueJob.Queue) {
+			t.Errorf("queue = %+v, want %+v", outJob.Queue, queueJob.Queue)
+		}
+		t.Errorf("got = %+v,\n\nwant %+v", outJob, queueJob)
 	}
 }
 

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -61,7 +61,7 @@ const (
 var (
 	// testConfig to be used throughout all the test suites
 	// for the global configuration
-	api *apiFeature
+	apiFeat *apiFeature
 
 	once   sync.Once
 	logger *log.Logger
@@ -103,6 +103,8 @@ type scenarioConfig struct {
 	jsonnetHarnessEnvOmit []string
 	// jsonnetMlflowEnabled overrides harness.mlflow_enabled when non-nil.
 	jsonnetMlflowEnabled *bool
+	// jsonnetQueueEnabled overrides harness.queue_enabled when non-nil.
+	jsonnetQueueEnabled *bool
 
 	waitDeadline time.Duration
 	waitInterval time.Duration
@@ -1446,7 +1448,15 @@ func (tc *scenarioConfig) requireMetricsURLForRemoteServer(ctx context.Context, 
 
 func (tc *scenarioConfig) saveScenarioName(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
 	tc.scenarioName = sc.Name
+	tc.jsonnetQueueEnabled = nil
 	return ctx, nil
+}
+
+func (tc *scenarioConfig) queueIsEnabledForJsonnetPayloads() error {
+	queueOn := true
+	tc.jsonnetQueueEnabled = &queueOn
+	logDebug("Queue enabled for jsonnet payloads\n")
+	return nil
 }
 
 func (tc *scenarioConfig) assetCleanup(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
@@ -1508,19 +1518,19 @@ func setUpTestConf() {
 	if err != nil {
 		panic(logError(fmt.Errorf("failed to create API feature: %v", err)))
 	}
-	api = apiFeature
+	apiFeat = apiFeature
 }
 
 func waitForService() {
-	tc := createScenarioConfig(api)
+	tc := createScenarioConfig(apiFeat)
 	if err := tc.theServiceIsRunning(context.Background()); err != nil {
 		panic("Stopped API Tests. Service is not ready for testing.\n")
 	}
 }
 
 func tidyUpTests() {
-	if api != nil {
-		api.cleanup(context.Background(), nil, nil)
+	if apiFeat != nil {
+		apiFeat.cleanup(context.Background(), nil, nil)
 	}
 	if s, ok := logger.Writer().(*os.File); ok {
 		err := s.Close()
@@ -1582,7 +1592,7 @@ func (tc *scenarioConfig) theModelEndpointIsReachable() error {
 
 // A bit of a hack to have some checks that the regexes are working as expected
 func checkRegexes() {
-	tc := createScenarioConfig(api)
+	tc := createScenarioConfig(apiFeat)
 	paths := [][]string{
 		{"/api/v1/evaluations", "evaluations", "", ""},
 		{"/api/v1/evaluations/jobs", "evaluations", "jobs", ""},
@@ -1670,13 +1680,14 @@ func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 }
 
 func InitializeScenario(ctx *godog.ScenarioContext) {
-	tc := createScenarioConfig(api)
+	tc := createScenarioConfig(apiFeat)
 
 	ctx.Before(tc.saveScenarioName)
 	ctx.Before(tc.requireMetricsURLForRemoteServer)
 	ctx.After(tc.assetCleanup)
 
 	ctx.Step(`^the service is running$`, tc.theServiceIsRunning)
+	ctx.Step(`^queue is enabled for payloads$`, tc.queueIsEnabledForJsonnetPayloads)
 	ctx.Step(`^the model endpoint is reachable$`, tc.theModelEndpointIsReachable)
 	ctx.Step(`^there are system providers$`, tc.thereAreSystemProviders)
 	ctx.Step(`^there are system collections$`, tc.thereAreSystemCollections)

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -256,13 +256,13 @@ func createApiFeature() (*apiFeature, error) {
 		return nil, logError(err)
 	}
 
-	api := &apiFeature{
+	apiFeat := &apiFeature{
 		client:         client,
 		baseURL:        baseURL,
 		metricsBaseURL: metricsBase,
 	}
-	api.startLocalServer(port)
-	return api, nil
+	apiFeat.startLocalServer(port)
+	return apiFeat, nil
 }
 
 // ensureFVTOTELConfig enables OTEL metrics export for embedded FVT servers when Prometheus

--- a/tests/features/test_data/evaluation_job.jsonnet
+++ b/tests/features/test_data/evaluation_job.jsonnet
@@ -3,14 +3,17 @@ local collectionId = test.value('collection_id');
 
 test.mergeOptional(
   test.mergeOptional(
-    {
-      model: test.model(),
-      name: 'test-evaluation-job',
-    } + if collectionId == '' then {
-      benchmarks: [test.defaultBenchmark()],
-      tags: ['environment'],
-    } else {},
-    if collectionId != '' then test.collection() else null,
+    test.mergeOptional(
+      {
+        model: test.model(),
+        name: 'test-evaluation-job',
+      } + if collectionId == '' then {
+        benchmarks: [test.defaultBenchmark()],
+        tags: ['environment'],
+      } else {},
+      if collectionId != '' then test.collection() else null,
+    ),
+    test.experiment('my-test-experiment'),
   ),
-  test.experiment('my-test-experiment'),
+  test.queue(),
 )

--- a/tests/features/test_data/jsonnet/test.libsonnet
+++ b/tests/features/test_data/jsonnet/test.libsonnet
@@ -150,4 +150,13 @@ local harness = std.parseJson(std.extVar('harness'));
         tags: tags,
       },
     },
+
+  // Queue block, or null when queue is not enabled (use with mergeOptional).
+  queue()::
+    if harness.queue_enabled then {
+      queue: {
+        kind: 'kueue',
+        name: $.env('QUEUE_NAME', '{{env:QUEUE_NAME|user-queue}}'),
+      },
+    },
 }


### PR DESCRIPTION
## What and why

- Add support of queue in the jsonnet generation
- Updated evaluation job feature scenarios to use .json files
- Refactored GPU step definitions to use apiFeat
- Enhanced jsonnet test to validate evaluation job with queue enabled

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation job scenarios now use JSON fixtures for request bodies, including queue-enabled flows.
  * Added support for enabling queue handling in payloads, with queue details included when applicable.

* **Bug Fixes**
  * Improved GPU test setup to use the active feature server consistently.
  * Updated evaluation job Jsonnet handling to better match queued job configurations.

* **Tests**
  * Expanded coverage for queue-enabled evaluation job generation and submission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->