### PR TITLE
chore: skip termination file write in local mode

### DIFF
--- a/cmd/eval_hub/main.go
+++ b/cmd/eval_hub/main.go
@@ -247,10 +247,12 @@ func main() {
 }
 
 func startUpFailed(conf *config.Config, err error, msg string, logger *slog.Logger) {
-	termErr := server.SetTerminationMessage(server.GetTerminationFile(conf, logger), fmt.Sprintf("%s: %s", msg, err.Error()), logger)
-	if termErr != nil {
-		logger.Error("Failed to set termination message", "message", msg, "error", termErr.Error())
-		log.Println(termErr.Error())
+	if conf == nil || conf.Service == nil || !conf.Service.LocalMode {
+		termErr := server.SetTerminationMessage(server.GetTerminationFile(conf, logger), fmt.Sprintf("%s: %s", msg, err.Error()), logger)
+		if termErr != nil {
+			logger.Error("Failed to set termination message", "message", msg, "error", termErr.Error())
+			log.Println(termErr.Error())
+		}
 	}
 	log.Fatal(err)
 }

--- a/cmd/eval_hub/main.go
+++ b/cmd/eval_hub/main.go
@@ -62,13 +62,13 @@ func main() {
 	logger, logShutdown, err := logging.NewLogger()
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(nil, err, "Failed to create service logger", logging.FallbackLogger())
+		startUpFailed(nil, args.LocalMode, err, "Failed to create service logger", logging.FallbackLogger())
 	}
 
 	serviceConfig, err := config.LoadConfig(logger, Version, Build, BuildDate, GitHash, args.ConfigDir)
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(nil, err, "Failed to create service config", logger)
+		startUpFailed(nil, args.LocalMode, err, "Failed to create service config", logger)
 	}
 
 	serviceConfig.Service.LocalMode = args.LocalMode
@@ -80,14 +80,14 @@ func main() {
 	providerConfigs, err := config.LoadProviderConfigs(logger, validate, args.ConfigDir)
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, err, "Failed to create provider configs", logger)
+		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create provider configs", logger)
 	}
 
 	// set up the collection configs
 	collectionConfigs, err := config.LoadCollectionConfigs(logger, validate, args.ConfigDir)
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, err, "Failed to create collection configs", logger)
+		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create collection configs", logger)
 	}
 
 	// setup OTEL before storage so DB metrics can register against the MeterProvider
@@ -95,14 +95,14 @@ func main() {
 	if serviceConfig.IsOTELEnabled() {
 		shutdown, err := otel.SetupOTEL(context.Background(), serviceConfig.OTEL, logger, serviceConfig.IsPrometheusEnabled())
 		if err != nil {
-			startUpFailed(serviceConfig, err, "Failed to setup OTEL", logger)
+			startUpFailed(serviceConfig, args.LocalMode, err, "Failed to setup OTEL", logger)
 		}
 		otelShutdown = shutdown
 	}
 
 	if serviceConfig.IsOTELMetricsEnabled() {
 		if err := metrics.Init(); err != nil {
-			startUpFailed(serviceConfig, err, "Failed to initialize OTEL metrics", logger)
+			startUpFailed(serviceConfig, args.LocalMode, err, "Failed to initialize OTEL metrics", logger)
 		}
 	}
 
@@ -117,20 +117,20 @@ func main() {
 	)
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, err, "Failed to create storage", logger)
+		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create storage", logger)
 	}
 	// setup runtime
 	runtime, err := runtimes.NewRuntime(logger, serviceConfig)
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, err, "Failed to create runtime", logger)
+		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create runtime", logger)
 	}
 	logger.Info("Runtime created", "runtime", runtime.Name())
 
 	// setup mlflow client if there is a tracking URI set
 	mlflowClient, mlflowTrackingURI, mlflowServerVersion, err := mlflow.SetupMLFlowClient(serviceConfig, logger)
 	if err != nil {
-		startUpFailed(serviceConfig, err, "Failed to create MLFlow client", logger)
+		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create MLFlow client", logger)
 	}
 
 	// create the server
@@ -143,7 +143,7 @@ func main() {
 
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, err, "Failed to create API server", logger)
+		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create API server", logger)
 	}
 
 	// Create the metrics server if Prometheus is enabled
