### PR TITLE
test(make): add Atris upgrade test Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -740,3 +740,64 @@ test-mcp-vscode: start-service build-mcp ## Run VS Code/Cursor MCP test scripts 
 	status=$$?; \
 	$(MAKE) stop-mcp stop-service; \
 	exit $$status
+
+## ------------------------------------------------------------------------------------------------
+## Atris Upgrade Tests
+## ------------------------------------------------------------------------------------------------
+
+.PHONY: run-pre-upgrade run-post-upgrade-verify run-post-upgrade run-post-upgrade-cleanup run-atris-upgrade
+
+run-pre-upgrade:
+	@echo "Running pre-upgrade tests for ${SOURCE_RELEASE} ..."
+	@test -n "$(JUNIT_XML)" || { \
+		echo "ERROR: JUNIT_XML is not set or is empty."; \
+		exit 1; \
+	}
+	@mkdir -p $(dir $(JUNIT_XML))
+	@echo "TODO"
+	@printf '%s\n' \
+		'<?xml version="1.0" encoding="UTF-8"?>' \
+		'<testsuites name="EvalHub Upgrade Tests" tests="0" skipped="0" failures="0" errors="0" time="0.0">' \
+		'</testsuites>' \
+		> "$(JUNIT_XML)"
+	@echo "Results saved to ${JUNIT_XML}"
+	@echo "Pre-upgrade tests complete"
+
+run-post-upgrade-verify:
+	@echo "Running post-upgrade verification tests for ${SOURCE_RELEASE} to ${TARGET_RELEASE} ..."
+	@test -n "$(JUNIT_XML)" || { \
+		echo "ERROR: JUNIT_XML is not set or is empty."; \
+		exit 1; \
+	}
+	@mkdir -p $(dir $(JUNIT_XML))
+	@echo "TODO"
+	@printf '%s\n' \
+		'<?xml version="1.0" encoding="UTF-8"?>' \
+		'<testsuites name="EvalHub Upgrade Tests" tests="0" skipped="0" failures="0" errors="0" time="0.0">' \
+		'</testsuites>' \
+		> "$(JUNIT_XML)"
+	@echo "Results saved to ${JUNIT_XML}"
+	@echo "Post-upgrade verification tests complete"
+
+run-post-upgrade:
+	@echo "Running post-upgrade tests for ${TARGET_RELEASE} ..."
+	@test -n "$(JUNIT_XML)" || { \
+		echo "ERROR: JUNIT_XML is not set or is empty."; \
+		exit 1; \
+	}
+	@mkdir -p $(dir $(JUNIT_XML))
+	@echo "TODO"
+	@printf '%s\n' \
+		'<?xml version="1.0" encoding="UTF-8"?>' \
+		'<testsuites name="EvalHub Upgrade Tests" tests="0" skipped="0" failures="0" errors="0" time="0.0">' \
+		'</testsuites>' \
+		> "$(JUNIT_XML)"
+	@echo "Results saved to ${JUNIT_XML}"
+	@echo "Post-upgrade tests complete"
+
+run-post-upgrade-cleanup:
+	@echo "Running post-upgrade cleanup for ${TARGET_RELEASE} ..."
+	@echo "TODO"
+	@echo "Post-upgrade cleanup complete"
+
+run-atris-upgrade: run-pre-upgrade run-post-upgrade-verify run-post-upgrade run-post-upgrade-cleanup


### PR DESCRIPTION
## What and why

Scaffold run-pre-upgrade, run-post-upgrade-verify, run-post-upgrade, and run-post-upgrade-cleanup targets for the Atris upgrade pipeline. Validate JUNIT_XML, create its parent directory, and write a stub JUnit report until the real test steps are implemented.

Assisted-by: Cursor
Signed-off-by: Julian Payne <julpayne@redhat.com>

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new upgrade testing workflow with steps for pre-upgrade checks, post-upgrade verification, post-upgrade execution, cleanup, and an all-in-one run option.
  * The workflow now creates the required test output directory automatically and produces a placeholder results file when run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->