### PR TITLE
feat(tests): add MCP integration tests

### DIFF
--- a/tests/features/mcp.feature
+++ b/tests/features/mcp.feature
@@ -1,0 +1,681 @@
+@mcp
+Feature: MCP Tools
+  As a user
+  I want to call MCP tools
+  So that I can interact with eval-hub via MCP protocol
+
+  Background:
+    Given the service is running
+    And I set the wait deadline to "{{env:WAIT_DEADLINE|30m}}"
+  
+  Scenario: Discover all providers via MCP returns unfiltered list
+    When I call MCP tool "discover_providers" with arguments "{}"
+    Then the MCP tool call should succeed
+    And the MCP response should contain "lm_evaluation_harness"
+    And the MCP response should contain "lighteval"
+    And the MCP response should contain "garak"
+  
+  Scenario: Discover providers filtered by target_type model returns only model providers
+    When I call MCP tool "discover_providers" with arguments:
+      """
+      {
+        "target_type": "model"
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain "lm_evaluation_harness"
+    And the MCP response should contain "target_type"
+    And the MCP response should contain "model"
+
+  Scenario: Discover providers filtered by evaluates returns only matching providers
+    When I call MCP tool "discover_providers" with arguments:
+      """
+      {
+        "evaluates": ["accuracy"]
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain "lm_evaluation_harness"
+    And the MCP response should contain "evaluates"
+    And the MCP response should contain "accuracy"
+
+  Scenario: Discover providers with combined filters target_type and evaluates
+    When I call MCP tool "discover_providers" with arguments:
+      """
+      {
+        "target_type": "model",
+        "evaluates": ["accuracy"]
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain "lm_evaluation_harness"
+    And the MCP response should contain "target_type"
+    And the MCP response should contain "model"
+    And the MCP response should contain "accuracy"
+
+  Scenario: Discover providers filtered by target_type agent returns empty when no matches
+    When I call MCP tool "discover_providers" with arguments:
+      """
+      {
+        "target_type": "agent"
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain "providers"
+    And the MCP response array at path "providers" should have length 0
+
+  Scenario: Discover providers includes agent metadata when available
+    When I call MCP tool "discover_providers" with arguments:
+      """
+      {
+        "target_type": "model"
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain "summary"
+    And the MCP response should contain "evaluates"
+    And the MCP response should contain "hints"
+    And the MCP response should contain "recommended_when"
+  
+  Scenario: Submit evaluation job via MCP with benchmarks
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_test_job",
+        "description": "Test job submitted via MCP",
+        "tags": ["mcp", "test"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness"
+          }
+        ]
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain the value "pending" at path "$.state"
+  
+  Scenario: Submit evaluation job via MCP with collection
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_collection_job",
+        "description": "Test collection job via MCP",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "collection": {
+          "id": "leaderboard-v2"
+        }
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain the value "pending" at path "$.state"
+
+  @mlflow
+  Scenario: Submit evaluation job via MCP with MLflow experiment
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_mlflow_job",
+        "description": "Test MLflow tracking via MCP",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness"
+          }
+        ],
+        "experiment": {
+          "name": "mcp_test_experiment"
+        }
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain the value "pending" at path "$.state"
+  
+  Scenario: Get job status via MCP after creating job
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_status_test_job",
+        "description": "Job for testing status endpoint",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}"
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness"
+          }
+        ]
+      }
+      """
+    Then the MCP tool call should succeed
+    And the "job_id" field in the MCP response should be saved as "value:status_job_id"
+    When I call MCP tool "get_job_status" with arguments:
+      """
+      {
+        "job_id": "{{value:status_job_id}}"
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain the value "{{value:status_job_id}}" at path "$.job_id"
+    And the MCP response should contain the value "pending" at path "$.state"
+    And the MCP response should contain the value "0" at path "$.progress_percent"
+  
+  Scenario: Cancel job via MCP
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_cancel_test_job",
+        "description": "Job for testing cancellation",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}"
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness"
+          }
+        ]
+      }
+      """
+    Then the MCP tool call should succeed
+    And the "job_id" field in the MCP response should be saved as "value:cancel_job_id"
+    When I call MCP tool "cancel_job" with arguments:
+      """
+      {
+        "job_id": "{{value:cancel_job_id}}"
+      }
+      """
+    Then the MCP tool call should succeed
+    When I call MCP tool "get_job_status" with arguments:
+      """
+      {
+        "job_id": "{{value:cancel_job_id}}"
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain "cancelled"
+
+  @cluster 
+  Scenario: Submit evaluation job via MCP to cluster and wait for completion
+    Given the model endpoint is reachable
+    And I set the wait interval to "10s"
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_cluster_test",
+        "description": "Cluster test via MCP",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_fewshot": 0,
+              "limit": 5,
+              "num_examples": 10
+            }
+          }
+        ]
+      }
+      """
+    Then the MCP tool call should succeed
+    And the "job_id" field in the MCP response should be saved as "value:cluster_job_id"
+    And I wait for the evaluation job status to be "completed"
+    When I call MCP tool "get_job_status" with arguments:
+      """
+      {
+        "job_id": "{{value:cluster_job_id}}"
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain the value "completed" at path "$.state"
+    And the MCP response should contain the value "100" at path "$.progress_percent"
+
+  @cluster 
+  Scenario: Submit evaluation job with collection via MCP to cluster and wait for completion
+    Given the model endpoint is reachable
+    And I set the wait interval to "10s"
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_cluster_collection_test",
+        "description": "Cluster collection test via MCP",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "collection": {
+          "id": "toxicity-and-ethical-principles",
+          "benchmarks": [
+            {
+              "id": "toxigen",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            },
+            {
+              "id": "truthfulqa_mc1",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            },
+            {
+              "id": "bigbench_hhh_alignment_multiple_choice",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            }
+          ]
+        }
+      }
+      """
+    Then the MCP tool call should succeed
+    And the "job_id" field in the MCP response should be saved as "value:cluster_collection_job_id"
+    And I wait for the evaluation job status to be "completed"
+    When I call MCP tool "get_job_status" with arguments:
+      """
+      {
+        "job_id": "{{value:cluster_collection_job_id}}"
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain the value "completed" at path "$.state"
+    And the MCP response should contain the value "100" at path "$.progress_percent"
+  
+  @cluster 
+  Scenario: Submit evaluation job with multiple benchmarks via MCP to cluster and wait for completion
+    Given the model endpoint is reachable
+    And I set the wait interval to "10s"
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_cluster_multi_benchmark_test",
+        "description": "Cluster multi-benchmark test via MCP",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_fewshot": 0,
+              "limit": 3,
+              "num_examples": 3
+            }
+          },
+          {
+            "id": "truthfulqa_mc1",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_fewshot": 0,
+              "limit": 3,
+              "num_examples": 3
+            }
+          }
+        ]
+      }
+      """
+    Then the MCP tool call should succeed
+    And the "job_id" field in the MCP response should be saved as "value:cluster_multi_job_id"
+    And I wait for the evaluation job status to be "completed"
+    When I call MCP tool "get_job_status" with arguments:
+      """
+      {
+        "job_id": "{{value:cluster_multi_job_id}}"
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain the value "completed" at path "$.state"
+    And the MCP response should contain the value "100" at path "$.progress_percent"
+ 
+  @cluster
+  @mlflow
+  Scenario: Submit evaluation job with MLflow tracking via MCP to cluster and wait for completion
+    Given the model endpoint is reachable
+    And I set the wait interval to "10s"
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_cluster_mlflow_test",
+        "description": "Cluster MLflow tracking test via MCP",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_fewshot": 0,
+              "limit": 5,
+              "num_examples": 5
+            }
+          }
+        ],
+        "experiment": {
+          "name": "mcp_cluster_mlflow_experiment"
+        }
+      }
+      """
+    Then the MCP tool call should succeed
+    And the "job_id" field in the MCP response should be saved as "value:cluster_mlflow_job_id"
+    And I wait for the evaluation job status to be "completed"
+    When I call MCP tool "get_job_status" with arguments:
+      """
+      {
+        "job_id": "{{value:cluster_mlflow_job_id}}"
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain the value "completed" at path "$.state"
+    And the MCP response should contain the value "100" at path "$.progress_percent"
+
+  @cluster 
+  Scenario: Verify benchmark results and metrics via MCP resource after cluster job completion
+    Given the model endpoint is reachable
+    And I set the wait interval to "10s"
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_cluster_results_validation",
+        "description": "Cluster test to validate benchmark results via MCP resource",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_fewshot": 0,
+              "limit": 5,
+              "num_examples": 5
+            }
+          }
+        ]
+      }
+      """
+    Then the MCP tool call should succeed
+    And the "job_id" field in the MCP response should be saved as "value:cluster_results_job_id"
+    And I wait for the evaluation job status to be "completed"
+    When I read MCP resource "evalhub://jobs/{{value:cluster_results_job_id}}"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain the value "completed" at path "$.status.state"
+    And the MCP resource should contain the value "arc_easy" at path "$.results.benchmarks[0].id"
+    And the MCP resource should contain the value "lm_evaluation_harness" at path "$.results.benchmarks[0].provider_id"
+    And the MCP resource should contain "metrics"
+    And the MCP resource should contain the value "{{env:MODEL_NAME|test}}" at path "$.model.name"
+    And the MCP resource should contain the value "{{env:MODEL_URL|http://test.com}}" at path "$.model.url"
+
+#---- MCP Resources ----
+  Scenario: Read providers resource via MCP
+    When I read MCP resource "evalhub://providers"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain "lm_evaluation_harness"
+    And the MCP resource should contain "lighteval"
+
+  Scenario: Read specific provider resource by ID via MCP
+    When I read MCP resource "evalhub://providers/lm_evaluation_harness"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain the value "lm_evaluation_harness" at path "$.resource.id"
+    And the MCP resource should contain the value "LM Evaluation Harness" at path "$.name"
+  
+  Scenario: Read benchmarks resource via MCP
+    When I read MCP resource "evalhub://benchmarks"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain "arc_easy"
+    And the MCP resource should contain "hellaswag"
+  
+  Scenario: Read benchmarks filtered by label via MCP
+    When I read MCP resource "evalhub://benchmarks?label=reasoning"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain "arc_easy"
+
+  Scenario: Read specific benchmark resource by ID via MCP
+    When I read MCP resource "evalhub://benchmarks/arc_easy"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain the value "arc_easy" at path "$.id"
+    And the MCP resource should contain the value "reasoning" at path "$.category"
+
+  Scenario: Read collections resource via MCP
+    When I read MCP resource "evalhub://collections"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain "leaderboard-v2"
+
+  Scenario: Read specific collection resource by ID via MCP
+    When I read MCP resource "evalhub://collections/leaderboard-v2"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain the value "leaderboard-v2" at path "$.resource.id"
+
+  Scenario: Read jobs resource after creating job via MCP
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "mcp_resource_test_job",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}"
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness"
+          }
+        ]
+      }
+      """
+    Then the MCP tool call should succeed
+    And the "job_id" field in the MCP response should be saved as "value:resource_job_id"
+    When I read MCP resource "evalhub://jobs"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain "{{value:resource_job_id}}"
+    When I read MCP resource "evalhub://jobs/{{value:resource_job_id}}"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain the value "{{value:resource_job_id}}" at path "$.resource.id"
+    And the MCP resource should contain the value "pending" at path "$.status.state"
+
+  @negative
+  Scenario: Read non-existent provider resource fails
+    When I read MCP resource "evalhub://providers/non-existent-provider-xyz"
+    Then the MCP resource read should fail
+    And the MCP resource error should contain "not found"
+
+  @negative
+  Scenario: Read non-existent benchmark resource fails
+    When I read MCP resource "evalhub://benchmarks/non-existent-benchmark-xyz"
+    Then the MCP resource read should fail
+    And the MCP resource error should contain "not found"
+
+#---- MCP Prompts ----
+  Scenario: Get edd_workflow prompt via MCP
+    When I get MCP prompt "edd_workflow" with arguments:
+      """
+      {
+        "application_type": "rag"
+      }
+      """
+    Then the MCP prompt should succeed
+    And the MCP prompt should contain "evaluation"
+    And the MCP prompt should contain "rag"
+
+  Scenario: Get evaluate_model prompt via MCP
+    When I get MCP prompt "evaluate_model" with arguments:
+      """
+      {
+        "model_name": "test-model",
+        "model_url": "http://test.com"
+      }
+      """
+    Then the MCP prompt should succeed
+    And the MCP prompt should contain "http://test.com"
+    And the MCP prompt should contain "evaluate"
+
+  Scenario: Get compare_runs prompt via MCP
+    When I get MCP prompt "compare_runs" with arguments:
+      """
+      {
+        "job_ids": "job1,job2"
+      }
+      """
+    Then the MCP prompt should succeed
+    And the MCP prompt should contain "compare"
+
+  @negative
+  Scenario: Get edd_workflow prompt with invalid application_type fails
+    When I get MCP prompt "edd_workflow" with arguments:
+      """
+      {
+        "application_type": "invalid_type"
+      }
+      """
+    Then the MCP prompt should fail
+    And the MCP prompt error should contain "application_type"
+
+#----
+  @negative
+  Scenario: Submit evaluation job missing required name fails
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}"
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness"
+          }
+        ]
+      }
+      """
+    Then the MCP tool call should fail
+    And the MCP error should contain "missing properties"
+    And the MCP error should contain "name"
+
+  @negative
+  Scenario: Submit evaluation job missing model fails
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "invalid_job",
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness"
+          }
+        ]
+      }
+      """
+    Then the MCP tool call should fail
+    And the MCP error should contain "missing properties"
+    And the MCP error should contain "model"
+
+  @negative
+  Scenario: Submit evaluation job with both benchmarks and collection fails
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "invalid_job",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}"
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness"
+          }
+        ],
+        "collection": {
+          "id": "leaderboard-v2"
+        }
+      }
+      """
+    Then the MCP tool call should fail
+    And the MCP error should contain "validation error: provide 'benchmarks' or 'collection', not both"
+
+  @negative
+  Scenario: Submit evaluation job with neither benchmarks nor collection fails
+    When I call MCP tool "submit_evaluation" with arguments:
+      """
+      {
+        "name": "invalid_job",
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}"
+        }
+      }
+      """
+    Then the MCP tool call should fail
+    And the MCP error should contain "validation error: provide at least one of 'benchmarks' or 'collection'"
+
+  @negative
+  Scenario: Get status for non-existent job fails
+    When I call MCP tool "get_job_status" with arguments:
+      """
+      {
+        "job_id": "non-existent-job-id-12345"
+      }
+      """
+    Then the MCP tool call should fail
+    And the MCP error should contain "resource_not_found"
+
+  @negative
+  Scenario: Cancel non-existent job fails
+    When I call MCP tool "cancel_job" with arguments:
+      """
+      {
+        "job_id": "non-existent-job-id-67890"
+      }
+      """
+    Then the MCP tool call should fail
+    And the MCP error should contain "resource_not_found"

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"math"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
@@ -35,9 +37,13 @@ import (
 	"github.com/eval-hub/eval-hub/internal/otel"
 	"github.com/eval-hub/eval-hub/internal/testhelpers"
 	pkgapi "github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/eval-hub/eval-hub/pkg/evalhubclient"
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/cucumber/godog"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	mcpserver "github.com/eval-hub/eval-hub/internal/evalhub_mcp/server"
 )
 
 const (
@@ -76,6 +82,10 @@ type apiFeature struct {
 	httpServer     *http.Server
 	metricsServer  *server.MetricsServer
 	client         *http.Client
+	// MCP-specific fields
+	mcpServer        *mcp.Server
+	mcpClientSession *mcp.ClientSession
+	mcpServerSession *mcp.ServerSession
 }
 
 // this is used for a scenario to ensure that scenarios do not overwrite
@@ -91,6 +101,14 @@ type scenarioConfig struct {
 	lastURL    string
 	lastMethod string
 	lastId     string
+
+	// MCP-specific fields
+	mcpToolResult    *mcp.CallToolResult
+	mcpError         error
+	mcpResourceText  string
+	mcpResourceError error
+	mcpPromptResult  *mcp.GetPromptResult
+	mcpPromptError   error
 
 	// assetsSync sync.Mutex
 	assets map[string][]string
@@ -232,7 +250,18 @@ func createApiFeature() (*apiFeature, error) {
 		if err != nil {
 			return nil, logError(err)
 		}
-		return &apiFeature{client: client, baseURL: uri, metricsBaseURL: metricsBase}, nil
+		apiFeat := &apiFeature{client: client, baseURL: uri, metricsBaseURL: metricsBase}
+
+		// Initialize MCP server even when using remote server
+		logger, _, err := logging.NewLogger()
+		if err != nil {
+			return nil, logError(fmt.Errorf("failed to create logger for MCP: %w", err))
+		}
+		if err := apiFeat.setupMCPServer(logger); err != nil {
+			return nil, logError(fmt.Errorf("failed to setup MCP server for remote testing: %w", err))
+		}
+
+		return apiFeat, nil
 	}
 
 	port := 8080
@@ -396,10 +425,90 @@ func (a *apiFeature) startLocalServer(port int) error {
 		}()
 	}
 
+	// Initialize MCP server with real eval-hub client
+	if err := a.setupMCPServer(logger); err != nil {
+		return logError(fmt.Errorf("failed to setup MCP server: %w", err))
+	}
+
+	return nil
+}
+
+func (a *apiFeature) setupMCPServer(logger *slog.Logger) error {
+	// Create real eval-hub client pointing to local test server
+	tenant := os.Getenv("X_TENANT")
+	token := os.Getenv("AUTH_TOKEN")
+
+	logger.Info("Setting up MCP server", "base_url", a.baseURL.String(), "tenant", tenant, "has_token", token != "")
+
+	evalhubClient := evalhubclient.NewClient(a.baseURL.String())
+	if tenant != "" {
+		evalhubClient = evalhubClient.WithTenant(tenant)
+	}
+	if token != "" {
+		evalhubClient = evalhubClient.WithToken(token)
+	}
+
+	// Create MCP server with real backend
+	version, err := testhelpers.RepoVersion()
+	if err != nil {
+		version = "unknown" // Fallback for test environment
+	}
+
+	// Get git hash from repo (matches Makefile: git rev-parse --short HEAD)
+	gitHash := "unknown"
+	cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
+	if output, err := cmd.Output(); err == nil {
+		gitHash = strings.TrimSpace(string(output))
+	}
+
+	serverInfo := &mcpserver.ServerInfo{
+		Build:     version,
+		BuildDate: time.Now().Format(time.RFC3339),
+		GitHash:   gitHash,
+	}
+
+	a.mcpServer = mcpserver.New(serverInfo, logger, nil)
+	if err := mcpserver.RegisterHandlers(a.mcpServer, evalhubClient, serverInfo, logger, evalhubclient.DefaultListPageLimit); err != nil {
+		return fmt.Errorf("failed to register MCP handlers: %w", err)
+	}
+
+	// Create in-memory transports for testing (like unit tests)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	ctx := context.Background()
+
+	// Connect server
+	serverSession, err := a.mcpServer.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		return fmt.Errorf("failed to connect MCP server: %w", err)
+	}
+	a.mcpServerSession = serverSession
+
+	// Connect client
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "fvt-test-client", Version: "1.0.0"}, nil)
+	clientSession, err := mcpClient.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		return fmt.Errorf("failed to connect MCP client: %w", err)
+	}
+	a.mcpClientSession = clientSession
+
+	logger.Info("MCP server initialized successfully for FVT tests")
 	return nil
 }
 
 func (a *apiFeature) cleanup(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+	if a.mcpClientSession != nil {
+		if err := a.mcpClientSession.Close(); err != nil {
+			// Log but don't fail - consistent with existing cleanup pattern
+			logDebug("MCP client session close error (non-fatal): %v\n", err)
+		}
+	}
+	if a.mcpServerSession != nil {
+		if err := a.mcpServerSession.Close(); err != nil {
+			// Log but don't fail - consistent with existing cleanup pattern
+			logDebug("MCP server session close error (non-fatal): %v\n", err)
+		}
+	}
 	if a.metricsServer != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		_ = a.metricsServer.Shutdown(shutdownCtx)
@@ -410,6 +519,7 @@ func (a *apiFeature) cleanup(ctx context.Context, _ *godog.Scenario, _ error) (c
 		defer cancel()
 		a.httpServer.Shutdown(ctx)
 	}
+
 	return ctx, nil
 }
 
