### PR TITLE
fix(ci): remove unnecessary '-no-fail' argument from Gosec Security Scanner in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,10 @@ jobs:
       env:
         # make sure that we use the golang version required by the project
         GOSECGOVERSION: go1.26.3
+        GOTOOLCHAIN: go1.26.3
       uses: securego/gosec@5a2f0a6455f43d8ac8efaf1591ee0fb400dce662 # v2.27.1
       with:
-        # verbose: -stdout -verbose=text
-        args: '-fmt sarif -out gosec-results.sarif -exclude-dir=tests ./...'
+        args: '-fmt sarif -out gosec-results.sarif -stdout -verbose=text -exclude-dir=tests ./...'
 
     - name: Upload SARIF file to GitHub Security tab
       uses: github/codeql-action/upload-sarif@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
       env:
         # make sure that we use the golang version required by the project
         GOTOOLCHAIN=auto
+        GOSECGOVERSION=go1.26.3
       uses: securego/gosec@5a2f0a6455f43d8ac8efaf1591ee0fb400dce662 # v2.27.1
       with:
         # verbose: -stdout -verbose=text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Run Gosec Security Scanner
       uses: securego/gosec@5a2f0a6455f43d8ac8efaf1591ee0fb400dce662 # v2.27.1
       with:
-        args: '-no-fail -fmt sarif -out gosec-results.sarif ./...'
+        args: '-fmt sarif -out gosec-results.sarif ./...'
 
     - name: Upload SARIF file to GitHub Security tab
       uses: github/codeql-action/upload-sarif@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
       # that are not caught by the following steps.
       env:
         # make sure that we use the golang version required by the project
-        GOTOOLCHAIN=auto
         GOSECGOVERSION=go1.26.3
       uses: securego/gosec@5a2f0a6455f43d8ac8efaf1591ee0fb400dce662 # v2.27.1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       # that are not caught by the following steps.
       env:
         # make sure that we use the golang version required by the project
-        GOSECGOVERSION=go1.26.3
+        GOSECGOVERSION: go1.26.3
       uses: securego/gosec@5a2f0a6455f43d8ac8efaf1591ee0fb400dce662 # v2.27.1
       with:
         # verbose: -stdout -verbose=text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,17 @@ jobs:
         cache: true
 
     - name: Run Gosec Security Scanner
+      # The recommended way to run the gosec scanner is to use -no-fail
+      # https://github.com/securego/gosec#integrating-with-code-scanning
+      # The problem is that this can hide some errors (such as golang version mismatch)
+      # that are not caught by the following steps.
+      env:
+        # make sure that we use the golang version required by the project
+        GOTOOLCHAIN=auto
       uses: securego/gosec@5a2f0a6455f43d8ac8efaf1591ee0fb400dce662 # v2.27.1
       with:
