### PR TITLE
ci(mcp): use pypi-mcp environment for MCP publish workflow

### DIFF
--- a/.github/workflows/publish-python-mcp.yml
+++ b/.github/workflows/publish-python-mcp.yml
@@ -188,7 +188,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: pypi-mcp
       url: https://pypi.org/p/eval-hub-mcp
     permissions:
       id-token: write


### PR DESCRIPTION


## What and why

The trusted publisher on PyPI is configured for the pypi-mcp environment, not pypi. Update the environment name to match so the OIDC token claims align with the publisher configuration.

Closes # NA

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MCP Python publish workflow to use a different deployment environment for releases, aligning publishing with the correct configuration and approval settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->