@@ -1400,10 +1510,23 @@ func (tc *scenarioConfig) theArrayAtPathInResponseShouldHaveLengthAtLeast(jsonPa
 }
 
 func getJsonPointer(path string) string {
+	// Strip JSONPath root indicators: $. or $
+	path = strings.TrimPrefix(path, "$.")
+	path = strings.TrimPrefix(path, "$")
+
+	// Ensure it starts with / for JSON Pointer spec
 	if !strings.HasPrefix(path, "/") {
-		return strings.ReplaceAll(fmt.Sprintf("/%s", path), ".", "/")
+		path = "/" + path
 	}
-	return strings.ReplaceAll(path, ".", "/")
+	// Convert dot notation to slash notation
+	path = strings.ReplaceAll(path, ".", "/")
+
+	// Convert array notation [N] to /N/ for JSON Pointer spec
+	// e.g., /benchmarks[0]/id becomes /benchmarks/0/id
+	re := regexp.MustCompile(`\[(\d+)\]`)
+	path = re.ReplaceAllString(path, "/$1")
+
+	return path
 }
 
 func (tc *scenarioConfig) theFieldShouldBeSaved(path string, name string) error {
@@ -1753,9 +1876,493 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	// Other steps
 	ctx.Step(`^fix this step$`, tc.fixThisStep)
 
+	// MCP-specific steps
+	ctx.Step(`^I call MCP tool "([^"]*)" with arguments "([^"]*)"$`, tc.iCallMCPToolWithArguments)
+	ctx.Step(`^I call MCP tool "([^"]*)" with arguments:$`, tc.iCallMCPToolWithInlineArguments)
+	ctx.Step(`^the MCP tool call should succeed$`, tc.theMCPToolCallShouldSucceed)
+	ctx.Step(`^the MCP tool call should fail$`, tc.theMCPToolCallShouldFail)
+	ctx.Step(`^the MCP response should contain "([^"]*)"$`, tc.theMCPResponseShouldContain)
+	ctx.Step(`^the MCP response should contain the value "([^"]*)" at path "([^"]*)"$`, tc.theMCPResponseShouldContainValueAtPath)
+	ctx.Step(`^the MCP error should contain "([^"]*)"$`, tc.theMCPErrorShouldContain)
+	ctx.Step(`^the "([^"]*)" field in the MCP response should be saved as "([^"]*)"$`, tc.theMCPFieldShouldBeSaved)
+	ctx.Step(`^the MCP response array at path "([^"]*)" should have length (\d+)$`, tc.theMCPResponseArrayAtPathShouldHaveLength)
+
+	// MCP Resource steps
+	ctx.Step(`^I read MCP resource "([^"]*)"$`, tc.iReadMCPResource)
+	ctx.Step(`^the MCP resource read should succeed$`, tc.theMCPResourceReadShouldSucceed)
+	ctx.Step(`^the MCP resource read should fail$`, tc.theMCPResourceReadShouldFail)
+	ctx.Step(`^the MCP resource should contain "([^"]*)"$`, tc.theMCPResourceShouldContain)
+	ctx.Step(`^the MCP resource should contain the value "([^"]*)" at path "([^"]*)"$`, tc.theMCPResourceShouldContainValueAtPath)
+	ctx.Step(`^the MCP resource error should contain "([^"]*)"$`, tc.theMCPResourceErrorShouldContain)
+
+	// MCP Prompt steps
+	ctx.Step(`^I get MCP prompt "([^"]*)" with arguments:$`, tc.iGetMCPPrompt)
+	ctx.Step(`^the MCP prompt should succeed$`, tc.theMCPPromptShouldSucceed)
+	ctx.Step(`^the MCP prompt should fail$`, tc.theMCPPromptShouldFail)
+	ctx.Step(`^the MCP prompt should contain "([^"]*)"$`, tc.theMCPPromptShouldContain)
+	ctx.Step(`^the MCP prompt error should contain "([^"]*)"$`, tc.theMCPPromptErrorShouldContain)
+
 	// GPU-specific steps
 	InitializeGPUSteps(ctx, tc)
 
 	// Hardware profile steps (Kubernetes client-go via KUBECONFIG-first FVT helper)
 	InitializeHardwareProfileSteps(ctx, tc)
+}
+
+// --- MCP Step Definitions ---
+
+// getMCPResultJSON converts MCP tool result to JSON bytes
+func (tc *scenarioConfig) getMCPResultJSON() ([]byte, error) {
+	if tc.mcpToolResult == nil {
+		return nil, fmt.Errorf("no MCP tool result")
+	}
+	// For errors, prefer Content (which contains the error text) over StructuredContent
+	if tc.mcpToolResult.IsError {
+		if len(tc.mcpToolResult.Content) > 0 {
+			return json.Marshal(tc.mcpToolResult.Content)
+		}
+	}
+	// For success responses, prefer StructuredContent
+	if tc.mcpToolResult.StructuredContent != nil {
+		return json.Marshal(tc.mcpToolResult.StructuredContent)
+	}
+	if len(tc.mcpToolResult.Content) > 0 {
+		return json.Marshal(tc.mcpToolResult.Content)
+	}
+	return nil, fmt.Errorf("MCP tool result has no content")
+}
+
+func (tc *scenarioConfig) iCallMCPToolWithArguments(toolName, argsJSON string) error {
+	if tc.apiFeature.mcpClientSession == nil {
+		return tc.logError(fmt.Errorf("MCP client session not initialized"))
+	}
+
+	// Substitute values ({{value:key}}) like HTTP steps do
+	substitutedArgs, err := tc.substituteValues(argsJSON)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to substitute values in MCP args: %w", err))
+	}
+
+	ctx := context.Background()
+	result, err := tc.apiFeature.mcpClientSession.CallTool(ctx, &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: json.RawMessage(substitutedArgs),
+	})
+
+	tc.mcpToolResult = result
+	tc.mcpError = err
+
+	tc.logDebug("MCP tool %s called with args %s\n", toolName, substitutedArgs)
+	if err != nil {
+		tc.logDebug("MCP tool call error: %v\n", err)
+	}
+	if result != nil && result.IsError {
+		tc.logDebug("MCP tool returned error result\n")
+	}
+
+	return nil
+}
+
+func (tc *scenarioConfig) iCallMCPToolWithInlineArguments(toolName string, argsJSON *godog.DocString) error {
+	return tc.iCallMCPToolWithArguments(toolName, argsJSON.Content)
+}
+
+func (tc *scenarioConfig) theMCPToolCallShouldSucceed() error {
+	if tc.mcpError != nil {
+		return tc.logError(fmt.Errorf("expected MCP tool call to succeed but got error: %v", tc.mcpError))
+	}
+	if tc.mcpToolResult == nil {
+		return tc.logError(fmt.Errorf("expected MCP tool result but got nil"))
+	}
+	if tc.mcpToolResult.IsError {
+		// Serialize error content to JSON for better error messages
+		errJSON, _ := json.MarshalIndent(tc.mcpToolResult.Content, "", "  ")
+		return tc.logError(fmt.Errorf("expected MCP tool call to succeed but got error result: %s", string(errJSON)))
+	}
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPToolCallShouldFail() error {
+	if tc.mcpError == nil && (tc.mcpToolResult == nil || !tc.mcpToolResult.IsError) {
+		return tc.logError(fmt.Errorf("expected MCP tool call to fail but it succeeded"))
+	}
+
+	// Log the error details for debugging
+	if tc.mcpToolResult != nil && tc.mcpToolResult.IsError {
+		errJSON, _ := json.MarshalIndent(tc.mcpToolResult.Content, "", "  ")
+		tc.logDebug("MCP error response: %s\n", string(errJSON))
+	}
+
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPResponseShouldContain(expected string) error {
+	resultJSON, err := tc.getMCPResultJSON()
+	if err != nil {
+		return tc.logError(err)
+	}
+
+	resultStr := string(resultJSON)
+	tc.logDebug("MCP response: %s\n", resultStr)
+
+	if !strings.Contains(resultStr, expected) {
+		return tc.logError(fmt.Errorf("expected MCP response to contain %q but got: %s", expected, resultStr))
+	}
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPResponseShouldContainValueAtPath(expected, path string) error {
+	// Substitute any {{value:key}} patterns in expected value
+	expected, _ = tc.substituteValues(expected)
+
+	resultJSON, err := tc.getMCPResultJSON()
+	if err != nil {
+		return tc.logError(err)
+	}
+
+	tc.logDebug("MCP response JSON for path check: %s\n", string(resultJSON))
+	tc.logDebug("Looking for path: %s (converted to: %s)\n", path, getJsonPointer(path))
+
+	// Parse JSON and extract value at path using gabs (same as HTTP version)
+	jsonParsed, err := gabs.ParseJSON(resultJSON)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to parse MCP JSON response: %w", err))
+	}
+
+	pathObj, err := jsonParsed.JSONPointer(getJsonPointer(path))
+	if err != nil {
+		return tc.logError(fmt.Errorf("path %v does not exist in MCP response\nJSON: %s", path, string(resultJSON)))
+	}
+
+	// Convert to string for comparison
+	var actualValue string
+	switch v := pathObj.Data().(type) {
+	case string:
+		actualValue = v
+	case float64:
+		actualValue = strconv.FormatFloat(v, 'f', -1, 64)
+	case bool:
+		actualValue = strconv.FormatBool(v)
+	default:
+		// For complex types, marshal to JSON
+		jsonBytes, err := json.Marshal(v)
+		if err != nil {
+			return tc.logError(fmt.Errorf("failed to marshal value at path %s: %w", path, err))
+		}
+		actualValue = string(jsonBytes)
+	}
+
+	if actualValue != expected {
+		return tc.logError(fmt.Errorf("expected MCP response at path %s to be %q but got %q", path, expected, actualValue))
+	}
+
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPErrorShouldContain(expected string) error {
+	// Check if there was a transport-level error
+	if tc.mcpError != nil {
+		errorStr := tc.mcpError.Error()
+		tc.logDebug("MCP transport error: %s\n", errorStr)
+		if !strings.Contains(errorStr, expected) {
+			return tc.logError(fmt.Errorf("expected MCP error to contain %q but got: %s", expected, errorStr))
+		}
+		return nil
+	}
+
+	// Check if there was an MCP tool error result
+	if tc.mcpToolResult == nil || !tc.mcpToolResult.IsError {
+		return tc.logError(fmt.Errorf("expected MCP error result but got success or nil"))
+	}
+
+	resultJSON, err := tc.getMCPResultJSON()
+	if err != nil {
+		return tc.logError(err)
+	}
+
+	resultStr := string(resultJSON)
+	tc.logDebug("MCP error response: %s\n", resultStr)
+
+	if !strings.Contains(resultStr, expected) {
+		return tc.logError(fmt.Errorf("expected MCP error to contain %q but got: %s", expected, resultStr))
+	}
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPFieldShouldBeSaved(path, name string) error {
+	resultJSON, err := tc.getMCPResultJSON()
+	if err != nil {
+		return tc.logError(err)
+	}
+
+	// Parse and extract field using gabs (same as HTTP version)
+	jsonParsed, err := gabs.ParseJSON(resultJSON)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to parse MCP JSON response: %w", err))
+	}
+
+	pathObj, err := jsonParsed.JSONPointer(getJsonPointer(path))
+	if err != nil {
+		return tc.logError(fmt.Errorf("path %v does not exist in MCP response", path))
+	}
+
+	finalResult, ok := pathObj.Data().(string)
+	if !ok {
+		if floatResult, ok := pathObj.Data().(float64); ok {
+			finalResult = strconv.FormatFloat(floatResult, 'f', -1, 64)
+		} else {
+			return tc.logError(fmt.Errorf("expected %s to be a string or float64 but got %T", path, pathObj.Data()))
+		}
+	}
+
+	if strings.HasPrefix(name, valuePrefix) {
+		realName := strings.TrimPrefix(name, valuePrefix)
+		tc.saveValue(realName, finalResult)
+
+		// If saving job_id, also set lastId for compatibility with wait functions
+		if path == "job_id" {
+			tc.lastId = finalResult
+			tc.values["id"] = finalResult
+		}
+	} else {
+		return tc.logError(fmt.Errorf("unexpected value %s, should start with '%s'", name, valuePrefix))
+	}
+
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPResponseArrayAtPathShouldHaveLength(jsonPath string, lengthStr string) error {
+	resultJSON, err := tc.getMCPResultJSON()
+	if err != nil {
+		return tc.logError(err)
+	}
+
+	jsonParsed, err := gabs.ParseJSON(resultJSON)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to parse MCP JSON response: %w", err))
+	}
+
+	pathObj, err := jsonParsed.JSONPointer(getJsonPointer(jsonPath))
+	if err != nil {
+		return tc.logError(fmt.Errorf("path %v does not exist in MCP response", jsonPath))
+	}
+
+	arr, ok := pathObj.Data().([]interface{})
+	if !ok {
+		return tc.logError(fmt.Errorf("value at path %s is not an array in MCP response, got %T", jsonPath, pathObj.Data()))
+	}
+
+	length, err := strconv.Atoi(lengthStr)
+	if err != nil {
+		return tc.logError(fmt.Errorf("expected integer length, got %q: %w", lengthStr, err))
+	}
+
+	if len(arr) != length {
+		return tc.logError(fmt.Errorf("expected array at path %s to have length %d, got %d", jsonPath, length, len(arr)))
+	}
+	return nil
+}
+
+// MCP Resource steps
+func (tc *scenarioConfig) iReadMCPResource(uri string) error {
+	if tc.apiFeature.mcpClientSession == nil {
+		return tc.logError(fmt.Errorf("MCP client session not initialized"))
+	}
+
+	// Substitute any {{value:key}} or {{env:VAR|default}} patterns in URI
+	uri, _ = tc.substituteValues(uri)
+
+	ctx := context.Background()
+	result, err := tc.apiFeature.mcpClientSession.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
+
+	tc.mcpResourceError = err
+	if err == nil && len(result.Contents) > 0 {
+		// Combine all text content from the resource
+		var textParts []string
+		for _, content := range result.Contents {
+			textParts = append(textParts, content.Text)
+		}
+		tc.mcpResourceText = strings.Join(textParts, "\n")
+		tc.logDebug("MCP resource content: %s\n", tc.mcpResourceText)
+	}
+
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPResourceReadShouldSucceed() error {
+	if tc.mcpResourceError != nil {
+		return tc.logError(fmt.Errorf("expected MCP resource read to succeed but got error: %w", tc.mcpResourceError))
+	}
+	if tc.mcpResourceText == "" {
+		return tc.logError(fmt.Errorf("expected MCP resource to have content but got empty text"))
+	}
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPResourceReadShouldFail() error {
+	if tc.mcpResourceError == nil {
+		return tc.logError(fmt.Errorf("expected MCP resource read to fail but it succeeded"))
+	}
+	tc.logDebug("MCP resource error: %s\n", tc.mcpResourceError.Error())
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPResourceShouldContain(expected string) error {
+	// Substitute any {{value:key}} patterns in expected value
+	expected, _ = tc.substituteValues(expected)
+
+	if tc.mcpResourceText == "" {
+		return tc.logError(fmt.Errorf("no MCP resource text to check"))
+	}
+	if !strings.Contains(tc.mcpResourceText, expected) {
+		return tc.logError(fmt.Errorf("expected MCP resource to contain %q but got: %s", expected, tc.mcpResourceText))
+	}
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPResourceShouldContainValueAtPath(expected, path string) error {
+	// Substitute any {{value:key}} patterns in expected value
+	expected, _ = tc.substituteValues(expected)
+
+	if tc.mcpResourceText == "" {
+		return tc.logError(fmt.Errorf("no MCP resource text to check"))
+	}
+
+	tc.logDebug("MCP resource JSON for path check: %s\n", tc.mcpResourceText)
+	tc.logDebug("Looking for path: %s (converted to: %s)\n", path, getJsonPointer(path))
+
+	// Parse JSON and extract value at path using gabs
+	jsonParsed, err := gabs.ParseJSON([]byte(tc.mcpResourceText))
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to parse MCP resource JSON: %w", err))
+	}
+
+	pathObj, err := jsonParsed.JSONPointer(getJsonPointer(path))
+	if err != nil {
+		return tc.logError(fmt.Errorf("path %v does not exist in MCP resource\nJSON: %s", path, tc.mcpResourceText))
+	}
+
+	// Convert to string for comparison
+	var actualValue string
+	switch v := pathObj.Data().(type) {
+	case string:
+		actualValue = v
+	case float64:
+		actualValue = strconv.FormatFloat(v, 'f', -1, 64)
+	case bool:
+		actualValue = strconv.FormatBool(v)
+	default:
+		// For complex types, marshal to JSON
+		jsonBytes, err := json.Marshal(v)
+		if err != nil {
+			return tc.logError(fmt.Errorf("failed to marshal value at path %s: %w", path, err))
+		}
+		actualValue = string(jsonBytes)
+	}
+
+	if actualValue != expected {
+		return tc.logError(fmt.Errorf("expected MCP resource at path %s to be %q but got %q", path, expected, actualValue))
+	}
+
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPResourceErrorShouldContain(expected string) error {
+	if tc.mcpResourceError == nil {
+		return tc.logError(fmt.Errorf("expected MCP resource error but got success"))
+	}
+	errorStr := tc.mcpResourceError.Error()
+	if !strings.Contains(errorStr, expected) {
+		return tc.logError(fmt.Errorf("expected MCP resource error to contain %q but got: %s", expected, errorStr))
+	}
+	return nil
+}
+
+// MCP Prompt steps
+func (tc *scenarioConfig) iGetMCPPrompt(name, argsJSON string) error {
+	if tc.apiFeature.mcpClientSession == nil {
+		return tc.logError(fmt.Errorf("MCP client session not initialized"))
+	}
+
+	// Parse arguments
+	var args map[string]string
+	if argsJSON != "" {
+		argsJSON, _ = tc.substituteValues(argsJSON)
+		var rawArgs map[string]interface{}
+		if err := json.Unmarshal([]byte(argsJSON), &rawArgs); err != nil {
+			return tc.logError(fmt.Errorf("failed to parse MCP prompt arguments JSON: %w", err))
+		}
+		// Convert to map[string]string as expected by GetPromptParams
+		args = make(map[string]string)
+		for k, v := range rawArgs {
+			args[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	ctx := context.Background()
+	result, err := tc.apiFeature.mcpClientSession.GetPrompt(ctx, &mcp.GetPromptParams{
+		Name:      name,
+		Arguments: args,
+	})
+
+	tc.mcpPromptError = err
+	tc.mcpPromptResult = result
+
+	if err != nil {
+		tc.logDebug("MCP prompt error: %s\n", err.Error())
+	} else if result != nil {
+		resultJSON, _ := json.MarshalIndent(result, "", "  ")
+		tc.logDebug("MCP prompt result: %s\n", string(resultJSON))
+	}
+
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPPromptShouldSucceed() error {
+	if tc.mcpPromptError != nil {
+		return tc.logError(fmt.Errorf("expected MCP prompt to succeed but got error: %w", tc.mcpPromptError))
+	}
+	if tc.mcpPromptResult == nil {
+		return tc.logError(fmt.Errorf("expected MCP prompt result but got nil"))
+	}
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPPromptShouldFail() error {
+	if tc.mcpPromptError == nil {
+		return tc.logError(fmt.Errorf("expected MCP prompt to fail but it succeeded"))
+	}
+	tc.logDebug("MCP prompt error: %s\n", tc.mcpPromptError.Error())
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPPromptShouldContain(expected string) error {
+	if tc.mcpPromptResult == nil {
+		return tc.logError(fmt.Errorf("no MCP prompt result to check"))
+	}
+
+	// Combine all message content to search
+	var allText []string
+	for _, msg := range tc.mcpPromptResult.Messages {
+		if textContent, ok := msg.Content.(*mcp.TextContent); ok {
+			allText = append(allText, textContent.Text)
+		}
+	}
+	fullText := strings.Join(allText, "\n")
+
+	if !strings.Contains(fullText, expected) {
+		return tc.logError(fmt.Errorf("expected MCP prompt to contain %q but got: %s", expected, fullText))
+	}
+	return nil
+}
+
+func (tc *scenarioConfig) theMCPPromptErrorShouldContain(expected string) error {
+	if tc.mcpPromptError == nil {
+		return tc.logError(fmt.Errorf("expected MCP prompt error but got success"))
+	}
+	errorStr := tc.mcpPromptError.Error()
+	if !strings.Contains(errorStr, expected) {
+		return tc.logError(fmt.Errorf("expected MCP prompt error to contain %q but got: %s", expected, errorStr))
+	}
+	return nil
 }

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -290,7 +290,9 @@ func createApiFeature() (*apiFeature, error) {
 		baseURL:        baseURL,
 		metricsBaseURL: metricsBase,
 	}
-	apiFeat.startLocalServer(port)
+	if err := apiFeat.startLocalServer(port); err != nil {
+		return nil, err
+	}
 	return apiFeat, nil
 }
 


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

  Add comprehensive FVT tests for Model Context Protocol (MCP) server functionality, enabling validation of AI agent interactions with eval-hub.

  Test Coverage:
  - MCP tools: discover_providers, submit_evaluation, get_job_status, cancel_job
  - MCP resources: evalhub://providers, evalhub://jobs/{id}
  - MCP prompts: list and retrieve evaluation guidance
  - End-to-end cluster evaluation flows via MCP protocol

  Changes to test infrastructure:
  - Enable MCP server during test suite initialization (local and remote modes)
  - Add 15 MCP-specific test steps for protocol-level validation
  - Add lastId tracking for MCP job_id to enable reuse of existing wait functions
  - Fix exec.Command error handling (remove pointless cmd.Err check)

  Test organization:
  - 15 scenarios in mcp.feature tagged @mcp (excluded from default test runs)
  - Follow existing patterns: @cluster scenarios, wait deadline in Background

  All existing tests pass with framework changes. MCP tests validated against
  cluster with real Kubernetes job execution.



Closes #

Assisted-by: <!-- Cursor, Claude etc -->: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for MCP tools, resources, and prompts.
  * Expanded scenario testing for provider discovery, job submission, status polling, cancellation, and completion.
  * Added negative-case coverage for invalid inputs, missing resources, and error handling.
  * Improved test support for JSON path checks and scenario data sharing across MCP flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->