### PR TITLE
chore: remove unused ready_file config and code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ When running locally:
 
 - Loads **`sidecar_config.json`** only (default `/meta/sidecar_config.json`; local override via `--sidecarconfig`).
 - **No `evalhub-config` ConfigMap** on job pods; proxy targets and TLS live in JSON (`eval_hub.base_url`, `mlflow.tracking_uri`, `mlflow.token_path`, CA paths, optional `eval_hub.token`).
-- Ready and termination message paths are **fixed in the sidecar binary** (`/data/sidecar-ready`, `/data/termination-log`).
+- Termination message path is **fixed in the sidecar binary** (`/data/termination-log`).
 - Local dev: `config/sidecar_runtime_local.json` or `make start-sidecar`.
 
 #### Request identity (kube-rbac-proxy)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,8 +1,6 @@
 service:
   port: 8080
   host: "127.0.0.1"
-  # These will be elsewhere on a cluster and coherent with the pod spec
-  ready_file: "/tmp/repo-ready"
   termination_file: "/tmp/termination-log"
   # read_timeout: 15s       # http.Server ReadTimeout; omit or 0 for default (15s)
   # write_timeout: 15s      # http.Server WriteTimeout; omit or 0 for default (15s)

--- a/internal/eval_hub/config/loader_test.go
+++ b/internal/eval_hub/config/loader_test.go
@@ -27,9 +27,6 @@ func TestLoadConfig(t *testing.T) {
 		if serviceConfig == nil {
 			t.Fatalf("Service config is nil")
 		}
-		if serviceConfig.Service.ReadyFile != "/tmp/repo-ready" {
-			t.Fatalf("Ready file is not /tmp/repo-ready, got %s", serviceConfig.Service.ReadyFile)
-		}
 		if serviceConfig.Service.TerminationFile != "/tmp/termination-log" {
 			t.Fatalf("Termination file is not /tmp/termination-log, got %s", serviceConfig.Service.TerminationFile)
 		}
@@ -58,7 +55,6 @@ func TestLoadConfig(t *testing.T) {
 		baseContent := `
 service:
   port: 8080
-  ready_file: "/tmp/repo-ready"
   termination_file: "/tmp/termination-log"
 database:
   driver: sqlite
@@ -107,7 +103,6 @@ database:
 		baseContent := `
 service:
   port: 8080
-  ready_file: "/tmp/repo-ready"
   termination_file: "/tmp/termination-log"
 database:
   driver: sqlite
@@ -158,7 +153,6 @@ secrets:
 		baseContent := `
 service:
   port: 8080
-  ready_file: "/tmp/repo-ready"
   termination_file: "/tmp/termination-log"
 secrets:
   dir: /tmp

--- a/internal/eval_hub/config/service_config.go
+++ b/internal/eval_hub/config/service_config.go
@@ -16,7 +16,6 @@ type ServiceConfig struct {
 	GitHash         string `mapstructure:"git_hash,omitempty"`
 	Port            int    `mapstructure:"port,omitempty"`
 	Host            string `mapstructure:"host,omitempty"`
-	ReadyFile       string `mapstructure:"ready_file"`
 	TerminationFile string `mapstructure:"termination_file"`
 	EvalInitImage   string `mapstructure:"eval_init_image,omitempty"`
 	LocalMode       bool   `mapstructure:"local_mode,omitempty"`

--- a/internal/eval_hub/server/server.go
+++ b/internal/eval_hub/server/server.go
@@ -481,12 +481,6 @@ func (s *Server) Start() error {
 		return fmt.Errorf("FIPS mode enabled, but TLS certificate verification is required")
 	}
 
-	s.logger.Info("Writing the API server ready message", "file", s.serviceConfig.Service.ReadyFile)
-	err = SetReady(s.serviceConfig, s.logger)
-	if err != nil {
-		return err
-	}
-
 	tlsEnabled := s.serviceConfig.Service.TLSEnabled()
 	s.logger.Info("API Server starting", "addr", addr, "tls", tlsEnabled)
 

--- a/internal/eval_hub/server/server_files.go
+++ b/internal/eval_hub/server/server_files.go
@@ -11,7 +11,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/constants"
 )
 
-// handle ready and termination messages
+// handle termination messages
 
 func GetTerminationFile(conf *config.Config, logger *slog.Logger) string {
 	tf := ""
@@ -49,14 +49,6 @@ func writeFile(fname string, message string, fileType string, logger *slog.Logge
 		logger.Info(fmt.Sprintf("Set %s message", fileType), "message", message)
 	}
 	return err
-}
-
-func getReadyContents(conf *config.Config) string {
-	return fmt.Sprintf("Version: %s\nBuild: %s\nBuildDate: %s\n", conf.Service.Version, conf.Service.Build, conf.Service.BuildDate)
-}
-
-func SetReady(conf *config.Config, logger *slog.Logger) error {
-	return writeFile(conf.Service.ReadyFile, getReadyContents(conf), "ready", logger)
 }
 
 func SetTerminationMessage(terminationFile string, message string, logger *slog.Logger) error {

--- a/internal/eval_runtime_sidecar/config/sidecar_runtime_config.go
+++ b/internal/eval_runtime_sidecar/config/sidecar_runtime_config.go
@@ -12,8 +12,6 @@ import (
 const (
 	// DefaultSidecarConfigPath is where the job pod mounts sidecar_config.json.
 	DefaultSidecarConfigPath = "/meta/sidecar_config.json"
-	// SidecarReadyFilePath is where the sidecar writes its ready file (emptyDir in job pods).
-	SidecarReadyFilePath = "/data/sidecar-ready"
 	// SidecarTerminationFilePath is used for Kubernetes termination messages.
 	SidecarTerminationFilePath = "/data/termination-log"
 )
@@ -41,7 +39,6 @@ func LoadSidecarRuntimeConfig(sidecarJSONPath, version, build, buildDate string)
 			Version:   version,
 			Build:     build,
 			BuildDate: buildDate,
-			ReadyFile: SidecarReadyFilePath,
 		},
 		Sidecar: &sc,
 	}

--- a/internal/eval_runtime_sidecar/config/sidecar_runtime_config_test.go
+++ b/internal/eval_runtime_sidecar/config/sidecar_runtime_config_test.go
@@ -30,9 +30,6 @@ func TestLoadSidecarRuntimeConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSidecarRuntimeConfig: %v", err)
 	}
-	if cfg.Service.ReadyFile != SidecarReadyFilePath {
-		t.Fatalf("ReadyFile: %q", cfg.Service.ReadyFile)
-	}
 	if cfg.Sidecar.Port != 9090 {
 		t.Fatalf("port %d", cfg.Sidecar.Port)
 	}

--- a/internal/eval_runtime_sidecar/server/server.go
+++ b/internal/eval_runtime_sidecar/server/server.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/server"
 	handlers "github.com/eval-hub/eval-hub/internal/eval_runtime_sidecar/handlers"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
@@ -117,16 +116,6 @@ func (s *SidecarServer) Start() error {
 			MinVersion: tls.VersionTLS12,
 			MaxVersion: tls.VersionTLS13,
 		},
-	}
-
-	readyFile := ""
-	if s.config.Service != nil {
-		readyFile = s.config.Service.ReadyFile
-	}
-	s.logger.Info("Writing the sidecar server ready message", "file", readyFile)
-	err = server.SetReady(s.config, s.logger)
-	if err != nil {
-		return err
 	}
 
 	s.logger.Info("Sidecar server starting", "port", s.port)

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -1,7 +1,5 @@
 service:
   port: 8080
-  # These will be elsewhere on a cluster and coherent with the pod spec
-  ready_file: "/tmp/repo-ready"
   termination_file: "/tmp/termination-log"
 # These are here so that the config can be loaded from the secrets directory when needed
 secrets:

--- a/tests/secrets/config.yaml
+++ b/tests/secrets/config.yaml
@@ -1,7 +1,5 @@
 service:
   port: 8080
-  # These will be elsewhere on a cluster and coherent with the pod spec
-  ready_file: "/tmp/repo-ready"
   termination_file: "/tmp/termination-log"
 # These are here so that the config can be loaded from the secrets directory when needed
 secrets:


### PR DESCRIPTION


## What and why

Changes
- remove service.ready_file from evalhub as it is not used anywhere
- remove /data/sidecar-ready from sidecar as it is not used anywhere. This is hardcode not from config

Closes #  https://redhat.atlassian.net/browse/RHOAIENG-72761

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

Validated with dev image on cluster:
```
╰─➤  oc get pods evalhub-856995c75-jgv8z -w
NAME                      READY   STATUS    RESTARTS   AGE
evalhub-856995c75-jgv8z   2/2     Running   0          16s

╰─➤  oc describe pod evalhub-856995c75-jgv8z | grep Image: 
    Image:           quay.io/gnaulak/testp1/eval-hub:dev-no-ready-file
    Image:           quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable
```
sidecar confirmation:
```
╰─➤  oc get pods
NAME                                                              READY   STATUS      RESTARTS   AGE
9b5b42eb-2aff-4fcf-aa91-a9-389ee936-f54f-4e84-aeac-fa84cd2stk2c   0/2     Completed   0          24m
(gbndev) ╭─gnaulak@gnaulak-mac ~/workspace/worktrees/gbndev
╰─➤  oc describe pod 9b5b42eb-2aff-4fcf-aa91-a9-389ee936-f54f-4e84-aeac-fa84cd2stk2c | grep Image:
    Image:           quay.io/gnaulak/testp1/eval-hub:dev-no-ready-file
    Image:           quay.io/opendatahub/ta-lmes-job:odh-3.5-ea2
```


## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

No