@@ -195,7 +195,7 @@ func main() {
 				logger.Info("API Server closed gracefully")
 				return
 			}
-			startUpFailed(serviceConfig, err, "API Server failed to start", logger)
+			startUpFailed(serviceConfig, args.LocalMode, err, "API Server failed to start", logger)
 		}
 	}()
 
@@ -246,13 +246,11 @@ func main() {
 	}
 }
 
-func startUpFailed(conf *config.Config, err error, msg string, logger *slog.Logger) {
-	if conf == nil || conf.Service == nil || !conf.Service.LocalMode {
-		termErr := server.SetTerminationMessage(server.GetTerminationFile(conf, logger), fmt.Sprintf("%s: %s", msg, err.Error()), logger)
-		if termErr != nil {
-			logger.Error("Failed to set termination message", "message", msg, "error", termErr.Error())
-			log.Println(termErr.Error())
-		}
+func startUpFailed(conf *config.Config, localMode bool, err error, msg string, logger *slog.Logger) {
+	termErr := server.SetTerminationMessage(server.GetTerminationFile(conf, localMode, logger), fmt.Sprintf("%s: %s", msg, err.Error()), logger)
+	if termErr != nil {
+		logger.Error("Failed to set termination message", "message", msg, "error", termErr.Error())
+		log.Println(termErr.Error())
 	}
 	log.Fatal(err)
 }

--- a/cmd/eval_hub/main.go
+++ b/cmd/eval_hub/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"fmt"
 	"log"
 	"log/slog"
 
@@ -59,16 +58,21 @@ func args() Args {
 func main() {
 	args := args()
 
+	startUpFailed := func(conf *config.Config, err error, msg string, logger *slog.Logger) {
+		server.HandleStartupFailure(conf, args.LocalMode, err, msg, logger)
+		log.Fatal(err)
+	}
+
 	logger, logShutdown, err := logging.NewLogger()
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(nil, args.LocalMode, err, "Failed to create service logger", logging.FallbackLogger())
+		startUpFailed(nil, err, "Failed to create service logger", logging.FallbackLogger())
 	}
 
 	serviceConfig, err := config.LoadConfig(logger, Version, Build, BuildDate, GitHash, args.ConfigDir)
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(nil, args.LocalMode, err, "Failed to create service config", logger)
+		startUpFailed(nil, err, "Failed to create service config", logger)
 	}
 
 	serviceConfig.Service.LocalMode = args.LocalMode
@@ -80,14 +84,14 @@ func main() {
 	providerConfigs, err := config.LoadProviderConfigs(logger, validate, args.ConfigDir)
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create provider configs", logger)
+		startUpFailed(serviceConfig, err, "Failed to create provider configs", logger)
 	}
 
 	// set up the collection configs
 	collectionConfigs, err := config.LoadCollectionConfigs(logger, validate, args.ConfigDir)
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create collection configs", logger)
+		startUpFailed(serviceConfig, err, "Failed to create collection configs", logger)
 	}
 
 	// setup OTEL before storage so DB metrics can register against the MeterProvider
@@ -95,14 +99,14 @@ func main() {
 	if serviceConfig.IsOTELEnabled() {
 		shutdown, err := otel.SetupOTEL(context.Background(), serviceConfig.OTEL, logger, serviceConfig.IsPrometheusEnabled())
 		if err != nil {
-			startUpFailed(serviceConfig, args.LocalMode, err, "Failed to setup OTEL", logger)
+			startUpFailed(serviceConfig, err, "Failed to setup OTEL", logger)
 		}
 		otelShutdown = shutdown
 	}
 
 	if serviceConfig.IsOTELMetricsEnabled() {
 		if err := metrics.Init(); err != nil {
-			startUpFailed(serviceConfig, args.LocalMode, err, "Failed to initialize OTEL metrics", logger)
+			startUpFailed(serviceConfig, err, "Failed to initialize OTEL metrics", logger)
 		}
 	}
 
@@ -117,20 +121,20 @@ func main() {
 	)
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create storage", logger)
+		startUpFailed(serviceConfig, err, "Failed to create storage", logger)
 	}
 	// setup runtime
 	runtime, err := runtimes.NewRuntime(logger, serviceConfig)
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create runtime", logger)
+		startUpFailed(serviceConfig, err, "Failed to create runtime", logger)
 	}
 	logger.Info("Runtime created", "runtime", runtime.Name())
 
 	// setup mlflow client if there is a tracking URI set
 	mlflowClient, mlflowTrackingURI, mlflowServerVersion, err := mlflow.SetupMLFlowClient(serviceConfig, logger)
 	if err != nil {
-		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create MLFlow client", logger)
+		startUpFailed(serviceConfig, err, "Failed to create MLFlow client", logger)
 	}
 
 	// create the server
