### PR TITLE
fix(sidecar): set WriteTimeout to 0 to prevent premature disconnection during LLM inference

### DIFF
--- a/internal/eval_runtime_sidecar/server/server.go
+++ b/internal/eval_runtime_sidecar/server/server.go
@@ -102,10 +102,16 @@ func (s *SidecarServer) Start() error {
 		return err
 	}
 	s.httpServer = &http.Server{
-		Addr:         fmt.Sprintf(":%d", s.port),
-		Handler:      handler,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
+		Addr:    fmt.Sprintf(":%d", s.port),
+		Handler: handler,
+		// ReadHeaderTimeout bounds slow-header attacks; ReadTimeout is left unset so the
+		// server can receive large request bodies (e.g. inference payloads) without a deadline.
+		ReadHeaderTimeout: 15 * time.Second,
+		// WriteTimeout must be 0 for a reverse proxy: Go measures it from the moment the
+		// request is received, so a non-zero value fires while the sidecar is still waiting
+		// for the upstream (LiteLLM / eval-hub) to respond. Upstream latency is instead
+		// bounded by each HTTP client's own Timeout (see http_client.go).
+		WriteTimeout: 0,
 		IdleTimeout:  60 * time.Second,
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,


### PR DESCRIPTION
## What and why

The sidecar server was configured with `WriteTimeout: 15s`. Go's `net/http` measures `WriteTimeout` from the moment a request arrives (not from when the response write begins) so this deadline fires while the sidecar is still waiting for an upstream LLM response. Inference calls to LiteLLM regularly take 15–26 seconds, causing the server to close the downstream connection before the response arrived. The adapter received `Server disconnected without sending a response` and the job failed.

For a reverse proxy, `WriteTimeout` must be `0`. Upstream latency is already bounded by each HTTP client's own `Timeout` field (`DefaultHTTPTimeout: 30s` in `http_client.go`). `ReadTimeout` is replaced with `ReadHeaderTimeout: 15s` to retain protection against slow-header attacks without adding a deadline on the request body or response write path.

Closes [RHOAIENG-72144](https://redhat.atlassian.net/browse/RHOAIENG-72144)

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server request handling to better support longer-running requests and upstream waits.
  * Reduced the chance of premature timeout errors during file uploads or slow responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->