### PR TITLE
feat(sidecar): support _sa_token secret key suffix for SA token injection via model proxy

### DIFF
--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -345,8 +345,9 @@ func TestIsModelCredentialKey(t *testing.T) {
 		{"api-key", true},
 		{"model-1_api-key", true},
 		{"model-1_url", true},
-		{"kfp_token", true},
-		{"svc_token", true},
+		{"kfp_sa_token", true},
+		{"svc_sa_token", true},
+		{"kfp_token", false},
 		{"hf-token", false},
 		{"ca_cert", false},
 		{"some-other-key", false},
@@ -359,12 +360,12 @@ func TestIsModelCredentialKey(t *testing.T) {
 	}
 }
 
-func TestBuildInternalModelRefSecretWithTokenSuffix(t *testing.T) {
-	// _token keys (e.g. kfp_token) must become <key>:ref in the internalModelRef secret
-	// so the adapter can send "Authorization: Bearer kfp_token:ref" and the sidecar resolves it.
+func TestBuildInternalModelRefSecretWithSATokenSuffix(t *testing.T) {
+	// _sa_token keys (e.g. kfp_sa_token) must become <key>:ref in the internalModelRef secret
+	// so the adapter can send "Authorization: Bearer kfp_sa_token:ref" and the sidecar resolves it.
 	data := map[string][]byte{
-		"kfp_token": []byte(""), // intentionally empty — SA token injected at runtime
-		"kfp_url":   []byte("https://kfp-svc"),
+		"kfp_sa_token": []byte(""), // intentionally empty — SA token injected at runtime
+		"kfp_url":      []byte("https://kfp-svc"),
 	}
 	clientset := fake.NewClientset()
 	helper := &KubernetesHelper{clientset: clientset}
@@ -375,8 +376,8 @@ func TestBuildInternalModelRefSecretWithTokenSuffix(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got := string(secret.Data["kfp_token"]); got != "kfp_token:ref" {
-		t.Errorf("kfp_token: want %q, got %q", "kfp_token:ref", got)
+	if got := string(secret.Data["kfp_sa_token"]); got != "kfp_sa_token:ref" {
+		t.Errorf("kfp_sa_token: want %q, got %q", "kfp_sa_token:ref", got)
 	}
 	if got := string(secret.Data["kfp_url"]); got != sidecarURL {
 		t.Errorf("kfp_url: want %q, got %q", sidecarURL, got)

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -363,7 +363,7 @@ func TestBuildInternalModelRefSecretWithTokenSuffix(t *testing.T) {
 	// _token keys (e.g. kfp_token) must become <key>:ref in the internalModelRef secret
 	// so the adapter can send "Authorization: Bearer kfp_token:ref" and the sidecar resolves it.
 	data := map[string][]byte{
-		"kfp_token": []byte(""),               // intentionally empty — SA token injected at runtime
+		"kfp_token": []byte(""), // intentionally empty — SA token injected at runtime
 		"kfp_url":   []byte("https://kfp-svc"),
 	}
 	clientset := fake.NewClientset()

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -345,6 +345,8 @@ func TestIsModelCredentialKey(t *testing.T) {
 		{"api-key", true},
 		{"model-1_api-key", true},
 		{"model-1_url", true},
+		{"kfp_token", true},
+		{"svc_token", true},
 		{"hf-token", false},
 		{"ca_cert", false},
 		{"some-other-key", false},
@@ -354,6 +356,30 @@ func TestIsModelCredentialKey(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("isModelCredentialKey(%q) = %v, want %v", tt.key, got, tt.want)
 		}
+	}
+}
+
+func TestBuildInternalModelRefSecretWithTokenSuffix(t *testing.T) {
+	// _token keys (e.g. kfp_token) must become <key>:ref in the internalModelRef secret
+	// so the adapter can send "Authorization: Bearer kfp_token:ref" and the sidecar resolves it.
+	data := map[string][]byte{
+		"kfp_token": []byte(""),               // intentionally empty — SA token injected at runtime
+		"kfp_url":   []byte("https://kfp-svc"),
+	}
+	clientset := fake.NewClientset()
+	helper := &KubernetesHelper{clientset: clientset}
+
+	const sidecarURL = "http://localhost:8080"
+	secret, err := buildInternalModelRefSecret(context.Background(), "default", "kfp-ref", data, sidecarURL, nil, helper)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := string(secret.Data["kfp_token"]); got != "kfp_token:ref" {
+		t.Errorf("kfp_token: want %q, got %q", "kfp_token:ref", got)
+	}
+	if got := string(secret.Data["kfp_url"]); got != sidecarURL {
+		t.Errorf("kfp_url: want %q, got %q", sidecarURL, got)
 	}
 }
 

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -361,10 +361,11 @@ func TestIsModelCredentialKey(t *testing.T) {
 }
 
 func TestBuildInternalModelRefSecretWithSATokenSuffix(t *testing.T) {
-	// _sa_token keys (e.g. kfp_sa_token) must become <key>:ref in the internalModelRef secret
-	// so the adapter can send "Authorization: Bearer kfp_sa_token:ref" and the sidecar resolves it.
+	// buildInternalModelRefSecret maps *_sa_token keys to <key>:ref regardless of the input
+	// value (including empty). The adapter sends "Authorization: Bearer kfp_sa_token:ref";
+	// empty-value SA injection is handled by the sidecar model proxy, not this layer.
 	data := map[string][]byte{
-		"kfp_sa_token": []byte(""), // intentionally empty — SA token injected at runtime
+		"kfp_sa_token": []byte(""), // empty is preserved through ref mapping; sidecar injects SA at runtime
 		"kfp_url":      []byte("https://kfp-svc"),
 	}
 	clientset := fake.NewClientset()

--- a/internal/eval_hub/runtimes/k8s/secret_builder.go
+++ b/internal/eval_hub/runtimes/k8s/secret_builder.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	modelAPIKeySuffix = "_api-key"
+	modelTokenSuffix  = "_token"
 	modelURLSuffix    = "_url"
 	modelHFTokenKey   = "hf-token"
 	modelCACertKey    = "ca_cert"
@@ -18,9 +19,12 @@ const (
 )
 
 // isModelCredentialKey reports whether k is a proxy-injectable credential key
-// (api-key, *_api-key, or *_url).
+// (api-key, *_api-key, *_token, or *_url).
 func isModelCredentialKey(k string) bool {
-	return k == modelSingleAPIKey || strings.HasSuffix(k, modelAPIKeySuffix) || strings.HasSuffix(k, modelURLSuffix)
+	return k == modelSingleAPIKey ||
+		strings.HasSuffix(k, modelAPIKeySuffix) ||
+		strings.HasSuffix(k, modelTokenSuffix) ||
+		strings.HasSuffix(k, modelURLSuffix)
 }
 
 // modelSecretInfo holds the result of inspecting the model credential secret.
@@ -59,6 +63,7 @@ func inspectModelSecret(ctx context.Context, namespace, secretName string, helpe
 //
 //   - "api-key"          → value becomes "api-key:ref" (sidecar injects real key)
 //   - "*_api-key" suffix → value becomes "<key>:ref"   (sidecar injects real key)
+//   - "*_token" suffix   → value becomes "<key>:ref"   (sidecar injects token or SA token when value empty)
 //   - "*_url" suffix     → value becomes sidecarProxyURL (adapter routes through sidecar)
 //   - "hf-token"         → omitted; projected directly from the model credential secret
 //   - "ca_cert"          → omitted; projected directly from the model credential secret
@@ -95,8 +100,8 @@ func buildInternalModelRefSecret(
 	}
 
 	if len(refData) == 0 {
-		return nil, fmt.Errorf("model credential secret data contains no recognised credential keys (expected %q or keys with %q or %q suffix)",
-			modelSingleAPIKey, modelAPIKeySuffix, modelURLSuffix)
+		return nil, fmt.Errorf("model credential secret data contains no recognised credential keys (expected %q or keys with %q, %q, or %q suffix)",
+			modelSingleAPIKey, modelAPIKeySuffix, modelTokenSuffix, modelURLSuffix)
 	}
 
 	secret := &corev1.Secret{

--- a/internal/eval_hub/runtimes/k8s/secret_builder.go
+++ b/internal/eval_hub/runtimes/k8s/secret_builder.go
@@ -30,7 +30,7 @@ func isModelCredentialKey(k string) bool {
 // modelSecretInfo holds the result of inspecting the model credential secret.
 type modelSecretInfo struct {
 	// hasCredentialKeys is true when the secret contains at least one proxy-injectable
-	// key (api-key, *_api-key, *_url), meaning credential injection should be activated.
+	// key (api-key, *_api-key, *_sa_token, or *_url), meaning credential injection should be activated.
 	hasCredentialKeys bool
 	// data is the full secret data, populated when hasCredentialKeys is true so callers
 	// can build the internalModelRef secret without a second API call.

--- a/internal/eval_hub/runtimes/k8s/secret_builder.go
+++ b/internal/eval_hub/runtimes/k8s/secret_builder.go
@@ -10,20 +10,20 @@ import (
 )
 
 const (
-	modelAPIKeySuffix = "_api-key"
-	modelTokenSuffix  = "_token"
-	modelURLSuffix    = "_url"
-	modelHFTokenKey   = "hf-token"
-	modelCACertKey    = "ca_cert"
-	modelSingleAPIKey = "api-key"
+	modelAPIKeySuffix  = "_api-key"
+	modelSATokenSuffix = "_sa_token"
+	modelURLSuffix     = "_url"
+	modelHFTokenKey    = "hf-token"
+	modelCACertKey     = "ca_cert"
+	modelSingleAPIKey  = "api-key"
 )
 
 // isModelCredentialKey reports whether k is a proxy-injectable credential key
-// (api-key, *_api-key, *_token, or *_url).
+// (api-key, *_api-key, *_sa_token, or *_url).
 func isModelCredentialKey(k string) bool {
 	return k == modelSingleAPIKey ||
 		strings.HasSuffix(k, modelAPIKeySuffix) ||
-		strings.HasSuffix(k, modelTokenSuffix) ||
+		strings.HasSuffix(k, modelSATokenSuffix) ||
 		strings.HasSuffix(k, modelURLSuffix)
 }
 
@@ -63,7 +63,7 @@ func inspectModelSecret(ctx context.Context, namespace, secretName string, helpe
 //
 //   - "api-key"          → value becomes "api-key:ref" (sidecar injects real key)
 //   - "*_api-key" suffix → value becomes "<key>:ref"   (sidecar injects real key)
-//   - "*_token" suffix   → value becomes "<key>:ref"   (sidecar injects token or SA token when value empty)
+//   - "*_sa_token" suffix → value becomes "<key>:ref"   (sidecar injects SA token when value empty)
 //   - "*_url" suffix     → value becomes sidecarProxyURL (adapter routes through sidecar)
 //   - "hf-token"         → omitted; projected directly from the model credential secret
 //   - "ca_cert"          → omitted; projected directly from the model credential secret
@@ -101,7 +101,7 @@ func buildInternalModelRefSecret(
 
 	if len(refData) == 0 {
 		return nil, fmt.Errorf("model credential secret data contains no recognised credential keys (expected %q or keys with %q, %q, or %q suffix)",
-			modelSingleAPIKey, modelAPIKeySuffix, modelTokenSuffix, modelURLSuffix)
+			modelSingleAPIKey, modelAPIKeySuffix, modelSATokenSuffix, modelURLSuffix)
 	}
 
 	secret := &corev1.Secret{

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -21,14 +21,14 @@ const modelRefSuffix = ":ref"
 // Key-naming conventions for multi-service secrets.
 //
 // _api-key holds an opaque API key forwarded as-is.
-// _token holds a bearer token; when its value is empty the sidecar injects the pod SA token —
-// this is the mechanism for KFP and other SA-token-authenticated in-cluster services.
+// _sa_token holds a bearer token; when its value is empty the sidecar injects the pod SA token
+// from saTokenPath — this is the mechanism for KFP and other SA-token-authenticated services.
 // _url holds the real upstream URL for the corresponding prefix.
 const (
-	modelSingleAPIKey = "api-key"
-	modelAPIKeySuffix = "_api-key"
-	modelTokenSuffix  = "_token"
-	modelURLSuffix    = "_url"
+	modelSingleAPIKey  = "api-key"
+	modelAPIKeySuffix  = "_api-key"
+	modelSATokenSuffix = "_sa_token"
+	modelURLSuffix     = "_url"
 )
 
 // xModelCredError is an internal sentinel header set by the Director when ref resolution fails.
@@ -59,11 +59,11 @@ func loggerForRequest(logger *slog.Logger, req *http.Request) *slog.Logger {
 // for the pod's lifetime — so per-request file reads are unnecessary.
 //
 // Per-request behaviour:
-//  1. If the Authorization header carries a ref token (e.g. "Bearer kfp_token:ref"):
+//  1. If the Authorization header carries a ref token (e.g. "Bearer kfp_sa_token:ref"):
 //     a. The credential is looked up from the in-memory cache by key name.
 //     b. For *_api-key keys: credential must be non-empty; upstream URL comes from *_url.
-//     c. For *_token keys: when the secret value is empty the SA token from saTokenPath is
-//     injected instead — this is the KFP path (kfp_token: "" in the secret, SA injected).
+//     c. For *_sa_token keys: when the secret value is empty the SA token from saTokenPath is
+//     injected instead — this is the KFP path (kfp_sa_token: "" in the secret, SA injected).
 //     d. The upstream URL is looked up from the cache under *_url for both suffixes;
 //     falls back to defaultTarget when absent.
 //  2. If resolution fails (key not in cache, path traversal, empty _api-key) the proxy
@@ -219,7 +219,7 @@ func loadSecretCache(mountPath string, logger *slog.Logger) map[string]string {
 			logger.Warn("skipping unreadable secret file", "file", e.Name(), "error", err)
 			continue
 		}
-		// Store all values including empty ones: _token keys may legitimately be empty
+		// Store all values including empty ones: _sa_token keys may legitimately be empty
 		// (signals SA token injection), and we need to distinguish "key present, value
 		// empty" from "key absent".
 		cache[e.Name()] = strings.TrimSpace(string(data))
@@ -233,12 +233,12 @@ func loadSecretCache(mountPath string, logger *slog.Logger) map[string]string {
 }
 
 // isCredentialKey reports whether key is a valid credential ref key.
-// Only "api-key", *_api-key, and *_token keys may appear as Bearer ref tokens.
+// Only "api-key", *_api-key, and *_sa_token keys may appear as Bearer ref tokens.
 // _url and other keys are not credentials and must not be forwarded as tokens.
 func isCredentialKey(key string) bool {
 	return key == modelSingleAPIKey ||
 		strings.HasSuffix(key, modelAPIKeySuffix) ||
-		strings.HasSuffix(key, modelTokenSuffix)
+		strings.HasSuffix(key, modelSATokenSuffix)
 }
 
 // resolveModelCredential resolves a Bearer ref token to a (upstream URL, credential) pair
@@ -246,7 +246,7 @@ func isCredentialKey(key string) bool {
 //
 // Key derivation:
 //   - "*_api-key:ref" → credential must be non-empty; upstream URL from *_url.
-//   - "*_token:ref"   → when secret value is empty, the SA token from saTokenPath is injected
+//   - "*_sa_token:ref" → when secret value is empty, the SA token from saTokenPath is injected
 //     instead (KFP path); upstream URL from *_url.
 //   - "api-key:ref"   → single-model shorthand; always uses defaultTarget.
 //
@@ -263,7 +263,7 @@ func resolveModelCredential(logger *slog.Logger, authHeader string, secretCache 
 	// Reject non-credential key suffixes early — _url and any unknown suffixes
 	// must not be resolved as bearer tokens.
 	if !isCredentialKey(key) {
-		return nil, "", fmt.Errorf("ref key %q is not a credential key (must be api-key, *_api-key, or *_token)", key)
+		return nil, "", fmt.Errorf("ref key %q is not a credential key (must be api-key, *_api-key, or *_sa_token)", key)
 	}
 
 	secretValue, ok := secretCache[key]
@@ -274,8 +274,8 @@ func resolveModelCredential(logger *slog.Logger, authHeader string, secretCache 
 
 	var realToken string
 	switch {
-	case strings.HasSuffix(key, modelTokenSuffix):
-		// _token keys: empty value means inject the pod SA token.
+	case strings.HasSuffix(key, modelSATokenSuffix):
+		// _sa_token keys: empty value means inject the pod SA token from saTokenPath.
 		if secretValue != "" {
 			realToken = secretValue
 		} else {
@@ -284,9 +284,9 @@ func resolveModelCredential(logger *slog.Logger, authHeader string, secretCache 
 				AuthTokenPath:  saTokenPath,
 			})
 			if realToken == "" {
-				return nil, "", fmt.Errorf("_token credential for key %q is empty and SA token is unavailable", key)
+				return nil, "", fmt.Errorf("_sa_token credential for key %q is empty and SA token is unavailable", key)
 			}
-			logger.Info("Injected SA token for _token credential", "key", key)
+			logger.Info("Injected SA token for _sa_token credential", "key", key)
 		}
 	default:
 		// api-key and *_api-key: value must be non-empty.
@@ -302,15 +302,15 @@ func resolveModelCredential(logger *slog.Logger, authHeader string, secretCache 
 }
 
 // resolveUpstreamURL returns the upstream URL for a secret key by stripping the credential
-// suffix (_api-key or _token) and looking up <prefix>_url in the cache.
+// suffix (_api-key or _sa_token) and looking up <prefix>_url in the cache.
 // Falls back to defaultTarget when no URL entry exists or the entry is invalid.
 func resolveUpstreamURL(logger *slog.Logger, key string, secretCache map[string]string, defaultTarget *url.URL) *url.URL {
 	var prefix string
 	switch {
 	case strings.HasSuffix(key, modelAPIKeySuffix):
 		prefix = strings.TrimSuffix(key, modelAPIKeySuffix)
-	case strings.HasSuffix(key, modelTokenSuffix):
-		prefix = strings.TrimSuffix(key, modelTokenSuffix)
+	case strings.HasSuffix(key, modelSATokenSuffix):
+		prefix = strings.TrimSuffix(key, modelSATokenSuffix)
 	default:
 		return defaultTarget
 	}

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -18,9 +18,15 @@ import (
 // A Bearer token "api-key:ref" means: look up "api-key" in the secret cache.
 const modelRefSuffix = ":ref"
 
-// modelAPIKeySuffix and modelURLSuffix are the key-naming conventions for multi-model secrets.
+// Key-naming conventions for multi-service secrets.
+//
+// _api-key holds an opaque API key forwarded as-is.
+// _token holds a bearer token; when its value is empty the sidecar injects the pod SA token —
+// this is the mechanism for KFP and other SA-token-authenticated in-cluster services.
+// _url holds the real upstream URL for the corresponding prefix.
 const (
 	modelAPIKeySuffix = "_api-key"
+	modelTokenSuffix  = "_token"
 	modelURLSuffix    = "_url"
 )
 
@@ -52,12 +58,15 @@ func loggerForRequest(logger *slog.Logger, req *http.Request) *slog.Logger {
 // for the pod's lifetime — so per-request file reads are unnecessary.
 //
 // Per-request behaviour:
-//  1. If the Authorization header carries a ref token (e.g. "Bearer model-1_api-key:ref"):
+//  1. If the Authorization header carries a ref token (e.g. "Bearer kfp_token:ref"):
 //     a. The credential is looked up from the in-memory cache by key name.
-//     b. The upstream URL is looked up from the cache under model-1_url; falls back to
-//     defaultTarget when absent (single-model case).
-//  2. If resolution fails (key not in cache, path traversal) the proxy returns HTTP 400
-//     to the eval container — the request is never forwarded.
+//     b. For *_api-key keys: credential must be non-empty; upstream URL comes from *_url.
+//     c. For *_token keys: when the secret value is empty the SA token from saTokenPath is
+//     injected instead — this is the KFP path (kfp_token: "" in the secret, SA injected).
+//     d. The upstream URL is looked up from the cache under *_url for both suffixes;
+//     falls back to defaultTarget when absent.
+//  2. If resolution fails (key not in cache, path traversal, empty _api-key) the proxy
+//     returns HTTP 400 to the eval container — the request is never forwarded.
 //  3. If no Authorization header is present, the SA token from saTokenPath is injected as
 //     a Bearer token. This covers SA-token-authenticated models: the adapter has no access
 //     to the SA token (pod-level auto-mount is disabled), so the sidecar injects it on
@@ -83,7 +92,7 @@ func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *s
 
 		authHeader := pr.In.Header.Get("Authorization")
 		if isModelRefToken(authHeader) {
-			resolvedTarget, realToken, err := resolveModelCredential(logger, reqID, authHeader, secretCache, defaultTarget)
+			resolvedTarget, realToken, err := resolveModelCredential(reqLog, authHeader, secretCache, defaultTarget, saTokenPath)
 			if err != nil {
 				// Signal the RoundTripper to return 400 without forwarding.
 				pr.Out.Header.Set(xModelCredError, err.Error())
@@ -209,9 +218,10 @@ func loadSecretCache(mountPath string, logger *slog.Logger) map[string]string {
 			logger.Warn("skipping unreadable secret file", "file", e.Name(), "error", err)
 			continue
 		}
-		if v := strings.TrimSpace(string(data)); v != "" {
-			cache[e.Name()] = v
-		}
+		// Store all values including empty ones: _token keys may legitimately be empty
+		// (signals SA token injection), and we need to distinguish "key present, value
+		// empty" from "key absent".
+		cache[e.Name()] = strings.TrimSpace(string(data))
 	}
 	keys := make([]string, 0, len(cache))
 	for k := range cache {
@@ -224,11 +234,12 @@ func loadSecretCache(mountPath string, logger *slog.Logger) map[string]string {
 // resolveModelCredential resolves a Bearer ref token to a (upstream URL, credential) pair
 // using the pre-loaded in-memory secret cache.
 //
-// Key derivation for the upstream URL:
-//   - "model-1_api-key:ref" → looks up "model-1_api-key" (token) and "model-1_url" (URL)
-//     in secretCache; falls back to defaultTarget when the URL key is absent.
-//   - "api-key:ref" → looks up the credential; always uses defaultTarget.
-func resolveModelCredential(logger *slog.Logger, requestID, authHeader string, secretCache map[string]string, defaultTarget *url.URL) (*url.URL, string, error) {
+// Key derivation:
+//   - "*_api-key:ref" → credential must be non-empty; upstream URL from *_url.
+//   - "*_token:ref"   → when secret value is empty, the SA token from saTokenPath is injected
+//     instead (KFP path); upstream URL from *_url.
+//   - "api-key:ref"   → single-model shorthand; always uses defaultTarget.
+func resolveModelCredential(logger *slog.Logger, authHeader string, secretCache map[string]string, defaultTarget *url.URL, saTokenPath string) (*url.URL, string, error) {
 	token := strings.TrimPrefix(authHeader, "Bearer ")
 	key := strings.TrimSuffix(token, modelRefSuffix)
 
@@ -236,32 +247,65 @@ func resolveModelCredential(logger *slog.Logger, requestID, authHeader string, s
 		return nil, "", fmt.Errorf("model ref token has invalid key %q", key)
 	}
 
-	realToken, ok := secretCache[key]
+	secretValue, ok := secretCache[key]
 	if !ok {
-		logger.Error("model credential not found in cache", "request_id", requestID, "key", key)
+		logger.Error("model credential not found in cache", "key", key)
 		return nil, "", fmt.Errorf("credential not found for key %q", key)
 	}
-	if realToken == "" {
-		return nil, "", fmt.Errorf("credential for key %q is empty", key)
-	}
 
-	target := defaultTarget
-
-	// For multi-model keys (*_api-key), look up the corresponding URL entry.
-	if strings.HasSuffix(key, modelAPIKeySuffix) {
-		prefix := strings.TrimSuffix(key, modelAPIKeySuffix)
-		urlKey := prefix + modelURLSuffix
-		if rawURL, exists := secretCache[urlKey]; exists && rawURL != "" {
-			parsed, parseErr := url.Parse(strings.TrimSuffix(rawURL, "/"))
-			if parseErr != nil || !parsed.IsAbs() || parsed.Host == "" {
-				logger.Warn("model URL in secret cache is invalid, using default target",
-					"request_id", requestID, "url_key", urlKey, "error", parseErr)
-			} else {
-				target = parsed
+	var realToken string
+	switch {
+	case strings.HasSuffix(key, modelTokenSuffix):
+		// _token keys: empty value means inject the pod SA token.
+		if secretValue != "" {
+			realToken = secretValue
+		} else {
+			realToken = resolveEvalHubOrMLflowToken(logger, AuthTokenInput{
+				TargetEndpoint: "model-sa",
+				AuthTokenPath:  saTokenPath,
+			})
+			if realToken == "" {
+				return nil, "", fmt.Errorf("_token credential for key %q is empty and SA token is unavailable", key)
 			}
+			logger.Info("Injected SA token for _token credential", "key", key)
 		}
+	default:
+		// _api-key and bare keys: value must be non-empty.
+		if secretValue == "" {
+			return nil, "", fmt.Errorf("credential for key %q is empty", key)
+		}
+		realToken = secretValue
 	}
 
-	logger.Info("Resolved model ref token", "request_id", requestID, "key", key, "target_host", target.Host)
+	target := resolveUpstreamURL(logger, key, secretCache, defaultTarget)
+	logger.Info("Resolved model ref token", "key", key, "target_host", target.Host)
 	return target, realToken, nil
+}
+
+// resolveUpstreamURL returns the upstream URL for a secret key by stripping the credential
+// suffix (_api-key or _token) and looking up <prefix>_url in the cache.
+// Falls back to defaultTarget when no URL entry exists or the entry is invalid.
+func resolveUpstreamURL(logger *slog.Logger, key string, secretCache map[string]string, defaultTarget *url.URL) *url.URL {
+	var prefix string
+	switch {
+	case strings.HasSuffix(key, modelAPIKeySuffix):
+		prefix = strings.TrimSuffix(key, modelAPIKeySuffix)
+	case strings.HasSuffix(key, modelTokenSuffix):
+		prefix = strings.TrimSuffix(key, modelTokenSuffix)
+	default:
+		return defaultTarget
+	}
+
+	urlKey := prefix + modelURLSuffix
+	rawURL, exists := secretCache[urlKey]
+	if !exists || rawURL == "" {
+		return defaultTarget
+	}
+	parsed, err := url.Parse(strings.TrimSuffix(rawURL, "/"))
+	if err != nil || !parsed.IsAbs() || parsed.Host == "" {
+		logger.Warn("service URL in secret cache is invalid, using default target",
+			"url_key", urlKey, "error", err)
+		return defaultTarget
+	}
+	return parsed
 }

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -25,6 +25,7 @@ const modelRefSuffix = ":ref"
 // this is the mechanism for KFP and other SA-token-authenticated in-cluster services.
 // _url holds the real upstream URL for the corresponding prefix.
 const (
+	modelSingleAPIKey = "api-key"
 	modelAPIKeySuffix = "_api-key"
 	modelTokenSuffix  = "_token"
 	modelURLSuffix    = "_url"
@@ -231,6 +232,15 @@ func loadSecretCache(mountPath string, logger *slog.Logger) map[string]string {
 	return cache
 }
 
+// isCredentialKey reports whether key is a valid credential ref key.
+// Only "api-key", *_api-key, and *_token keys may appear as Bearer ref tokens.
+// _url and other keys are not credentials and must not be forwarded as tokens.
+func isCredentialKey(key string) bool {
+	return key == modelSingleAPIKey ||
+		strings.HasSuffix(key, modelAPIKeySuffix) ||
+		strings.HasSuffix(key, modelTokenSuffix)
+}
+
 // resolveModelCredential resolves a Bearer ref token to a (upstream URL, credential) pair
 // using the pre-loaded in-memory secret cache.
 //
@@ -239,12 +249,21 @@ func loadSecretCache(mountPath string, logger *slog.Logger) map[string]string {
 //   - "*_token:ref"   → when secret value is empty, the SA token from saTokenPath is injected
 //     instead (KFP path); upstream URL from *_url.
 //   - "api-key:ref"   → single-model shorthand; always uses defaultTarget.
+//
+// Any other key suffix (e.g. *_url) is rejected with an error — non-credential
+// keys must not be forwarded as bearer tokens.
 func resolveModelCredential(logger *slog.Logger, authHeader string, secretCache map[string]string, defaultTarget *url.URL, saTokenPath string) (*url.URL, string, error) {
 	token := strings.TrimPrefix(authHeader, "Bearer ")
 	key := strings.TrimSuffix(token, modelRefSuffix)
 
 	if key == "" || strings.ContainsAny(key, "/\\") {
 		return nil, "", fmt.Errorf("model ref token has invalid key %q", key)
+	}
+
+	// Reject non-credential key suffixes early — _url and any unknown suffixes
+	// must not be resolved as bearer tokens.
+	if !isCredentialKey(key) {
+		return nil, "", fmt.Errorf("ref key %q is not a credential key (must be api-key, *_api-key, or *_token)", key)
 	}
 
 	secretValue, ok := secretCache[key]
@@ -270,7 +289,7 @@ func resolveModelCredential(logger *slog.Logger, authHeader string, secretCache 
 			logger.Info("Injected SA token for _token credential", "key", key)
 		}
 	default:
-		// _api-key and bare keys: value must be non-empty.
+		// api-key and *_api-key: value must be non-empty.
 		if secretValue == "" {
 			return nil, "", fmt.Errorf("credential for key %q is empty", key)
 		}

--- a/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
@@ -397,9 +397,9 @@ func TestModelProxySATokenNotInjectedWhenAuthPresent(t *testing.T) {
 	}
 }
 
-// TestModelProxyTokenSuffixInjectsSATokenWhenEmpty verifies the KFP path:
-// secret has "kfp_token: """ (empty) — sidecar injects the SA token and routes to kfp_url.
-func TestModelProxyTokenSuffixInjectsSATokenWhenEmpty(t *testing.T) {
+// TestModelProxySATokenSuffixInjectsSATokenWhenEmpty verifies the KFP path:
+// secret has "kfp_sa_token: """ (empty) — sidecar injects the SA token and routes to kfp_url.
+func TestModelProxySATokenSuffixInjectsSATokenWhenEmpty(t *testing.T) {
 	// Clear the shared SA token cache so we read from the file written by this test.
 	UpdateCachedToken(AuthTokenInput{TargetEndpoint: "model-sa"}, "")
 	var gotAuth, gotHost string
@@ -428,15 +428,15 @@ func TestModelProxyTokenSuffixInjectsSATokenWhenEmpty(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	// kfp_token is intentionally empty — SA token should be injected.
-	writeFile("kfp_token", "")
+	// kfp_sa_token is intentionally empty — SA token should be injected.
+	writeFile("kfp_sa_token", "")
 	writeFile("kfp_url", kfpUpstream.URL)
 
 	defaultTarget, _ := url.Parse(defaultUpstream.URL)
 	rp := NewModelReverseProxy(defaultTarget, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, saTokenPath)
 
 	req := httptest.NewRequest(http.MethodGet, "/apis/v1beta1/runs", nil)
-	req.Header.Set("Authorization", "Bearer kfp_token:ref")
+	req.Header.Set("Authorization", "Bearer kfp_sa_token:ref")
 	rr := httptest.NewRecorder()
 	rp.ServeHTTP(rr, req)
 
@@ -452,9 +452,9 @@ func TestModelProxyTokenSuffixInjectsSATokenWhenEmpty(t *testing.T) {
 	}
 }
 
-// TestModelProxyTokenSuffixUsesExplicitValueWhenNonEmpty verifies that when kfp_token has a
+// TestModelProxySATokenSuffixUsesExplicitValueWhenNonEmpty verifies that when kfp_sa_token has a
 // non-empty value (e.g. a user-provided JWT), it is forwarded as-is without SA injection.
-func TestModelProxyTokenSuffixUsesExplicitValueWhenNonEmpty(t *testing.T) {
+func TestModelProxySATokenSuffixUsesExplicitValueWhenNonEmpty(t *testing.T) {
 	var gotAuth string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
@@ -463,7 +463,7 @@ func TestModelProxyTokenSuffixUsesExplicitValueWhenNonEmpty(t *testing.T) {
 	defer upstream.Close()
 
 	secretDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(secretDir, "kfp_token"), []byte("user-provided-jwt"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(secretDir, "kfp_sa_token"), []byte("user-provided-jwt"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -471,7 +471,7 @@ func TestModelProxyTokenSuffixUsesExplicitValueWhenNonEmpty(t *testing.T) {
 	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/apis/v1beta1/runs", nil)
-	req.Header.Set("Authorization", "Bearer kfp_token:ref")
+	req.Header.Set("Authorization", "Bearer kfp_sa_token:ref")
 	rr := httptest.NewRecorder()
 	rp.ServeHTTP(rr, req)
 
@@ -511,9 +511,9 @@ func TestModelProxyReturns400OnURLKeyRef(t *testing.T) {
 	}
 }
 
-// TestModelProxyTokenSuffixReturns400WhenEmptyAndNoSAToken verifies that when kfp_token is
+// TestModelProxySATokenSuffixReturns400WhenEmptyAndNoSAToken verifies that when kfp_sa_token is
 // empty and no SA token is available, the proxy returns 400 rather than forwarding.
-func TestModelProxyTokenSuffixReturns400WhenEmptyAndNoSAToken(t *testing.T) {
+func TestModelProxySATokenSuffixReturns400WhenEmptyAndNoSAToken(t *testing.T) {
 	// Clear the shared SA token cache so a stale token from a prior test doesn't mask the error.
 	UpdateCachedToken(AuthTokenInput{TargetEndpoint: "model-sa"}, "")
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -522,7 +522,7 @@ func TestModelProxyTokenSuffixReturns400WhenEmptyAndNoSAToken(t *testing.T) {
 	defer upstream.Close()
 
 	secretDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(secretDir, "kfp_token"), []byte(""), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(secretDir, "kfp_sa_token"), []byte(""), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -531,11 +531,11 @@ func TestModelProxyTokenSuffixReturns400WhenEmptyAndNoSAToken(t *testing.T) {
 	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/apis/v1beta1/runs", nil)
-	req.Header.Set("Authorization", "Bearer kfp_token:ref")
+	req.Header.Set("Authorization", "Bearer kfp_sa_token:ref")
 	rr := httptest.NewRecorder()
 	rp.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 when _token empty and no SA token, got %d", rr.Code)
+		t.Fatalf("expected 400 when _sa_token empty and no SA token, got %d", rr.Code)
 	}
 }

--- a/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
@@ -483,6 +483,34 @@ func TestModelProxyTokenSuffixUsesExplicitValueWhenNonEmpty(t *testing.T) {
 	}
 }
 
+// TestModelProxyReturns400OnURLKeyRef verifies that a *_url:ref Bearer token is rejected
+// with 400. URL keys are routing hints — not credentials — and must never be forwarded
+// as bearer tokens even if the key exists in the secret cache.
+func TestModelProxyReturns400OnURLKeyRef(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	secretDir := t.TempDir()
+	// kfp_url is present in cache — proxy must still reject it as a ref token.
+	if err := os.WriteFile(filepath.Join(secretDir, "kfp_url"), []byte(upstream.URL), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	target, _ := url.Parse(upstream.URL)
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/completions", nil)
+	req.Header.Set("Authorization", "Bearer kfp_url:ref")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for _url ref key, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
 // TestModelProxyTokenSuffixReturns400WhenEmptyAndNoSAToken verifies that when kfp_token is
 // empty and no SA token is available, the proxy returns 400 rather than forwarding.
 func TestModelProxyTokenSuffixReturns400WhenEmptyAndNoSAToken(t *testing.T) {

--- a/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
@@ -59,7 +59,9 @@ func TestModelProxyLogsRequestID(t *testing.T) {
 
 func TestResolveModelCredentialLogsRequestID(t *testing.T) {
 	var logBuf bytes.Buffer
-	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	base := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Callers pass a logger pre-enriched with request_id; simulate that here.
+	log := base.With("request_id", "resolve-req-id")
 
 	secretDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(secretDir, "api-key"), []byte("sk-real-key"), 0600); err != nil {
@@ -67,8 +69,8 @@ func TestResolveModelCredentialLogsRequestID(t *testing.T) {
 	}
 
 	target, _ := url.Parse("https://model.example.com/v1")
-	cache := loadSecretCache(secretDir, log)
-	_, _, err := resolveModelCredential(log, "resolve-req-id", "Bearer api-key:ref", cache, target)
+	cache := loadSecretCache(secretDir, base)
+	_, _, err := resolveModelCredential(log, "Bearer api-key:ref", cache, target, "")
 	if err != nil {
 		t.Fatalf("resolveModelCredential: %v", err)
 	}
@@ -392,5 +394,120 @@ func TestModelProxySATokenNotInjectedWhenAuthPresent(t *testing.T) {
 	}
 	if gotAuth != "Bearer sk-explicit-key" {
 		t.Fatalf("expected explicit auth forwarded unchanged, got %q", gotAuth)
+	}
+}
+
+// TestModelProxyTokenSuffixInjectsSATokenWhenEmpty verifies the KFP path:
+// secret has "kfp_token: """ (empty) — sidecar injects the SA token and routes to kfp_url.
+func TestModelProxyTokenSuffixInjectsSATokenWhenEmpty(t *testing.T) {
+	// Clear the shared SA token cache so we read from the file written by this test.
+	UpdateCachedToken(AuthTokenInput{TargetEndpoint: "model-sa"}, "")
+	var gotAuth, gotHost string
+	kfpUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer kfpUpstream.Close()
+
+	defaultUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer defaultUpstream.Close()
+
+	saTokenDir := t.TempDir()
+	saTokenPath := filepath.Join(saTokenDir, "token")
+	if err := os.WriteFile(saTokenPath, []byte("sa-token-injected"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	secretDir := t.TempDir()
+	writeFile := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(secretDir, name), []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// kfp_token is intentionally empty — SA token should be injected.
+	writeFile("kfp_token", "")
+	writeFile("kfp_url", kfpUpstream.URL)
+
+	defaultTarget, _ := url.Parse(defaultUpstream.URL)
+	rp := NewModelReverseProxy(defaultTarget, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, saTokenPath)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/v1beta1/runs", nil)
+	req.Header.Set("Authorization", "Bearer kfp_token:ref")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if gotAuth != "Bearer sa-token-injected" {
+		t.Fatalf("expected SA token injected, got %q", gotAuth)
+	}
+	kfpHost := strings.TrimPrefix(kfpUpstream.URL, "http://")
+	if gotHost != kfpHost {
+		t.Fatalf("expected request routed to kfp upstream %q, got host %q", kfpHost, gotHost)
+	}
+}
+
+// TestModelProxyTokenSuffixUsesExplicitValueWhenNonEmpty verifies that when kfp_token has a
+// non-empty value (e.g. a user-provided JWT), it is forwarded as-is without SA injection.
+func TestModelProxyTokenSuffixUsesExplicitValueWhenNonEmpty(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	secretDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(secretDir, "kfp_token"), []byte("user-provided-jwt"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	target, _ := url.Parse(upstream.URL)
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/v1beta1/runs", nil)
+	req.Header.Set("Authorization", "Bearer kfp_token:ref")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if gotAuth != "Bearer user-provided-jwt" {
+		t.Fatalf("expected explicit token forwarded, got %q", gotAuth)
+	}
+}
+
+// TestModelProxyTokenSuffixReturns400WhenEmptyAndNoSAToken verifies that when kfp_token is
+// empty and no SA token is available, the proxy returns 400 rather than forwarding.
+func TestModelProxyTokenSuffixReturns400WhenEmptyAndNoSAToken(t *testing.T) {
+	// Clear the shared SA token cache so a stale token from a prior test doesn't mask the error.
+	UpdateCachedToken(AuthTokenInput{TargetEndpoint: "model-sa"}, "")
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	secretDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(secretDir, "kfp_token"), []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	target, _ := url.Parse(upstream.URL)
+	// No SA token path — simulates unavailable SA token.
+	rp := NewModelReverseProxy(target, &http.Client{}, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/v1beta1/runs", nil)
+	req.Header.Set("Authorization", "Bearer kfp_token:ref")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when _token empty and no SA token, got %d", rr.Code)
 	}
 }


### PR DESCRIPTION
The previous PRs #676 #672 moved the pod SA token exclusively to the sidecar. The Garak adapter's KFP client was authenticating using the SA token from the standard pod SA mount path, which is no longer available to the adapter. So this PR extends the _api-key/_url secret convention with **_sa_token/_url** to allow KFP and other in-cluster SA-token authenticated services to route through the sidecar proxy.

Secret key | Value | Effect
-- | -- | --
kfp_sa_token | "" (empty) | Sidecar injects pod SA token
kfp_sa_token | <jwt> | Sidecar forwards the value as-is
kfp_url | https://kfp-svc... | Sidecar routes to this upstream

kfp can be <any_service>.
The adapter receives `kfp_sa_token:ref` and `http://localhost:8080` in its mounted secret (same ref mechanism as _api-key). It sends `Authorization: Bearer kfp_sa_token:ref` to the sidecar, which resolves the ref, injects the SA token if the secret value is empty and routes to kfp_url.

## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes # https://redhat.atlassian.net/browse/RHOAIENG-70469

Assisted-by: <!-- Cursor, Claude etc --> Claude

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

Created a secret with kfp_sa_token: "" (empty) and kfp_url pointing to a mock in-cluster HTTP echo server. Submitted an evaluation referencing the secret, then from the adapter container. Details below:

Created a model credential secret containing both a real api-key (for model auth) and a kfp_sa_token/kfp_url pair for KFP access. kfp_sa_token is intentionally empty — this signals the sidecar to inject the pod SA token at runtime.
kfp_url decodes to http://mock-kfp-svc.prabhu.svc.cluster.local:8080 — a simple in-cluster HTTP echo server used as a mock KFP upstream.
```
oc get secret model-api-key-kfp-secret -o yaml
apiVersion: v1
data:
  api-key: dGVzdC1hcGkta2V5LTEyMzQ1
  kfp_sa_token: ""
  kfp_url: aHR0cDovL21vY2sta2ZwLXN2Yy5wcmFiaHUuc3ZjLmNsdXN0ZXIubG9jYWw6ODA4MA==
kind: Secret
metadata:
  creationTimestamp: "2026-06-30T11:53:06Z"
  name: model-api-key-kfp-secret
  namespace: tenant
  resourceVersion: "117014977"
  uid: 66ea7f5d-a46e-4d82-be01-dd5e201c89dc
type: Opaque
```

Referenced the secret in the evaluation job payload via `model.auth.secret_ref`: Ex:
```
{
  "resource": {
    "id": "5ad47d55-b420-4b70-8bd6-b172f7c39566",
    "tenant": "tenant",
    "created_at": "2026-07-01T09:57:58.14281848Z",
    "owner": "system:serviceaccount:tenant:tenant-user",
    "mlflow_experiment_id": "1"
  },
  "status": {
    "state": "pending",
    "message": {
      "message": "Evaluation job created",
      "message_code": "evaluation_job_created"
    }
  },
  "results": {
    "mlflow_experiment_url": "https://mlflow.opendatahub.svc.cluster.local:8443/api/2.0/mlflow/experiments"
  },
  "name": "model api key/cert test",
  "model": {
    "url": "https://vllm-llama-apikey-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct",
    "auth": {
      "secret_ref": "model-api-key-kfp-secret"
    }
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "tokenizer": "google/flan-t5-small"
      }
    }
  ],
  "experiment": {
    "name": "exp12"
  }
}
```

Verifying KFP token injection
From inside the adapter container, simulated a KFP call through the sidecar proxy:
`curl -s http://localhost:8080/test -H "Authorization: Bearer kfp_sa_token:ref"`
The mock upstream echoed back the forwarded request, showing the real SA token in the Authorization header (truncated for brevity):
Json
```
{"path": "/test", "headers": {"Host": "mock-kfp-svc.prabhu.svc.cluster.local:8080", "User-Agent": "curl/7.76.1", "Accept": "*/*", "Authorization": "Bearer sa-token", "X-Global-Transaction-Id": "8162af4b-648c-426a-834c-5a24166e5988", "Accept-Encoding": "gzip"}}
```

Sidecar Logs:
-------------
Confirm SA token injection and correct routing to the KFP upstream:
```
{"level":"info","ts":"2026-07-01T09:58:00.028Z","caller":"proxy/model_proxy.go:231","msg":"Loaded model secret cache","path":"/var/run/secrets/model","keys":["api-key","kfp_sa_token","kfp_url"]}
{"level":"info","ts":"2026-07-01T09:58:35.223Z","caller":"proxy/auth.go:113","msg":"Read auth token from file","request_id":"8162af4b-648c-426a-834c-5a24166e5988","path":"/var/run/secrets/kubernetes.io/serviceaccount/token"}
{"level":"info","ts":"2026-07-01T09:58:35.223Z","caller":"proxy/model_proxy.go:289","msg":"Injected SA token for _sa_token credential","request_id":"8162af4b-648c-426a-834c-5a24166e5988","key":"kfp_sa_token"}
{"level":"info","ts":"2026-07-01T09:58:35.223Z","caller":"proxy/model_proxy.go:300","msg":"Resolved model ref token","request_id":"8162af4b-648c-426a-834c-5a24166e5988","key":"kfp_sa_token","target_host":"mock-kfp-svc.prabhu.svc.cluster.local:8080"}
{"level":"info","ts":"2026-07-01T09:58:35.223Z","caller":"proxy/model_proxy.go:130","msg":"Proxying model request","request_id":"8162af4b-648c-426a-834c-5a24166e5988","method":"GET","url":"http://mock-kfp-svc.prabhu.svc.cluster.local:8080/test","headers":{"Accept":["*/*"],"Authorization":["Bearer ***"],"User-Agent":["curl/7.76.1"],"X-Global-Transaction-Id":["8162af4b-648c-426a-834c-5a24166e5988"]}}
{"level":"info","ts":"2026-07-01T09:58:35.231Z","caller":"proxy/model_proxy.go:135","msg":"Response from model proxy","request_id":"8162af4b-648c-426a-834c-5a24166e5988","method":"GET","url":"http://mock-kfp-svc.prabhu.svc.cluster.local:8080/test","status":200}

```
_token is not recognized any more:
```
(app-root) sh-5.1$ curl -s http://localhost:8080/test -H "Authorization: Bearer kfp_token:ref"
ref key "kfp_token" is not a credential key (must be api-key, *_api-key, or *_sa_token)
```

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `*_sa_token` model credential keys, including automatic service-account token injection when the token value is empty.
* **Bug Fixes**
  * Improved credential handling so `kfp_token` is not treated as a credential key, and `*_url:ref` tokens are rejected instead of being forwarded.
  * Fail-fast behavior now consistently returns `400` when required credentials (including SA tokens) can’t be resolved.
* **Tests**
  * Expanded unit and proxy tests for `kfp_sa_token`/`kfp_url` token-suffix behavior and updated request logging coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->