@@ -143,7 +147,7 @@ func main() {
 
 	if err != nil {
 		// we do this as no point trying to continue
-		startUpFailed(serviceConfig, args.LocalMode, err, "Failed to create API server", logger)
+		startUpFailed(serviceConfig, err, "Failed to create API server", logger)
 	}
 
 	// Create the metrics server if Prometheus is enabled
@@ -195,7 +199,7 @@ func main() {
 				logger.Info("API Server closed gracefully")
 				return
 			}
-			startUpFailed(serviceConfig, args.LocalMode, err, "API Server failed to start", logger)
+			startUpFailed(serviceConfig, err, "API Server failed to start", logger)
 		}
 	}()
 
@@ -244,13 +248,4 @@ func main() {
 		logger.Info("API Server shutdown gracefully")
 		_ = logShutdown() // ignore the error
 	}
-}
-
-func startUpFailed(conf *config.Config, localMode bool, err error, msg string, logger *slog.Logger) {
-	termErr := server.SetTerminationMessage(server.GetTerminationFile(conf, localMode, logger), fmt.Sprintf("%s: %s", msg, err.Error()), logger)
-	if termErr != nil {
-		logger.Error("Failed to set termination message", "message", msg, "error", termErr.Error())
-		log.Println(termErr.Error())
-	}
-	log.Fatal(err)
 }

--- a/internal/eval_hub/server/server_files.go
+++ b/internal/eval_hub/server/server_files.go
@@ -60,3 +60,10 @@ func SetTerminationMessage(terminationFile string, message string, logger *slog.
 	}
 	return writeFile(terminationFile, message, "termination", logger)
 }
+
+func HandleStartupFailure(conf *config.Config, localMode bool, err error, msg string, logger *slog.Logger) {
+	termErr := SetTerminationMessage(GetTerminationFile(conf, localMode, logger), fmt.Sprintf("%s: %s", msg, err.Error()), logger)
+	if termErr != nil {
+		logger.Error("Failed to set termination message", "message", msg, "error", termErr.Error())
+	}
+}