-        args: '-fmt sarif -out gosec-results.sarif ./...'
+        # verbose: -stdout -verbose=text
+        args: '-fmt sarif -out gosec-results.sarif -exclude-dir=tests ./...'
 
     - name: Upload SARIF file to GitHub Security tab
       uses: github/codeql-action/upload-sarif@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,11 +103,7 @@ Made-with: Cursor
 Generated with: Claude Code
 ```
 
-Always end the commit message body with this sign-off trailer (after any AI-assistance trailers) for the current user, for example:
-
-```text
-Signed-off-by: Julian Payne <julpayne@redhat.com>
-```
+For DCO sign-off, use `git commit -s` (or `git commit --signoff`). Do **not** include a `Signed-off-by` line in the commit message body; `-s` appends it from the author's configured `user.name` and `user.email`.
 
 ## Architecture Overview
 

--- a/cmd/eval_hub/main.go
+++ b/cmd/eval_hub/main.go
@@ -78,7 +78,10 @@ func main() {
 	serviceConfig.Service.LocalMode = args.LocalMode
 
 	// set up the validator
-	validate := validation.NewValidator()
+	validate, err := validation.NewValidator()
+	if err != nil {
+		startUpFailed(serviceConfig, err, "Failed to create validator", logger)
+	}
 
 	// set up the provider configs
 	providerConfigs, err := config.LoadProviderConfigs(logger, validate, args.ConfigDir)

--- a/cmd/eval_runtime_init/main.go
+++ b/cmd/eval_runtime_init/main.go
@@ -22,12 +22,12 @@ const (
 	envBucket         = "TEST_DATA_S3_BUCKET"
 	envKey            = "TEST_DATA_S3_KEY"
 	envTimeout        = "TEST_DATA_S3_TIMEOUT"
-	secretDir         = "/var/run/secrets/test-data"
+	secretDir         = "/var/run/secrets/test-data" // #nosec G101 -- K8s secret mount path
 	destDir           = "/test_data"
 	regionOptionalKey = "AWS_DEFAULT_REGION"
 	endpointKey       = "AWS_S3_ENDPOINT"
 	accessKeyIDKey    = "AWS_ACCESS_KEY_ID"
-	secretAccessKey   = "AWS_SECRET_ACCESS_KEY"
+	secretAccessKey   = "AWS_SECRET_ACCESS_KEY" // #nosec G101 -- env var name, not a credential value
 	defaultTimeout    = 10 * time.Minute
 )
 
@@ -90,9 +90,15 @@ func run() error {
 		}
 	})
 
-	if err := os.MkdirAll(destDir, 0o755); err != nil {
+	if err := os.MkdirAll(destDir, 0o750); err != nil {
 		return fmt.Errorf("create dest dir: %w", err)
 	}
+
+	destRoot, err := os.OpenRoot(destDir)
+	if err != nil {
+		return fmt.Errorf("open dest root: %w", err)
+	}
+	defer destRoot.Close()
 
 	slog.Info("starting download", "bucket", bucket, "key", keyPrefix)
 
@@ -117,7 +123,7 @@ func run() error {
 				continue
 			}
 			found = true
-			written, err := downloadObject(ctx, client, bucket, keyPrefix, *obj.Key)
+			written, err := downloadObject(ctx, client, destRoot, bucket, keyPrefix, *obj.Key)
 			if err != nil {
 				return err
 			}
@@ -151,22 +157,16 @@ func loadAWSConfig(ctx context.Context, region, accessKey, secretKey string) (aw
 	return cfg, nil
 }
 
-func downloadObject(ctx context.Context, client *s3.Client, bucket, prefix, key string) (int64, error) {
-	rel := strings.TrimPrefix(key, prefix)
-	rel = strings.TrimPrefix(rel, "/")
-	if rel == "" {
-		rel = path.Base(key)
-	}
-	if rel == "." || rel == "/" {
-		return 0, errors.New("invalid object key for destination path")
+func downloadObject(ctx context.Context, client *s3.Client, destRoot *os.Root, bucket, prefix, key string) (int64, error) {
+	rel, err := relativeDestPath(prefix, key)
+	if err != nil {
+		return 0, err
 	}
 
-	destPath := filepath.Join(destDir, filepath.FromSlash(rel))
-	if !strings.HasPrefix(destPath, destDir+string(os.PathSeparator)) && destPath != destDir {
-		return 0, fmt.Errorf("invalid destination path resolved for %q", key)
-	}
-	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-		return 0, fmt.Errorf("create dir for %q: %w", destPath, err)
+	if dir := path.Dir(rel); dir != "." {
+		if err := destRoot.MkdirAll(dir, 0o750); err != nil {
+			return 0, fmt.Errorf("create dir for %q: %w", key, err)
+		}
 	}
 
 	resp, err := client.GetObject(ctx, &s3.GetObjectInput{
@@ -178,24 +178,40 @@ func downloadObject(ctx context.Context, client *s3.Client, bucket, prefix, key 
 	}
 	defer resp.Body.Close()
 
-	file, err := os.Create(destPath)
+	file, err := destRoot.Create(rel)
 	if err != nil {
-		return 0, fmt.Errorf("create file %q: %w", destPath, err)
+		return 0, fmt.Errorf("create file %q: %w", key, err)
 	}
 	defer file.Close()
 
 	written, err := io.Copy(file, resp.Body)
 	if err != nil {
-		return 0, fmt.Errorf("write file %q: %w", destPath, err)
+		return 0, fmt.Errorf("write file %q: %w", key, err)
 	}
 	return written, nil
+}
+
+func relativeDestPath(prefix, key string) (string, error) {
+	rel := strings.TrimPrefix(key, prefix)
+	rel = strings.TrimPrefix(rel, "/")
+	if rel == "" {
+		rel = path.Base(key)
+	}
+	rel = filepath.FromSlash(rel)
+	if rel == "." || rel == "/" {
+		return "", errors.New("invalid object key for destination path")
+	}
+	if !filepath.IsLocal(rel) {
+		return "", fmt.Errorf("object key escapes destination directory: %q", key)
+	}
+	return filepath.ToSlash(rel), nil
 }
 
 func readSecret(name string) string {
 	if name == "" {
 		return ""
 	}
-	content, err := os.ReadFile(filepath.Join(secretDir, name))
+	content, err := os.ReadFile(filepath.Join(secretDir, name)) // #nosec G304 -- name is a fixed secret key
 	if err != nil {
 		return ""
 	}

--- a/cmd/eval_runtime_init/main_test.go
+++ b/cmd/eval_runtime_init/main_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestRelativeDestPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		prefix  string
+		key     string
+		want    string
+		wantErr string
+	}{
+		{
+			name:   "nested under prefix",
+			prefix: "datasets/run-1",
+			key:    "datasets/run-1/examples.jsonl",
+			want:   "examples.jsonl",
+		},
+		{
+			name:   "nested subdirectory",
+			prefix: "datasets/run-1",
+			key:    "datasets/run-1/subdir/file.txt",
+			want:   "subdir/file.txt",
+		},
+		{
+			name:   "prefix only uses basename",
+			prefix: "datasets/run-1",
+			key:    "datasets/run-1",
+			want:   "run-1",
+		},
+		{
+			name:    "path traversal rejected",
+			prefix:  "datasets/run-1",
+			key:     "datasets/run-1/../../etc/passwd",
+			wantErr: "escapes destination directory",
+		},
+		{
+			name:    "dot only rejected",
+			prefix:  "datasets",
+			key:     "datasets/.",
+			wantErr: "invalid object key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := relativeDestPath(tt.prefix, tt.key)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("relativeDestPath() = (%q, nil), want error containing %q", got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("relativeDestPath() error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("relativeDestPath() = %v, want (%q, nil)", err, tt.want)
+			}
+			if got != tt.want {
+				t.Fatalf("relativeDestPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDownloadObjectRejectsInvalidKey(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	destRoot, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("OpenRoot() = %v", err)
+	}
+	defer destRoot.Close()
+
+	_, err = downloadObject(context.Background(), nil, destRoot, "bucket", "datasets/run-1", "datasets/run-1/../../etc/passwd")
+	if err == nil {
+		t.Fatal("downloadObject() = nil, want relative path error")
+	}
+}
+
+func TestDownloadObjectWritesNestedFile(t *testing.T) {
+	t.Parallel()
+
+	const objectKey = "data/nested/file.txt"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/bucket/"+objectKey {
+			_, _ = io.Copy(w, strings.NewReader("hello"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("ak", "sk", "")),
+	)
+	if err != nil {
+		t.Fatalf("LoadDefaultConfig() = %v", err)
+	}
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(srv.URL)
+		o.UsePathStyle = true
+	})
+
+	dir := t.TempDir()
+	destRoot, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("OpenRoot() = %v", err)
+	}
+	defer destRoot.Close()
+
+	written, err := downloadObject(ctx, client, destRoot, "bucket", "data/", objectKey)
+	if err != nil {
+		t.Fatalf("downloadObject() = %v, want nil error", err)
+	}
+	if written != int64(len("hello")) {
+		t.Fatalf("downloadObject() wrote %d bytes, want %d", written, len("hello"))
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "nested", "file.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile() = %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("file contents = %q, want %q", got, "hello")
+	}
+}

--- a/cmd/validate_configs/main.go
+++ b/cmd/validate_configs/main.go
@@ -16,7 +16,11 @@ func main() {
 	flag.Parse()
 
 	logger := logging.FallbackLogger()
-	validate := validation.NewValidator()
+	validate, err := validation.NewValidator()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create validator: %v\n", err)
+		os.Exit(1)
+	}
 
 	providers, err := config.LoadProviderConfigs(logger, validate, *configDir)
 	if err != nil {

--- a/internal/eval_hub/config/loader.go
+++ b/internal/eval_hub/config/loader.go
@@ -68,7 +68,10 @@ func readConfig(logger *slog.Logger, name string, ext string, dirs ...string) (*
 	}
 	if len(envMappings.EnvMappings) > 0 {
 		for envName, field := range envMappings.EnvMappings {
-			configValues.BindEnv(field, strings.ToUpper(envName))
+			if err := configValues.BindEnv(field, strings.ToUpper(envName)); err != nil {
+				logger.Error("Failed to bind environment variable", "field_name", field, "env_name", envName, "error", err.Error())
+				return nil, err
+			}
 			logger.Info("Mapped environment variable", "field_name", field, "env_name", envName)
 		}
 		// now we need to reload the config file

--- a/internal/eval_hub/config/loader_gpu_test.go
+++ b/internal/eval_hub/config/loader_gpu_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
 	"github.com/eval-hub/eval-hub/internal/logging"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 )
 
 func TestLoadProviderConfigs_ParsesGPUProviderFixture(t *testing.T) {
@@ -15,7 +15,7 @@ func TestLoadProviderConfigs_ParsesGPUProviderFixture(t *testing.T) {
 	configRoot := t.TempDir()
 	copyProviderFixture(t, configRoot, "provider_gpu_test.yaml")
 
-	providers, err := config.LoadProviderConfigs(logger, validation.NewValidator(), configRoot)
+	providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), configRoot)
 	if err != nil {
 		t.Fatalf("LoadProviderConfigs failed: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestLoadProviderConfigs_ParsesGPUNodeSelectorFixture(t *testing.T) {
 	configRoot := t.TempDir()
 	copyProviderFixture(t, configRoot, "provider_gpu_a100.yaml")
 
-	providers, err := config.LoadProviderConfigs(logger, validation.NewValidator(), configRoot)
+	providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), configRoot)
 	if err != nil {
 		t.Fatalf("LoadProviderConfigs failed: %v", err)
 	}
@@ -98,7 +98,7 @@ benchmarks:
 		t.Fatalf("write provider yaml: %v", err)
 	}
 
-	providers, err := config.LoadProviderConfigs(logger, validation.NewValidator(), configRoot)
+	providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), configRoot)
 	if err != nil {
 		t.Fatalf("LoadProviderConfigs failed: %v", err)
 	}

--- a/internal/eval_hub/config/loader_test.go
+++ b/internal/eval_hub/config/loader_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
 	"github.com/eval-hub/eval-hub/internal/logging"
 	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
@@ -225,14 +224,14 @@ secrets:
 	})
 
 	t.Run("loads providers from config dir", func(t *testing.T) {
-		_, err := config.LoadProviderConfigs(logger, validation.NewValidator())
+		_, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t))
 		if err != nil {
 			t.Fatalf("LoadProviderConfigs failed: %v", err)
 		}
 	})
 
 	t.Run("loads collections from config dir", func(t *testing.T) {
-		_, err := config.LoadCollectionConfigs(logger, validation.NewValidator())
+		_, err := config.LoadCollectionConfigs(logger, testhelpers.NewValidator(t))
 		if err != nil {
 			t.Fatalf("LoadCollectionConfigs failed: %v", err)
 		}
@@ -311,7 +310,7 @@ func TestLoadProviderConfigs(t *testing.T) {
 		os.MkdirAll(provDir, 0755)
 		writeProviderYAML(t, provDir, "alpha", "Alpha Provider")
 
-		providers, err := config.LoadProviderConfigs(logger, validation.NewValidator(), dir)
+		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), dir)
 		if err != nil {
 			t.Fatalf("LoadProviderConfigs failed: %v", err)
 		}
@@ -331,7 +330,7 @@ func TestLoadProviderConfigs(t *testing.T) {
 		writeProviderYAML(t, provDir, "beta", "Beta")
 		writeProviderYAML(t, provDir, "gamma", "Gamma")
 
-		providers, err := config.LoadProviderConfigs(logger, validation.NewValidator(), dir)
+		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), dir)
 		if err != nil {
 			t.Fatalf("LoadProviderConfigs failed: %v", err)
 		}
@@ -347,7 +346,7 @@ func TestLoadProviderConfigs(t *testing.T) {
 		content := "name: No ID Provider\ndescription: missing id field\n"
 		os.WriteFile(filepath.Join(provDir, "noid.yaml"), []byte(content), 0600)
 
-		providers, err := config.LoadProviderConfigs(logger, validation.NewValidator(), dir)
+		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), dir)
 		if err == nil {
 			t.Fatalf("LoadProviderConfigs did not fail when expecting an error for missing id")
 		}
@@ -364,7 +363,7 @@ func TestLoadProviderConfigs(t *testing.T) {
 		os.WriteFile(filepath.Join(provDir, "readme.txt"), []byte("ignore me"), 0600)
 		os.MkdirAll(filepath.Join(provDir, "subdir"), 0755)
 
-		providers, err := config.LoadProviderConfigs(logger, validation.NewValidator(), dir)
+		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), dir)
 		if err != nil {
 			t.Fatalf("LoadProviderConfigs failed: %v", err)
 		}
@@ -376,7 +375,7 @@ func TestLoadProviderConfigs(t *testing.T) {
 	t.Run("returns empty map when providers dir missing", func(t *testing.T) {
 		dir := t.TempDir() // no "providers" subdir
 
-		providers, err := config.LoadProviderConfigs(logger, validation.NewValidator(), dir)
+		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), dir)
 		if err != nil {
 			t.Fatalf("LoadProviderConfigs failed: %v", err)
 		}
@@ -386,7 +385,7 @@ func TestLoadProviderConfigs(t *testing.T) {
 	})
 
 	t.Run("falls back to default lookup paths when no explicit dir", func(t *testing.T) {
-		providers, err := config.LoadProviderConfigs(logger, validation.NewValidator(), "")
+		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), "")
 		if err != nil {
 			t.Fatalf("LoadProviderConfigs failed: %v", err)
 		}
@@ -412,7 +411,7 @@ benchmarks:
 `
 		os.WriteFile(filepath.Join(provDir, "mytest.yaml"), []byte(content), 0600)
 
-		providers, err := config.LoadProviderConfigs(logger, validation.NewValidator(), dir)
+		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), dir)
 		if err != nil {
 			t.Fatalf("LoadProviderConfigs failed: %v", err)
 		}

--- a/internal/eval_hub/config/watcher_test.go
+++ b/internal/eval_hub/config/watcher_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
 	"github.com/eval-hub/eval-hub/internal/logging"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
 	"github.com/fsnotify/fsnotify"
 )