--- a/internal/eval_hub/server/server_files.go
+++ b/internal/eval_hub/server/server_files.go
@@ -13,7 +13,10 @@ import (
 
 // handle termination messages
 
-func GetTerminationFile(conf *config.Config, logger *slog.Logger) string {
+func GetTerminationFile(conf *config.Config, localMode bool, logger *slog.Logger) string {
+	if localMode {
+		return ""
+	}
 	tf := ""
 	if (conf != nil) && (conf.Service != nil) {
 		tf = strings.TrimSpace(conf.Service.TerminationFile)
@@ -52,5 +55,8 @@ func writeFile(fname string, message string, fileType string, logger *slog.Logge
 }
 
 func SetTerminationMessage(terminationFile string, message string, logger *slog.Logger) error {
+	if terminationFile == "" {
+		return nil
+	}
 	return writeFile(terminationFile, message, "termination", logger)
 }

--- a/internal/eval_hub/server/server_files_test.go
+++ b/internal/eval_hub/server/server_files_test.go
@@ -1,7 +1,7 @@
 package server_test
 
 import (
-	"io"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -13,7 +13,7 @@ import (
 )
 
 func discardLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return slog.New(slog.DiscardHandler)
 }
 
 func TestGetTerminationFile(t *testing.T) {
@@ -139,4 +139,38 @@ func TestSetTerminationMessage_EmptyPath(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no-op for empty path, got error: %v", err)
 	}
+}
+
+func TestHandleStartupFailure_WritesTerminationFile(t *testing.T) {
+	dir := t.TempDir()
+	termFile := filepath.Join(dir, "termination-log")
+	conf := &config.Config{Service: &config.ServiceConfig{TerminationFile: termFile}}
+
+	server.HandleStartupFailure(conf, false, errors.New("db connect failed"), "Failed to create storage", discardLogger())
+
+	data, err := os.ReadFile(termFile)
+	if err != nil {
+		t.Fatalf("failed to read termination file: %v", err)
+	}
+	want := "Failed to create storage: db connect failed"
+	if string(data) != want {
+		t.Errorf("got %q, want %q", string(data), want)
+	}
+}
+
+func TestHandleStartupFailure_LocalModeSkipsFile(t *testing.T) {
+	dir := t.TempDir()
+	termFile := filepath.Join(dir, "termination-log")
+	conf := &config.Config{Service: &config.ServiceConfig{TerminationFile: termFile}}
+
+	server.HandleStartupFailure(conf, true, errors.New("boom"), "Failed", discardLogger())
+
+	if _, err := os.Stat(termFile); !os.IsNotExist(err) {
+		t.Error("expected no termination file in local mode")
+	}
+}
+
+func TestHandleStartupFailure_NilConfig(t *testing.T) {
+	t.Setenv(constants.EnvVarTerminationFile, "")
+	server.HandleStartupFailure(nil, false, errors.New("boom"), "Failed", discardLogger())
 }

--- a/internal/eval_hub/server/server_files_test.go
+++ b/internal/eval_hub/server/server_files_test.go
@@ -1,0 +1,142 @@
+package server_test
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/constants"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/server"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestGetTerminationFile(t *testing.T) {
+	const fallback = "/opt/evalhub/work/termination-log"
+
+	tests := []struct {
+		name      string
+		conf      *config.Config
+		localMode bool
+		envVal    string
+		want      string
+	}{
+		{
+			name:      "from config",
+			conf:      &config.Config{Service: &config.ServiceConfig{TerminationFile: "/custom/termination-log"}},
+			localMode: false,
+			want:      "/custom/termination-log",
+		},
+		{
+			name:      "config takes precedence over env",
+			conf:      &config.Config{Service: &config.ServiceConfig{TerminationFile: "/from-config"}},
+			localMode: false,
+			envVal:    "/from-env",
+			want:      "/from-config",
+		},
+		{
+			name:      "whitespace-only config falls through",
+			conf:      &config.Config{Service: &config.ServiceConfig{TerminationFile: "   "}},
+			localMode: false,
+			want:      fallback,
+		},
+		{
+			name:      "from env var",
+			conf:      &config.Config{Service: &config.ServiceConfig{}},
+			localMode: false,
+			envVal:    "/env/termination-log",
+			want:      "/env/termination-log",
+		},
+		{
+			name:      "nil config",
+			conf:      nil,
+			localMode: false,
+			want:      fallback,
+		},
+		{
+			name:      "nil service config",
+			conf:      &config.Config{},
+			localMode: false,
+			want:      fallback,
+		},
+		{
+			name:      "local mode returns empty",
+			conf:      &config.Config{Service: &config.ServiceConfig{TerminationFile: "/should-be-ignored"}},
+			localMode: true,
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(constants.EnvVarTerminationFile, tt.envVal)
+			got := server.GetTerminationFile(tt.conf, tt.localMode, discardLogger())
+			if got != tt.want {
+				t.Errorf("GetTerminationFile() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetTerminationMessage_WritesFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "termination-log")
+
+	err := server.SetTerminationMessage(path, "startup failed: boom", discardLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read termination file: %v", err)
+	}
+	if string(data) != "startup failed: boom" {
+		t.Errorf("expected 'startup failed: boom', got %q", string(data))
+	}
+}
+
+func TestSetTerminationMessage_OverwritesExisting(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "termination-log")
+
+	if err := os.WriteFile(path, []byte("old message"), 0o644); err != nil {
+		t.Fatalf("failed to seed file: %v", err)
+	}
+
+	err := server.SetTerminationMessage(path, "new message", discardLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read termination file: %v", err)
+	}
+	if string(data) != "new message" {
+		t.Errorf("expected 'new message', got %q", string(data))
+	}
+}
+
+func TestSetTerminationMessage_InvalidPath(t *testing.T) {
+	t.Parallel()
+	err := server.SetTerminationMessage("/nonexistent/dir/termination-log", "msg", discardLogger())
+	if err == nil {
+		t.Error("expected error for invalid path, got nil")
+	}
+}
+
+func TestSetTerminationMessage_EmptyPath(t *testing.T) {
+	t.Parallel()
+	err := server.SetTerminationMessage("", "msg", discardLogger())
+	if err != nil {
+		t.Errorf("expected no-op for empty path, got error: %v", err)
+	}
+}


### PR DESCRIPTION

## What and why

The Kubernetes termination message file is unnecessary when running locally since errors are already visible on stderr and in log files.


Currently we get: `on failure`
```
{"level":"error","ts":"2026-07-02T20:21:49.539+0530","caller":"eval_hub/main.go:221","msg":"Failed to set termination message","message":"Failed to create service config","error":"failed to create the termination file: /opt/evalhub/work/termination-log: open /opt/evalhub/work/termination-log: no such file or directory","stacktrace":"main.startUpFailed\n\t/home/runner/work/eval-hub/eval-hub/cmd/eval_hub/main.go:221\nmain.main\n\t/home/runner/work/eval-hub/eval-hub/cmd/eval_hub/main.go:71\nruntime.main\n\t/opt/hostedtoolcache/go/1.26.3/x64/src/runtime/proc.go:290"}
2026/07/02 20:21:49 failed to create the termination file: /opt/evalhub/work/termination-log: open /opt/evalhub/work/termination-log: no such file or directory
2026/07/02 20:21:49 Config File "config" Not Found in "[/Users/gnaulak/workspace/worktrees/eval-hub/chore-local-no-term-file/config/config]"
```

With patch, we get a cleaner exit on `-local` mode now
```
╰─➤  eval-hub-server -local -configdir ./config
{"level":"info","ts":"2026-07-02T20:35:47.597+0530","caller":"config/loader.go:341","msg":"Start reading configuration","version":"0.4.4","build":"0.4.3","build_date":"2026-07-02T20:33:28+0530","dirs":["./config"]}
{"level":"error","ts":"2026-07-02T20:35:47.597+0530","caller":"config/loader.go:58","msg":"Failed to read the configuration file","file":"config.yaml","dirs":"[./config]","error":"Config File \"config\" Not Found in \"[/Users/gnaulak/workspace/worktrees/eval-hub/chore-local-no-term-file/config/config]\"","stacktrace":"github.com/eval-hub/eval-hub/internal/eval_hub/config.readConfig\n\t/Users/gnaulak/workspace/worktrees/eval-hub/chore-local-no-term-file/internal/eval_hub/config/loader.go:58\ngithub.com/eval-hub/eval-hub/internal/eval_hub/config.LoadConfig\n\t/Users/gnaulak/workspace/worktrees/eval-hub/chore-local-no-term-file/internal/eval_hub/config/loader.go:347\nmain.main\n\t/Users/gnaulak/workspace/worktrees/eval-hub/chore-local-no-term-file/cmd/eval_hub/main.go:68\nruntime.main\n\t/Users/gnaulak/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.3.darwin-arm64/src/runtime/proc.go:290"}
{"level":"error","ts":"2026-07-02T20:35:47.597+0530","caller":"config/loader.go:349","msg":"Failed to read configuration file config.yaml","error":"Config File \"config\" Not Found in \"[/Users/gnaulak/workspace/worktrees/eval-hub/chore-local-no-term-file/config/config]\"","dirs":["./config"],"stacktrace":"github.com/eval-hub/eval-hub/internal/eval_hub/config.LoadConfig\n\t/Users/gnaulak/workspace/worktrees/eval-hub/chore-local-no-term-file/internal/eval_hub/config/loader.go:349\nmain.main\n\t/Users/gnaulak/workspace/worktrees/eval-hub/chore-local-no-term-file/cmd/eval_hub/main.go:68\nruntime.main\n\t/Users/gnaulak/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.3.darwin-arm64/src/runtime/proc.go:290"}
2026/07/02 20:35:47 Config File "config" Not Found in "[/Users/gnaulak/workspace/worktrees/eval-hub/chore-local-no-term-file/config/config]"
```

Closes # NA

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup failure handling so termination messages are written only when appropriate (skipped in local mode).
  * Updated local-mode behavior to avoid writing termination message files during fatal startup errors.
* **Tests**
  * Added unit tests covering termination-file path resolution, message writing/overwriting behavior, and local vs. non-local startup failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->