@@ -58,7 +58,7 @@ func TestWatcher_ReloadsOnFileChange(t *testing.T) {
 
 	logger := logging.FallbackLogger()
 	store := &mockStorage{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 
 	w := NewWatcher(logger, validate, store, dir)
 	w.debounce = 100 * time.Millisecond // speed up tests
@@ -110,7 +110,7 @@ func TestWatcher_DebouncesMutipleEvents(t *testing.T) {
 
 	logger := logging.FallbackLogger()
 	store := &mockStorage{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 
 	w := NewWatcher(logger, validate, store, dir)
 	w.debounce = 200 * time.Millisecond
@@ -146,7 +146,7 @@ func TestWatcher_StopsOnContextCancel(t *testing.T) {
 
 	logger := logging.FallbackLogger()
 	store := &mockStorage{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 
 	w := NewWatcher(logger, validate, store, dir)
 

--- a/internal/eval_hub/handlers/collections_test.go
+++ b/internal/eval_hub/handlers/collections_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
@@ -215,7 +215,7 @@ func TestHandleListCollections(t *testing.T) {
 		fakeStorage: &fakeStorage{},
 		collections: collections,
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -338,7 +338,7 @@ func TestHandleListCollections_ReturnsStoredBenchmarkURL(t *testing.T) {
 		fakeStorage: &fakeStorage{},
 		collections: collections,
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -384,7 +384,7 @@ func TestHandleGetCollection_ReturnsStoredBenchmarkURL(t *testing.T) {
 		fakeStorage: &fakeStorage{},
 		collection:  coll,
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -419,7 +419,7 @@ func TestHandleListCollections_StorageError(t *testing.T) {
 		fakeStorage: &fakeStorage{},
 		err:         serviceerrors.NewServiceError(messages.InternalServerError, "Error", "db error"),
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -450,7 +450,7 @@ func TestHandleCreateCollection(t *testing.T) {
 			},
 		},
 	}}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -510,7 +510,7 @@ func TestHandleGetCollection(t *testing.T) {
 		},
 	}
 	storage := &getCollectionStorage{fakeStorage: &fakeStorage{}, collection: coll}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -539,7 +539,7 @@ func TestHandleGetCollection(t *testing.T) {
 
 func TestHandleGetCollection_MissingPathParam(t *testing.T) {
 	storage := &fakeStorage{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -580,7 +580,7 @@ func TestHandleUpdateCollection(t *testing.T) {
 			},
 		},
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -683,7 +683,7 @@ func TestHandlePatchCollection_EnrichesFullBenchmarkElementBeforeStorage(t *test
 		},
 		hook: hook,
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -745,7 +745,7 @@ func TestHandlePatchCollection_EnrichesFullBenchmarksArrayBeforeStorage(t *testi
 		},
 		hook: hook,
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -793,7 +793,7 @@ func TestHandlePatchCollection(t *testing.T) {
 			},
 		},
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -816,7 +816,7 @@ func TestHandlePatchCollection(t *testing.T) {
 
 func TestHandleDeleteCollection(t *testing.T) {
 	storage := &updatePatchDeleteCollectionStorage{fakeStorage: &fakeStorage{}}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -862,7 +862,7 @@ func (s *tenantTrackingStorage) PatchCollection(_ string, _ *api.Patch) (*api.Co
 func (s *tenantTrackingStorage) DeleteCollection(_ string) error { return nil }
 
 func TestCollectionHandlers_PropagateTenantAndOwner(t *testing.T) {
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	tests := []struct {

--- a/internal/eval_hub/handlers/evaluation_logs.go
+++ b/internal/eval_hub/handlers/evaluation_logs.go
@@ -90,7 +90,7 @@ func (h *Handlers) handleGetEvaluationLogs(
 	)
 }
 
-func (h *Handlers) resolveJobBenchmarks(ctx *executioncontext.ExecutionContext, storage interface {
+func (h *Handlers) resolveJobBenchmarks(_ *executioncontext.ExecutionContext, storage interface {
 	GetCollection(id string) (*api.CollectionResource, error)
 }, job *api.EvaluationJobResource) ([]api.EvaluationBenchmarkConfig, error) {
 	var collection *api.CollectionResource

--- a/internal/eval_hub/handlers/evaluation_logs.go
+++ b/internal/eval_hub/handlers/evaluation_logs.go
@@ -69,7 +69,7 @@ func (h *Handlers) handleGetEvaluationLogs(
 				return err
 			}
 
-			benchmarks, err := h.resolveJobBenchmarks(ctx, storage.WithContext(runtimeCtx), job)
+			benchmarks, err := h.resolveJobBenchmarks(storage.WithContext(runtimeCtx), job)
 			if err != nil {
 				w.Error(err, ctx.RequestID)
 				return err
@@ -90,7 +90,7 @@ func (h *Handlers) handleGetEvaluationLogs(
 	)
 }
 
-func (h *Handlers) resolveJobBenchmarks(_ *executioncontext.ExecutionContext, storage interface {
+func (h *Handlers) resolveJobBenchmarks(storage interface {
 	GetCollection(id string) (*api.CollectionResource, error)
 }, job *api.EvaluationJobResource) ([]api.EvaluationBenchmarkConfig, error) {
 	var collection *api.CollectionResource

--- a/internal/eval_hub/handlers/evaluation_logs_test.go
+++ b/internal/eval_hub/handlers/evaluation_logs_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
@@ -89,7 +89,7 @@ func TestHandleGetEvaluationJobLogs(t *testing.T) {
 			},
 		},
 	}
-	h := handlers.New(storage, validation.NewValidator(), runtime, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), runtime, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "test-tenant")
@@ -146,7 +146,7 @@ func TestHandleGetEvaluationBenchmarkLogs(t *testing.T) {
 			},
 		},
 	}
-	h := handlers.New(storage, validation.NewValidator(), runtime, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), runtime, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-2", logger, "test-user", "test-tenant")
@@ -195,7 +195,7 @@ func TestHandleGetEvaluationJobLogsRejectsInvalidTailLines(t *testing.T) {
 		},
 	}
 	runtime := &logsRuntime{logs: "ignored"}
-	h := handlers.New(storage, validation.NewValidator(), runtime, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), runtime, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-3", logger, "test-user", "test-tenant")
@@ -230,7 +230,7 @@ func TestHandleGetEvaluationJobLogsRejectsEmptySinceSeconds(t *testing.T) {
 		},
 	}
 	runtime := &logsRuntime{logs: "ignored"}
-	h := handlers.New(storage, validation.NewValidator(), runtime, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), runtime, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-4", logger, "test-user", "test-tenant")
@@ -251,7 +251,7 @@ func TestHandleGetEvaluationJobLogsRejectsEmptySinceSeconds(t *testing.T) {
 }
 
 func TestHandleGetEvaluationJobLogsMissingJobID(t *testing.T) {
-	h := handlers.New(&fakeStorage{}, validation.NewValidator(), &logsRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{}, testhelpers.NewValidator(t), &logsRuntime{}, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-5", logger, "test-user", "test-tenant")
@@ -268,7 +268,7 @@ func TestHandleGetEvaluationJobLogsMissingJobID(t *testing.T) {
 }
 
 func TestHandleGetEvaluationBenchmarkLogsMissingBenchmarkIndex(t *testing.T) {
-	h := handlers.New(&fakeStorage{}, validation.NewValidator(), &logsRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{}, testhelpers.NewValidator(t), &logsRuntime{}, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-6", logger, "test-user", "test-tenant")
@@ -285,7 +285,7 @@ func TestHandleGetEvaluationBenchmarkLogsMissingBenchmarkIndex(t *testing.T) {
 }
 
 func TestHandleGetEvaluationBenchmarkLogsInvalidBenchmarkIndex(t *testing.T) {
-	h := handlers.New(&fakeStorage{}, validation.NewValidator(), &logsRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{}, testhelpers.NewValidator(t), &logsRuntime{}, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-7", logger, "test-user", "test-tenant")
@@ -311,7 +311,7 @@ func TestHandleGetEvaluationJobLogsNoRuntime(t *testing.T) {
 			Resource: api.EvaluationResource{Resource: api.Resource{ID: jobID}},
 		},
 	}
-	h := handlers.New(storage, validation.NewValidator(), nil, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), nil, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-8", logger, "test-user", "test-tenant")
@@ -340,7 +340,7 @@ func TestHandleGetEvaluationJobLogsRuntimeError(t *testing.T) {
 			},
 		},
 	}
-	h := handlers.New(storage, validation.NewValidator(), runtime, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), runtime, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-9", logger, "test-user", "test-tenant")
@@ -364,7 +364,7 @@ func TestHandleGetEvaluationJobLogsRejectsTailLinesOverMax(t *testing.T) {
 		},
 	}
 	runtime := &logsRuntime{}
-	h := handlers.New(storage, validation.NewValidator(), runtime, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), runtime, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-10", logger, "test-user", "test-tenant")
@@ -389,7 +389,7 @@ func TestHandleGetEvaluationJobLogsRejectsNonPositiveSinceSeconds(t *testing.T) 
 		},
 	}
 	runtime := &logsRuntime{}
-	h := handlers.New(storage, validation.NewValidator(), runtime, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), runtime, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-11", logger, "test-user", "test-tenant")
@@ -430,7 +430,7 @@ func TestHandleGetEvaluationJobLogsResolvesCollectionBenchmarks(t *testing.T) {
 			},
 		},
 	}
-	h := handlers.New(storage, validation.NewValidator(), runtime, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), runtime, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-12", logger, "test-user", "test-tenant")
@@ -455,7 +455,7 @@ func TestHandleGetEvaluationJobLogsJobNotFound(t *testing.T) {
 		fakeStorage: fakeStorage{},
 		getJobErr:   serviceerrors.NewServiceError(messages.ResourceNotFound, "Type", "evaluation job", "ResourceId", jobID),
 	}
-	h := handlers.New(storage, validation.NewValidator(), &logsRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &logsRuntime{}, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-13", logger, "test-user", "test-tenant")
@@ -483,7 +483,7 @@ func TestHandleGetEvaluationJobLogsCollectionNotFound(t *testing.T) {
 			},
 		},
 	}
-	h := handlers.New(storage, validation.NewValidator(), &logsRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &logsRuntime{}, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-14", logger, "test-user", "test-tenant")
@@ -507,7 +507,7 @@ func TestHandleGetEvaluationJobLogsRejectsInvalidSinceSeconds(t *testing.T) {
 		},
 	}
 	runtime := &logsRuntime{}
-	h := handlers.New(storage, validation.NewValidator(), runtime, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), runtime, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-15", logger, "test-user", "test-tenant")
@@ -532,7 +532,7 @@ func TestHandleGetEvaluationJobLogsRejectsInvalidTimestamps(t *testing.T) {
 		},
 	}
 	runtime := &logsRuntime{}
-	h := handlers.New(storage, validation.NewValidator(), runtime, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), runtime, nil, nil)
 	rec := httptest.NewRecorder()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-16", logger, "test-user", "test-tenant")

--- a/internal/eval_hub/handlers/evaluations_hardware_config_test.go
+++ b/internal/eval_hub/handlers/evaluations_hardware_config_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serialization"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
@@ -17,7 +17,7 @@ func TestEvaluationJobConfigHardwareConfigRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-hwp", logger, "test-user", "test-tenant")
 
 	t.Run("omits empty namespace in response", func(t *testing.T) {

--- a/internal/eval_hub/handlers/evaluations_test.go
+++ b/internal/eval_hub/handlers/evaluations_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/server"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
@@ -754,7 +754,7 @@ func (r *updateEvaluationRequest) PathValue(name string) string {
 
 func TestHandleUpdateEvaluationRejectsCancelledStatus(t *testing.T) {
 	storage := &fakeStorage{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -785,7 +785,7 @@ func TestHandleUpdateEvaluationRejectsCancelledStatus(t *testing.T) {
 func TestHandleUpdateEvaluationAcceptsValidPhase(t *testing.T) {
 	t.Parallel()
 	storage := &updateEvaluationStorage{fakeStorage: &fakeStorage{}}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -812,7 +812,7 @@ func TestHandleUpdateEvaluationAcceptsValidPhase(t *testing.T) {
 func TestHandleUpdateEvaluationRejectsInvalidPhase(t *testing.T) {
 	t.Parallel()
 	storage := &updateEvaluationStorage{fakeStorage: &fakeStorage{}}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -854,7 +854,7 @@ func TestHandleCreateEvaluationRejectsExperimentWhenMLflowDisabled(t *testing.T)
 	}
 	storage := &fakeStorage{providerConfigs: providerConfigs}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-mlflow-exp", logger, "test-user", "test-tenant")
 
@@ -893,7 +893,7 @@ func TestHandleCreateEvaluationRejectsEmptyExperimentName(t *testing.T) {
 	}
 	storage := &fakeStorage{providerConfigs: providerConfigs}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-empty-exp", logger, "test-user", "test-tenant")
 
@@ -931,7 +931,7 @@ func TestHandleListEvaluations_WriteJSON_logsExtraArgs(t *testing.T) {
 			{Resource: api.EvaluationResource{Resource: api.Resource{ID: "job-2"}}},
 		},
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
 	req := &listEvaluationsRequest{
@@ -981,7 +981,7 @@ func TestHandleCreateEvaluationRejectsInvalidQueueName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	storage := &fakeStorage{}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 
 	invalidNames := []string{
@@ -1020,7 +1020,7 @@ func TestHandleCreateEvaluationRejectsInvalidHardwareProfileRef(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	storage := &fakeStorage{}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 
 	invalidNames := []string{

--- a/internal/eval_hub/handlers/openapi.go
+++ b/internal/eval_hub/handlers/openapi.go
@@ -25,7 +25,7 @@ func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_
 		for key, value := range noCacheHeaders {
 			w.SetHeader(key, value)
 		}
-		w.Write(contents)
+		_, _ = w.Write(contents)
 	}
 
 	// Determine content type based on Accept header
@@ -41,7 +41,7 @@ func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_
 	if exePath != "" {
 		exeDir := filepath.Dir(exePath)
 		specPath := filepath.Join(exeDir, "docs", file)
-		contents, err := os.ReadFile(specPath)
+		contents, err := os.ReadFile(specPath) // #nosec G304 -- bundled OpenAPI spec beside executable
 		if err == nil {
 			found(contents, contentType)
 			return
@@ -66,7 +66,7 @@ func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_
 			continue
 		}
 		paths = append(paths, absPath)
-		contents, err := os.ReadFile(absPath)
+		contents, err := os.ReadFile(absPath) // #nosec G304 -- OpenAPI spec from configured docs paths
 		if err == nil {
 			found(contents, contentType)
 			return
@@ -135,5 +135,5 @@ func (h *Handlers) HandleDocs(ctx *executioncontext.ExecutionContext, r http_wra
 		w.SetHeader(key, value)
 	}
 	w.SetHeader("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(html))
+	_, _ = w.Write([]byte(html))
 }

--- a/internal/eval_hub/handlers/otel.go
+++ b/internal/eval_hub/handlers/otel.go
@@ -7,12 +7,11 @@ import (
 
 func (h *Handlers) withSpan(ctx *executioncontext.ExecutionContext, fn otel.SpanFunction, component string, operation string, atts ...string) error {
 	attributes := make(map[string]string)
-	for i := 0; i < len(atts); i += 2 {
-		if i+1 >= len(atts) {
-			attributes[atts[i]] = ""
-		} else {
-			attributes[atts[i]] = atts[i+1]
-		}
+	for i := 0; i+1 < len(atts); i += 2 {
+		attributes[atts[i]] = atts[i+1]
+	}
+	if len(atts)%2 == 1 {
+		attributes[atts[len(atts)-1]] = ""
 	}
 	return otel.WithSpan(
 		ctx.Ctx,

--- a/internal/eval_hub/handlers/otel_test.go
+++ b/internal/eval_hub/handlers/otel_test.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
+)
+
+func TestWithSpanOddAttributeCount(t *testing.T) {
+	t.Parallel()
+
+	h := New(nil, nil, nil, nil, &config.Config{})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "user", "tenant")
+
+	err := h.withSpan(ctx, func(context.Context) error { return nil }, "test", "op", "key", "value", "orphan")
+	if err != nil {
+		t.Fatalf("withSpan() = %v, want nil", err)
+	}
+}

--- a/internal/eval_hub/handlers/providers_gpu_test.go
+++ b/internal/eval_hub/handlers/providers_gpu_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/constants"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
 	"github.com/eval-hub/eval-hub/internal/logging"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
@@ -46,7 +46,7 @@ func TestHandleGetProvider_ReturnsGPUConfig(t *testing.T) {
 		provider.Resource.ID: provider,
 	}}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	req := &providersRequest{
 		MockRequest: createMockRequest("GET", "/api/v1/evaluations/providers/"+provider.Resource.ID),
@@ -75,7 +75,7 @@ func TestHandleListProviders_ReturnsGPUConfig(t *testing.T) {
 		providers:   []api.ProviderResource{provider},
 	}
 	logger := logging.FallbackLogger()
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	req := &providersRequest{
 		MockRequest: createMockRequest("GET", "/api/v1/evaluations/providers"),
@@ -111,7 +111,7 @@ func TestHandleUpdateProvider_PreservesGPUConfig(t *testing.T) {
 	}
 
 	logger := logging.FallbackLogger()
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	body := `{
 		"name":"GPU Provider Updated",
@@ -161,7 +161,7 @@ func TestHandleUpdateProvider_PreservesGPUConfig(t *testing.T) {
 func TestHandleCreateProvider_RejectsInvalidImagePullPolicy(t *testing.T) {
 	storage := &fakeStorage{}
 	logger := logging.FallbackLogger()
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	body := `{
 		"name":"My Provider",
@@ -214,7 +214,7 @@ func TestHandlePatchProvider_RejectsInvalidImagePullPolicy(t *testing.T) {
 		},
 	}
 	logger := logging.FallbackLogger()
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	body := `[{
 		"op":"replace",

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -44,11 +44,11 @@ const (
 	envMLFlowTrackingURIName          = "MLFLOW_TRACKING_URI"
 	envMLFlowWorkspaceName            = "MLFLOW_WORKSPACE"
 	mlflowTokenVolumeName             = "mlflow-token"
-	mlflowTokenMountPath              = "/var/run/secrets/mlflow"
+	mlflowTokenMountPath              = "/var/run/secrets/mlflow" // #nosec G101 -- K8s secret mount path
 	mlflowTokenFile                   = "token"
 	ociCredentialsVolumeName          = "oci-credentials"
-	ociCredentialsMountPath           = "/etc/evalhub/.docker/config.json"
-	ociCredentialsSubPath             = ".dockerconfigjson"
+	ociCredentialsMountPath           = "/etc/evalhub/.docker/config.json" // #nosec G101 -- K8s secret mount path
+	ociCredentialsSubPath             = ".dockerconfigjson"                // #nosec G101 -- K8s secret subpath name
 	envOCIAuthConfigPathName          = "OCI_AUTH_CONFIG_PATH"
 	modelAuthVolumeName               = "model-auth" // credentials secret; mounted in sidecar only
 	modelAuthMountPath                = "/var/run/secrets/model"
@@ -56,7 +56,7 @@ const (
 	// adapter DownwardAPI namespace volume so the SDK finds files at the expected locations.
 	k8sSAMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
 	// evalhub SA token — projected into sidecar only; pod-level auto-mount is disabled so adapter cannot see it.
-	evalhubSATokenVolumeName = "evalhub-sa-token"
+	evalhubSATokenVolumeName = "evalhub-sa-token" // #nosec G101 -- K8s projected volume name
 	evalhubSATokenFile       = "token"
 	// pod namespace projected into adapter via DownwardAPI so the SDK can set X-Tenant on sidecar requests.
 	// The SA token auto-mount is disabled so the standard namespace file is absent; we expose it explicitly.
@@ -64,7 +64,7 @@ const (
 	adapterNamespaceFile            = "namespace"
 	modelInternalAuthVolumeName     = "model-auth-internal" // internalModelRef projected volume; mounted in adapter during credential injection
 	testDataSecretVolumeName        = "test-data-secret"
-	testDataSecretMountPath         = "/var/run/secrets/test-data"
+	testDataSecretMountPath         = "/var/run/secrets/test-data" // #nosec G101 -- K8s secret mount path
 	serviceCABundleFile             = "service-ca.crt"
 	envMLFlowCertPathName           = "MLFLOW_TRACKING_SERVER_CERT_PATH"
 	envEvalHubModeName              = "EVALHUB_MODE"
@@ -191,6 +191,13 @@ func mergeVolumesByName(slices ...[]corev1.Volume) []corev1.Volume {
 	return out
 }
 
+func sidecarPortFromInt(port int) (int32, error) {
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("port %d out of range (1-65535)", port)
+	}
+	return int32(port), nil
+}
+
 func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 	if cfg.adapterImage == "" {
 		return nil, fmt.Errorf("adapter image is required")
@@ -234,8 +241,12 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 		},
 	}
 	probePort := defaultSidecarPort
-	if cfg.sidecarConfig != nil {
-		probePort = int32(cfg.sidecarConfig.Port)
+	if cfg.sidecarConfig != nil && cfg.sidecarConfig.Port != 0 {
+		p, err := sidecarPortFromInt(cfg.sidecarConfig.Port)
+		if err != nil {
+			return nil, fmt.Errorf("sidecar port: %w", err)
+		}
+		probePort = p
 	}
 	// Sidecar is added as an init container with restartPolicy=Always to be
 	// promoted as a native sidecar container (KEP-753).

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -11,6 +11,47 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func TestSidecarPortFromInt(t *testing.T) {
+	t.Parallel()
+
+	got, err := sidecarPortFromInt(8080)
+	if err != nil {
+		t.Fatalf("sidecarPortFromInt(8080) = %v, want nil error", err)
+	}
+	if got != 8080 {
+		t.Fatalf("sidecarPortFromInt(8080) = %d, want 8080", got)
+	}
+
+	for _, port := range []int{0, -1, 65536} {
+		if _, err := sidecarPortFromInt(port); err == nil {
+			t.Fatalf("sidecarPortFromInt(%d) = nil error, want out of range error", port)
+		}
+	}
+}
+
+func TestBuildJobRejectsInvalidSidecarPort(t *testing.T) {
+	cfg := &jobConfig{
+		jobID:          "job-bad-port",
+		resourceGUID:   "guid-bp",
+		benchmarkIndex: 0,
+		namespace:      "default",
+		providerID:     "provider-1",
+		benchmarkID:    "bench-1",
+		adapterImage:   "adapter:latest",
+		sidecarConfig: &config.SidecarConfig{
+			Port: 70000,
+		},
+	}
+
+	_, err := buildJob(cfg)
+	if err == nil {
+		t.Fatal("buildJob() = nil, want sidecar port error")
+	}
+	if !strings.Contains(err.Error(), "sidecar port") {
+		t.Fatalf("buildJob() error = %v, want sidecar port error", err)
+	}
+}
+
 func findContainer(containers []corev1.Container, name string) *corev1.Container {
 	for i := range containers {
 		if containers[i].Name == name {

--- a/internal/eval_hub/runtimes/k8s/job_config.go
+++ b/internal/eval_hub/runtimes/k8s/job_config.go
@@ -110,7 +110,11 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 	sidecarBaseURL := ""
 	if serviceConfig != nil && serviceConfig.Sidecar != nil {
 		if serviceConfig.Sidecar.Port != 0 {
-			port = int32(serviceConfig.Sidecar.Port)
+			p, err := sidecarPortFromInt(serviceConfig.Sidecar.Port)
+			if err != nil {
+				return nil, fmt.Errorf("sidecar port: %w", err)
+			}
+			port = p
 		}
 		sidecarBaseURL = strings.TrimSpace(serviceConfig.Sidecar.BaseURL)
 	}

--- a/internal/eval_hub/runtimes/k8s/job_config_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_config_test.go
@@ -1,8 +1,10 @@
 package k8s
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/runtimes/shared"
 	"github.com/eval-hub/eval-hub/pkg/api"
 	corev1 "k8s.io/api/core/v1"
@@ -100,6 +102,82 @@ func TestBuildJobConfigDefaults(t *testing.T) {
 	callback := spec.CallbackURL
 	if callback == nil || *callback != callbackURL {
 		t.Fatalf("expected job spec json callback_url to be %q, got %v", callbackURL, callback)
+	}
+}
+
+func TestBuildJobConfigRejectsInvalidSidecarPort(t *testing.T) {
+	evaluation := &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{
+			Resource: api.Resource{ID: "job-123"},
+		},
+		EvaluationJobConfig: api.EvaluationJobConfig{
+			Model: api.ModelRef{
+				URL:  "http://model",
+				Name: "model",
+			},
+			Benchmarks: []api.EvaluationBenchmarkConfig{
+				{Ref: api.Ref{ID: "bench-1"}},
+			},
+		},
+	}
+	provider := &api.ProviderResource{
+		Resource: api.Resource{ID: "provider-1"},
+		ProviderConfig: api.ProviderConfig{
+			Runtime: &api.Runtime{
+				K8s: &api.K8sRuntime{
+					Image: "adapter:latest",
+				},
+			},
+		},
+	}
+	serviceConfig := &config.Config{
+		Sidecar: &config.SidecarConfig{Port: 70000},
+	}
+
+	_, err := buildJobConfig(evaluation, provider, &evaluation.Benchmarks[0], 0, serviceConfig, nil)
+	if err == nil {
+		t.Fatal("buildJobConfig() = nil, want sidecar port error")
+	}
+	if !strings.Contains(err.Error(), "sidecar port") {
+		t.Fatalf("buildJobConfig() error = %v, want sidecar port error", err)
+	}
+}
+
+func TestBuildJobConfigUsesValidSidecarPort(t *testing.T) {
+	evaluation := &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{
+			Resource: api.Resource{ID: "job-123"},
+		},
+		EvaluationJobConfig: api.EvaluationJobConfig{
+			Model: api.ModelRef{
+				URL:  "http://model",
+				Name: "model",
+			},
+			Benchmarks: []api.EvaluationBenchmarkConfig{
+				{Ref: api.Ref{ID: "bench-1"}},
+			},
+		},
+	}
+	provider := &api.ProviderResource{
+		Resource: api.Resource{ID: "provider-1"},
+		ProviderConfig: api.ProviderConfig{
+			Runtime: &api.Runtime{
+				K8s: &api.K8sRuntime{
+					Image: "adapter:latest",
+				},
+			},
+		},
+	}
+	serviceConfig := &config.Config{
+		Sidecar: &config.SidecarConfig{Port: 9090},
+	}
+
+	cfg, err := buildJobConfig(evaluation, provider, &evaluation.Benchmarks[0], 0, serviceConfig, nil)
+	if err != nil {
+		t.Fatalf("buildJobConfig() = %v, want nil error", err)
+	}
+	if cfg.sidecarBaseURL != "http://localhost:9090" {
+		t.Fatalf("sidecarBaseURL = %q, want http://localhost:9090", cfg.sidecarBaseURL)
 	}
 }
 

--- a/internal/eval_hub/runtimes/local/local_runtime.go
+++ b/internal/eval_hub/runtimes/local/local_runtime.go
@@ -203,7 +203,7 @@ func (r *LocalRuntime) runBenchmark(
 	// Create output directory: /tmp/evalhub-jobs/<job_id>/<benchmark_index>/<provider_id>/<benchmark_id>/
 	jobDir := filepath.Join(localJobsBaseDir, jobID, fmt.Sprintf("%d", benchmarkIndex), bench.ProviderID, bench.ID)
 	metaDir := filepath.Join(jobDir, "meta")
-	if err := os.MkdirAll(metaDir, 0755); err != nil {
+	if err := os.MkdirAll(metaDir, 0o750); err != nil {
 		return fmt.Errorf("create meta directory: %w", err)
 	}
 
@@ -214,7 +214,7 @@ func (r *LocalRuntime) runBenchmark(
 
 	// Write job.json
 	jobSpecPath := filepath.Join(metaDir, "job.json")
-	if err := os.WriteFile(jobSpecPath, []byte(specJSON), 0644); err != nil {
+	if err := os.WriteFile(jobSpecPath, []byte(specJSON), 0o600); err != nil {
 		return fmt.Errorf("write job spec: %w", err)
 	}
 
@@ -234,7 +234,7 @@ func (r *LocalRuntime) runBenchmark(
 
 	// Build command using shell interpretation
 	command := provider.Runtime.Local.Command
-	cmd := exec.Command("sh", "-c", command)
+	cmd := exec.Command("sh", "-c", command) // #nosec G204 -- local runtime executes provider-defined commands by design
 	// Setpgid places the child in its own process group (PGID = child PID).
 	// This is critical for two reasons:
 	//   1. cancelJob calls Kill(-PID, SIGKILL) which targets the entire process
@@ -257,7 +257,7 @@ func (r *LocalRuntime) runBenchmark(
 
 	// Capture stdout/stderr to log file
 	logFilePath := filepath.Join(jobDir, "jobrun.log")
-	logFile, err := os.Create(logFilePath)
+	logFile, err := os.Create(logFilePath) // #nosec G304 -- log path derived from trusted job metadata
 	if err != nil {
 		return fmt.Errorf("create log file: %w", err)
 	}
@@ -275,7 +275,7 @@ func (r *LocalRuntime) runBenchmark(
 
 	// Start the process
 	if err := cmd.Start(); err != nil {
-		logFile.Close()
+		_ = logFile.Close()
 		return fmt.Errorf("start local process: %w", err)
 	}
 
@@ -283,7 +283,7 @@ func (r *LocalRuntime) runBenchmark(
 	r.tracker.addPID(jobID, pid)
 
 	// Close the log file — the child process has its own fd copy.
-	logFile.Close()
+	_ = logFile.Close()
 
 	r.logger.Info(
 		"local runtime process started",

--- a/internal/eval_hub/runtimes/shared/logs.go
+++ b/internal/eval_hub/runtimes/shared/logs.go
@@ -17,7 +17,7 @@ const tailReadBlockSize = 8192
 // TailFileLines returns up to the last n non-empty-terminated lines from a file.
 // A missing file yields an empty string without error.
 func TailFileLines(path string, n int) (string, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(path) // #nosec G304 -- log file path from runtime job metadata
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil

--- a/internal/eval_hub/serialization/json_test.go
+++ b/internal/eval_hub/serialization/json_test.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/executioncontext"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
 	"github.com/eval-hub/eval-hub/internal/logging"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
 func TestUnmarshal_OneOfValidationErrorListsAllowedValues(t *testing.T) {
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := logging.FallbackLogger()
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "user", "tenant")
 
@@ -40,7 +40,7 @@ func TestUnmarshal_OneOfValidationErrorListsAllowedValues(t *testing.T) {
 }
 
 func TestUnmarshal_TestDataRefMutualExclusionValidationError(t *testing.T) {
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := logging.FallbackLogger()
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "user", "tenant")
 
@@ -73,7 +73,7 @@ func TestUnmarshal_TestDataRefMutualExclusionValidationError(t *testing.T) {
 }
 
 func TestUnmarshal_TestDataRefRequiredValidationError(t *testing.T) {
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := logging.FallbackLogger()
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "user", "tenant")
 

--- a/internal/eval_hub/server/server_test.go
+++ b/internal/eval_hub/server/server_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/runtimes/shared"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/server"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/storage"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
 	"github.com/eval-hub/eval-hub/internal/logging"
 	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
@@ -287,7 +286,7 @@ func createServerWithLocalMode(t *testing.T, port int, localMode bool) (*server.
 	if err != nil {
 		return nil, err
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	serviceConfig, err := config.LoadConfig(logger, testhelpers.Version(t), "local", time.Now().Format(time.RFC3339), "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to load service config: %w", err)

--- a/internal/eval_hub/storage/sql/collections_test.go
+++ b/internal/eval_hub/storage/sql/collections_test.go
@@ -9,15 +9,15 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/storage"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/storage/sql"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
 	"github.com/eval-hub/eval-hub/internal/logging"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
 func TestCollections_PassCriteria(t *testing.T) {
 	logger := logging.FallbackLogger()
 
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	// set up the collection configs
 	collectionConfigs, err := config.LoadCollectionConfigs(logger, validate, "../../../../config")
 	if err != nil {
@@ -90,7 +90,7 @@ func TestCollections_PassCriteria(t *testing.T) {
 func TestCollections_BenchmarksExist(t *testing.T) {
 	logger := logging.FallbackLogger()
 
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	// set up the collection configs
 	collectionConfigs, err := config.LoadCollectionConfigs(logger, validate, "../../../../config")
 	if err != nil {

--- a/internal/eval_hub/storage/sql/evaluations_test.go
+++ b/internal/eval_hub/storage/sql/evaluations_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/common"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/constants"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/storage/sql"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
@@ -642,7 +642,7 @@ func testEvaluationsStorage(t *testing.T, driver string, databaseName string) {
 		if completedAtStr == "" {
 			t.Fatalf("CompletedAt is empty")
 		}
-		val := validation.NewValidator()
+		val := testhelpers.NewValidator(t)
 		err := val.Struct(status)
 		if err != nil {
 			t.Fatalf("Failed to validate status: %v", err)

--- a/internal/eval_hub/storage/sql/serialization_failure.go
+++ b/internal/eval_hub/storage/sql/serialization_failure.go
@@ -1,8 +1,9 @@
 package sql
 
 import (
+	"crypto/rand"
 	"errors"
-	"math/rand"
+	"math/big"
 	"strings"
 	"time"
 
@@ -37,8 +38,23 @@ func serializationFailureBackoff(attempt int) time.Duration {
 	if delay > serializationRetryMaxDelay {
 		delay = serializationRetryMaxDelay
 	}
-	jitter := time.Duration(rand.Int63n(int64(delay/4 + 1)))
+	jitter, err := serializationRetryJitter(delay)
+	if err != nil {
+		return delay
+	}
 	return delay + jitter
+}
+
+func serializationRetryJitter(delay time.Duration) (time.Duration, error) {
+	max := int64(delay/4 + 1)
+	if max <= 0 {
+		return 0, nil
+	}
+	n, err := rand.Int(rand.Reader, big.NewInt(max))
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(n.Int64()), nil
 }
 
 func retryOnSerializationFailure(maxAttempts int, run func() error) error {

--- a/internal/eval_hub/storage/sql/serialization_failure_test.go
+++ b/internal/eval_hub/storage/sql/serialization_failure_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
@@ -69,6 +70,34 @@ func TestSerializationFailureBackoff(t *testing.T) {
 		if got < serializationRetryBaseDelay || got > wantMax {
 			t.Fatalf("serializationFailureBackoff(%d) = %v, want in [%v, %v]", attempt, got, serializationRetryBaseDelay, wantMax)
 		}
+	}
+}
+
+func TestSerializationRetryJitter(t *testing.T) {
+	t.Parallel()
+
+	delay := 100 * time.Millisecond
+	maxJitter := delay/4 + 1
+	for i := 0; i < 20; i++ {
+		jitter, err := serializationRetryJitter(delay)
+		if err != nil {
+			t.Fatalf("serializationRetryJitter() = %v, want nil error", err)
+		}
+		if jitter < 0 || jitter >= maxJitter {
+			t.Fatalf("serializationRetryJitter() = %v, want in [0, %v)", jitter, maxJitter)
+		}
+	}
+}
+
+func TestSerializationRetryJitterZeroMax(t *testing.T) {
+	t.Parallel()
+
+	jitter, err := serializationRetryJitter(-5 * time.Millisecond)
+	if err != nil {
+		t.Fatalf("serializationRetryJitter() = %v, want nil error", err)
+	}
+	if jitter != 0 {
+		t.Fatalf("serializationRetryJitter() = %v, want 0", jitter)
 	}
 }
 

--- a/internal/eval_hub/storage/sql/sql.go
+++ b/internal/eval_hub/storage/sql/sql.go
@@ -117,7 +117,7 @@ func NewStorage(
 	success := false
 	defer func() {
 		if !success {
-			pool.Close()
+			_ = pool.Close()
 		}
 	}()
 

--- a/internal/eval_hub/validation/validator.go
+++ b/internal/eval_hub/validation/validator.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -24,14 +25,14 @@ var (
 	rfc1123DNSLabelRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 )
 
-func NewValidator() *validator.Validate {
+func NewValidator() (*validator.Validate, error) {
 	validate := validator.New(validator.WithRequiredStructEnabled())
 	for alias, definition := range tagAliases {
 		validate.RegisterAlias(alias, definition)
 	}
 	register(validate)
-	registerCustomValidators(validate)
-	return validate
+	err := registerCustomValidators(validate)
+	return validate, err
 }
 
 func register(instance *validator.Validate) {
@@ -47,14 +48,19 @@ func register(instance *validator.Validate) {
 	)
 }
 
-func registerCustomValidators(instance *validator.Validate) {
+func registerCustomValidators(instance *validator.Validate) error {
 	// https://github.com/go-playground/validator/blob/v10.30.2/non-standard/validators/notblank.go
-	instance.RegisterValidation("notblank", validators.NotBlank)
-	instance.RegisterValidation("rfc1123_dns_label", validateRFC1123DNSLabel)
+	if err := instance.RegisterValidation("notblank", validators.NotBlank); err != nil {
+		return fmt.Errorf("register validator failed for notblank: %w", err)
+	}
+	if err := instance.RegisterValidation("rfc1123_dns_label", validateRFC1123DNSLabel); err != nil {
+		return fmt.Errorf("register validator failed for rfc1123_dns_label: %w", err)
+	}
 	// Benchmarks min=1 only when Collection is not set (required_without handles presence; this enforces length)
 	instance.RegisterStructValidation(evaluationJobConfigBenchmarksMin, api.EvaluationJobConfig{})
 	// Exactly one of s3 or pvc must be set in TestDataRef.
 	instance.RegisterStructValidation(validateTestDataRefMutualExclusion, api.TestDataRef{})
+	return nil
 }
 
 func validateRFC1123DNSLabel(fl validator.FieldLevel) bool {

--- a/internal/eval_hub/validation/validator_test.go
+++ b/internal/eval_hub/validation/validator_test.go
@@ -19,6 +19,18 @@ func newTestValidator(t *testing.T) *validator.Validate {
 	return v
 }
 
+func TestNewValidator(t *testing.T) {
+	t.Parallel()
+
+	validate, err := NewValidator()
+	if err != nil {
+		t.Fatalf("NewValidator() = %v, want nil error", err)
+	}
+	if validate == nil {
+		t.Fatal("NewValidator() returned nil")
+	}
+}
+
 func TestEvaluationJobConfigBenchmarksMin_WithCollection(t *testing.T) {
 	validate := newTestValidator(t)
 	// When Collection is set with ID, empty Benchmarks is allowed

--- a/internal/eval_hub/validation/validator_test.go
+++ b/internal/eval_hub/validation/validator_test.go
@@ -7,18 +7,20 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
 	"github.com/eval-hub/eval-hub/pkg/api"
-	"github.com/go-playground/validator/v10"
+	validator "github.com/go-playground/validator/v10"
 )
 
-func TestNewValidator(t *testing.T) {
-	validate := NewValidator()
-	if validate == nil {
-		t.Fatal("NewValidator() returned nil validator")
+func newTestValidator(t *testing.T) *validator.Validate {
+	t.Helper()
+	v, err := NewValidator()
+	if err != nil {
+		t.Fatal(err)
 	}
+	return v
 }
 
 func TestEvaluationJobConfigBenchmarksMin_WithCollection(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	// When Collection is set with ID, empty Benchmarks is allowed
 	cfg := api.EvaluationJobConfig{
 		Name:       "test-evaluation-job",
@@ -33,7 +35,7 @@ func TestEvaluationJobConfigBenchmarksMin_WithCollection(t *testing.T) {
 }
 
 func TestEvaluationJobConfigBenchmarksMin_WithoutCollection_EmptyBenchmarks(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	// When Collection is not set, Benchmarks must have at least 1 element
 	cfg := api.EvaluationJobConfig{
 		Name:       "test-evaluation-job",
@@ -55,7 +57,7 @@ func TestEvaluationJobConfigBenchmarksMin_WithoutCollection_EmptyBenchmarks(t *t
 }
 
 func TestEvaluationJobConfigBenchmarksMin_WithoutCollection_WithBenchmark(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	cfg := api.EvaluationJobConfig{
 		Name:  "test-evaluation-job",
 		Model: api.ModelRef{URL: "http://test.com", Name: "model"},
@@ -70,7 +72,7 @@ func TestEvaluationJobConfigBenchmarksMin_WithoutCollection_WithBenchmark(t *tes
 }
 
 func TestEvaluationJobConfig_ExperimentWithoutNameFails(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	cfg := api.EvaluationJobConfig{
 		Name:  "test-evaluation-job",
 		Model: api.ModelRef{URL: "http://test.com", Name: "model"},
@@ -100,7 +102,7 @@ func TestEvaluationJobConfig_ExperimentWithoutNameFails(t *testing.T) {
 }
 
 func TestEvaluationJobConfig_ExperimentNameEmptyStringFails(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	cfg := api.EvaluationJobConfig{
 		Name:  "test-evaluation-job",
 		Model: api.ModelRef{URL: "http://test.com", Name: "model"},
@@ -130,7 +132,7 @@ func TestEvaluationJobConfig_ExperimentNameEmptyStringFails(t *testing.T) {
 }
 
 func TestEvaluationJobConfig_ExperimentNameWhitespaceOnlyFails(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	ws := " \t "
 	cfg := api.EvaluationJobConfig{
 		Name:  "test-evaluation-job",
@@ -161,7 +163,7 @@ func TestEvaluationJobConfig_ExperimentNameWhitespaceOnlyFails(t *testing.T) {
 }
 
 func TestQueueConfig_InvalidNameRejected(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	invalid := []string{
 		"user-queue!@#$%",
 		"-starts-with-dash",
@@ -190,7 +192,7 @@ func TestQueueConfig_InvalidNameRejected(t *testing.T) {
 }
 
 func TestQueueConfig_ValidNameAccepted(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	valid := []string{
 		"my-queue",
 		"queue1",
@@ -214,7 +216,7 @@ func TestQueueConfig_ValidNameAccepted(t *testing.T) {
 }
 
 func TestBenchmarkHardwareConfig_InvalidNameRejected(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	invalid := []string{
 		"profile!@#$%",
 		"-starts-with-dash",
@@ -247,7 +249,7 @@ func TestBenchmarkHardwareConfig_InvalidNameRejected(t *testing.T) {
 }
 
 func TestBenchmarkHardwareConfig_ValidNameAccepted(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	valid := []struct {
 		name      string
 		namespace string
@@ -281,7 +283,7 @@ func TestBenchmarkHardwareConfig_ValidNameAccepted(t *testing.T) {
 }
 
 func TestBenchmarkHardwareConfig_InvalidNamespaceRejected(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	cfg := api.EvaluationJobConfig{
 		Name:  "test-job",
 		Model: api.ModelRef{URL: "http://test.com", Name: "model"},
@@ -304,7 +306,7 @@ func TestBenchmarkHardwareConfig_InvalidNamespaceRejected(t *testing.T) {
 }
 
 func TestEvaluationJobConfig_ExperimentOmittedOk(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	cfg := api.EvaluationJobConfig{
 		Name:  "test-evaluation-job",
 		Model: api.ModelRef{URL: "http://test.com", Name: "model"},
@@ -320,7 +322,7 @@ func TestEvaluationJobConfig_ExperimentOmittedOk(t *testing.T) {
 }
 
 func TestK8sRuntimeImagePullPolicy_InvalidValueRejected(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	cfg := api.ProviderConfig{
 		Name: "test-provider",
 		Runtime: &api.Runtime{
@@ -346,7 +348,7 @@ func TestK8sRuntimeImagePullPolicy_InvalidValueRejected(t *testing.T) {
 }
 
 func TestK8sRuntimeImagePullPolicy_ValidValuesAccepted(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	for _, policy := range []string{"", "if_not_present", "always"} {
 		cfg := api.ProviderConfig{
 			Name: "test-provider",
@@ -422,7 +424,7 @@ func TestValidateCollectionOverrides_EmptyOverrides(t *testing.T) {
 }
 
 func TestTestDataRef_BothS3AndPVCRejected(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	ref := api.TestDataRef{
 		S3:  &api.S3TestDataRef{Bucket: "b", Key: "k", SecretRef: "s"},
 		PVC: &api.PVCTestDataRef{ClaimName: "my-pvc"},
@@ -434,7 +436,7 @@ func TestTestDataRef_BothS3AndPVCRejected(t *testing.T) {
 }
 
 func TestTestDataRef_NeitherS3NorPVCRejected(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	ref := api.TestDataRef{}
 	err := validate.Struct(ref)
 	if err == nil {
@@ -443,7 +445,7 @@ func TestTestDataRef_NeitherS3NorPVCRejected(t *testing.T) {
 }
 
 func TestTestDataRef_PVCOnlyAccepted(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	ref := api.TestDataRef{
 		PVC: &api.PVCTestDataRef{ClaimName: "my-pvc"},
 	}
@@ -453,7 +455,7 @@ func TestTestDataRef_PVCOnlyAccepted(t *testing.T) {
 }
 
 func TestTestDataRef_S3OnlyAccepted(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	ref := api.TestDataRef{
 		S3: &api.S3TestDataRef{Bucket: "b", Key: "k", SecretRef: "s"},
 	}
@@ -463,7 +465,7 @@ func TestTestDataRef_S3OnlyAccepted(t *testing.T) {
 }
 
 func TestPVCTestDataRef_InvalidClaimNameRejected(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	cases := []string{"", "My_PVC", "my pvc", "-leading-hyphen", "trailing-hyphen-"}
 	for _, name := range cases {
 		ref := api.PVCTestDataRef{ClaimName: name}
@@ -474,7 +476,7 @@ func TestPVCTestDataRef_InvalidClaimNameRejected(t *testing.T) {
 }
 
 func TestPVCTestDataRef_ValidClaimNameAccepted(t *testing.T) {
-	validate := NewValidator()
+	validate := newTestValidator(t)
 	cases := []string{"my-pvc", "eval-datasets-pvc", "pvc123", "a"}
 	for _, name := range cases {
 		ref := api.PVCTestDataRef{ClaimName: name}

--- a/internal/eval_runtime_sidecar/config/sidecar_runtime_config.go
+++ b/internal/eval_runtime_sidecar/config/sidecar_runtime_config.go
@@ -21,7 +21,7 @@ func LoadSidecarRuntimeConfig(sidecarJSONPath, version, build, buildDate string)
 	if strings.TrimSpace(sidecarJSONPath) == "" {
 		sidecarJSONPath = DefaultSidecarConfigPath
 	}
-	data, err := os.ReadFile(sidecarJSONPath)
+	data, err := os.ReadFile(sidecarJSONPath) // #nosec G304 -- sidecar config path from CLI or default mount
 	if err != nil {
 		return nil, fmt.Errorf("read sidecar config %q: %w", sidecarJSONPath, err)
 	}

--- a/internal/eval_runtime_sidecar/handlers/evalhub.go
+++ b/internal/eval_runtime_sidecar/handlers/evalhub.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ServiceAccountTokenPathDefault is the in-cluster path for the k8s SA token (Eval Hub API auth).
-const ServiceAccountTokenPathDefault = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+const ServiceAccountTokenPathDefault = "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec G101 -- K8s SA token path
 
 // newEvalhubProxy builds a reverse proxy to eval_hub.base_url (Eval Hub REST API, e.g. /api/v1/evaluations/ for job callbacks to the hub).
 func newEvalhubProxy(config *config.Config, logger *slog.Logger) (*httputil.ReverseProxy, error) {

--- a/internal/eval_runtime_sidecar/handlers/mlflow.go
+++ b/internal/eval_runtime_sidecar/handlers/mlflow.go
@@ -12,7 +12,7 @@ import (
 )
 
 // MLFlowTokenPathDefault is the default path for the MLflow bearer token in the container.
-const MLFlowTokenPathDefault = "/var/run/secrets/mlflow/token"
+const MLFlowTokenPathDefault = "/var/run/secrets/mlflow/token" // #nosec G101 -- K8s secret mount path
 
 // /api/2.0|3.0/mlflow/... and /api/2.0/mlflow-artifacts/... are proxied to mlflow.tracking_uri.
 // (mlflow-artifacts is a separate top-level path on the tracking server, not under /mlflow/.)

--- a/internal/eval_runtime_sidecar/proxy/http_client.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client.go
@@ -50,7 +50,7 @@ func buildTLSConfig(caCertPath string, insecureSkipVerify bool, logger *slog.Log
 		MaxVersion: tls.VersionTLS13,
 	}
 	if caCertPath != "" && !insecureSkipVerify {
-		caCert, err := os.ReadFile(caCertPath)
+		caCert, err := os.ReadFile(caCertPath) // #nosec G304 -- CA bundle path from sidecar configuration
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %s CA certificate at %s: %w", certLabel, caCertPath, err)
 		}

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -34,7 +34,7 @@ const (
 // xModelCredError is an internal sentinel header set by the Director when ref resolution fails.
 // The modelRoundTripper checks for it and returns 400 to the eval container instead of
 // forwarding a request with a literal ref token.
-const xModelCredError = "X-Model-Cred-Error"
+const xModelCredError = "X-Model-Cred-Error" // #nosec G101 -- internal HTTP header name, not a credential
 
 const globalTransactionIDHeader = "X-Global-Transaction-Id"
 
@@ -211,10 +211,10 @@ func loadSecretCache(mountPath string, logger *slog.Logger) map[string]string {
 	}
 	for _, e := range entries {
 		// Skip directories and Kubernetes secret mount internals (..data, ..2024_... symlinks).
-		if e.IsDir() || strings.HasPrefix(e.Name(), "..") {
+		if e.IsDir() || strings.HasPrefix(e.Name(), "..") || strings.Contains(e.Name(), string(filepath.Separator)) {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(mountPath, e.Name()))
+		data, err := os.ReadFile(filepath.Join(mountPath, e.Name())) // #nosec G304 -- entry name validated above
 		if err != nil {
 			logger.Warn("skipping unreadable secret file", "file", e.Name(), "error", err)
 			continue

--- a/internal/eval_runtime_sidecar/proxy/oci_auth.go
+++ b/internal/eval_runtime_sidecar/proxy/oci_auth.go
@@ -75,7 +75,7 @@ type registryAuthConfig struct {
 // and repository from exports.oci.coordinates using shared.JobSpec. Host is normalized to a URL (https:// if no scheme).
 // Returns ("", "", nil) when the file has no OCI exports; returns ("", "", err) on read/parse errors.
 func GetOCICoordinatesFromJobSpec(path string) (host, repository string, err error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- job spec path from sidecar configuration
 	if err != nil {
 		return "", "", fmt.Errorf("read job spec: %w", err)
 	}
@@ -106,7 +106,7 @@ func LoadTokenProducerFromOCISecret(ociSecretMountPath, registryHost, repository
 	if httpClient == nil {
 		return nil, fmt.Errorf("oci http client is required")
 	}
-	data, err := os.ReadFile(ociSecretMountPath)
+	data, err := os.ReadFile(ociSecretMountPath) // #nosec G304 -- OCI secret mount path from configuration
 	if err != nil {
 		return nil, fmt.Errorf("read OCI secret: %w", err)
 	}

--- a/internal/evalhub_mcp/config/config.go
+++ b/internal/evalhub_mcp/config/config.go
@@ -152,7 +152,7 @@ func validateAuthConfig(cfg *Config) error {
 }
 
 func bindEnvs(v *viper.Viper, envs ...string) error {
-	for i := 0; i < len(envs); i += 2 {
+	for i := 0; i+1 < len(envs); i += 2 {
 		err := v.BindEnv(envs[i], envs[i+1])
 		if err != nil {
 			return fmt.Errorf("binding environment variable %s: %w", envs[i], err)

--- a/internal/evalhub_mcp/server/prompts.go
+++ b/internal/evalhub_mcp/server/prompts.go
@@ -297,7 +297,7 @@ func parseJobIDs(raw string) []string {
 }
 
 func replaceTemplateVariables(s string, variables ...string) string {
-	for i := 0; i < len(variables); i += 2 {
+	for i := 0; i+1 < len(variables); i += 2 {
 		s = strings.ReplaceAll(s, "{"+variables[i]+"}", variables[i+1])
 	}
 	return s

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -232,8 +232,9 @@ func serveHTTP(ctx context.Context, mcpHandler http.Handler, cfg *config.Config,
 
 	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", cfg.Port))
 	httpServer := &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 15 * time.Second,
 	}
 
 	errCh := make(chan error, 1)

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -235,6 +235,9 @@ func serveHTTP(ctx context.Context, mcpHandler http.Handler, cfg *config.Config,
 		Addr:              addr,
 		Handler:           mux,
 		ReadHeaderTimeout: 15 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	errCh := make(chan error, 1)

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -6,7 +6,7 @@ import (
 )
 
 func readFile(path string) string {
-	content, err := os.ReadFile(path)
+	content, err := os.ReadFile(path) // #nosec G304 -- platform metadata path from Kubernetes downward API
 	if err != nil {
 		return ""
 	}

--- a/internal/testhelpers/version.go
+++ b/internal/testhelpers/version.go
@@ -62,6 +62,8 @@ func Version(t *testing.T) string {
 }
 
 func NewValidator(t *testing.T) *validator.Validate {
+	t.Helper()
+
 	validate, err := validation.NewValidator()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/testhelpers/version.go
+++ b/internal/testhelpers/version.go
@@ -7,6 +7,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
+	"github.com/go-playground/validator/v10"
 )
 
 func findRepoRoot() (string, error) {
@@ -36,7 +39,7 @@ func RepoVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	data, err := os.ReadFile(filepath.Join(root, "VERSION"))
+	data, err := os.ReadFile(filepath.Join(root, "VERSION")) // #nosec G304 -- repo root resolved from test caller location
 	if err != nil {
 		return "", fmt.Errorf("read VERSION: %w", err)
 	}
@@ -56,4 +59,12 @@ func Version(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return version
+}
+
+func NewValidator(t *testing.T) *validator.Validate {
+	validate, err := validation.NewValidator()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return validate
 }

--- a/internal/testhelpers/version_test.go
+++ b/internal/testhelpers/version_test.go
@@ -18,6 +18,13 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestNewValidator(t *testing.T) {
+	validate := NewValidator(t)
+	if validate == nil {
+		t.Fatal("NewValidator() returned nil")
+	}
+}
+
 func TestRepoVersion(t *testing.T) {
 	root, err := findRepoRoot()
 	if err != nil {

--- a/pkg/api/collections_test.go
+++ b/pkg/api/collections_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/eval-hub/eval-hub/internal/eval_hub/validation"
+	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
@@ -46,7 +46,7 @@ func TestCollectionsValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to unmarshal collection config: %v", err)
 		}
-		validator := validation.NewValidator()
+		validator := testhelpers.NewValidator(t)
 		err = validator.Struct(config)
 		if err != nil {
 			t.Fatalf("failed to validate collection config: %v", err)

--- a/pkg/evalhubclient/client.go
+++ b/pkg/evalhubclient/client.go
@@ -358,7 +358,7 @@ func (c *Client) doRequest(method, path string, body any, queryParams url.Values
 
 		statusCode = resp.StatusCode
 		respBody, err = io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			wrapped := fmt.Errorf("failed to read response body: %w", err)
 			c.logEvalHubRequestFailed(start, statusCode, wrapped.Error(), nil)

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -284,11 +284,11 @@ func (a *apiFeature) startLocalServer(port int) error {
 	if err != nil {
 		return err
 	}
-	validate := validation.NewValidator()
-	version, err := testhelpers.RepoVersion()
+	validate, err := validation.NewValidator()
 	if err != nil {
-		return logError(fmt.Errorf("read VERSION: %w", err))
+		return logError(err)
 	}
+	version, err := testhelpers.RepoVersion()
 	serviceConfig, err := config.LoadConfig(logger, version, "local", time.Now().Format(time.RFC3339), "")
 	if err != nil {
 		return logError(fmt.Errorf("failed to load service config: %w", err))

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -289,6 +289,9 @@ func (a *apiFeature) startLocalServer(port int) error {
 		return logError(err)
 	}
 	version, err := testhelpers.RepoVersion()
+	if err != nil {
+		return logError(err)
+	}
 	serviceConfig, err := config.LoadConfig(logger, version, "local", time.Now().Format(time.RFC3339), "")
 	if err != nil {
 		return logError(fmt.Errorf("failed to load service config: %w", err))


### PR DESCRIPTION
## What and why

The securego/gosec action was invoked with -no-fail, so the job always exits 0 regardless of findings. This PR removes the `-no-fail` option and fixes the exposed gosec warnings.

Closes [#RHOAIENG-69274](https://redhat.atlassian.net/browse/RHOAIENG-69274)

## Real code fixes

| Rule | Count | Issue | Fix |
|------|-------|-------|-----|
| **G112** | 1 | MCP HTTP server missing `ReadHeaderTimeout` (Slowloris) | Set `ReadHeaderTimeout: 15s` in `internal/evalhub_mcp/server/server.go` |
| **G115** | 2 | `int` → `int32` overflow on sidecar port | Added `sidecarPortFromInt()` with 1–65535 validation in `job_builders.go` / `job_config.go` |
| **G301** | 3 | Directory permissions too open (`0755`) | Changed to `0o750` in `eval_runtime_init`, `local_runtime` |
| **G306** | 1 | `WriteFile` permissions too open (`0644`) | Changed to `0o600` for local job spec in `local_runtime` |
| **G404** | 1 | Weak RNG (`math/rand`) for DB retry jitter | Switched to `crypto/rand` in `serialization_failure.go` |
| **G602** | 3 | Potential slice index out of range | Fixed loop bounds in `otel.go`, `prompts.go`, `config.go` |
| **G104** | 9 | Unhandled errors | Handled `Close`/`Write`/`BindEnv`/`RegisterValidation` errors in `client.go`, `validator.go`, `sql.go`, `openapi.go`, `loader.go`, `local_runtime` |
| **G703** | 2 | Path traversal writing S3 downloads | `os.OpenRoot(destDir)` + `filepath.IsLocal()` in `cmd/eval_runtime_init/main.go` |
| **G304** | 1 | Path traversal file create (init container) | Same `os.OpenRoot` change resolves the create/write case |

**Additional hardening:** `internal/eval_runtime_sidecar/proxy/model_proxy.go` now rejects secret filenames containing path separators when loading the credential cache.

---

## False positives — `#nosec` with justification

| Rule | Count | Issue | Rationale |
|------|-------|-------|-----------|
| **G101** | 10 | “Hardcoded credentials” | Kubernetes mount paths, environment variable *names*, and HTTP header names — not secret values |
| **G304** | 12 | “File inclusion via variable” | Trusted configuration paths (OpenAPI spec, sidecar JSON, CA certificates, OCI secrets, job logs) |
| **G204** | 1 | Subprocess launched with variable command | Intentional for local runtime provider-defined commands |

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated CI security scanning to fail the build on findings (still producing SARIF) and to scan consistently while skipping test directories.

* **Security**
  * Hardened runtime S3 downloads with a sandboxed destination and tightened benchmark artifact permissions.

* **Bug Fixes**
  * Improved startup behavior when validation setup fails (clear error + exit).
  * Added strict sidecar port validation and safer handling of malformed template/env inputs.
  * Increased HTTP header timeout to 15s.

* **Tests**
  * Added/updated coverage for runtime destination-path handling, sidecar ports, and validator creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->