### PR TITLE
chore(github): add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# Global fallback — all PRs need at least one approval
+* @ruivieira @julpayne
+
+# Go service
+/cmd/ @ruivieira @julpayne
+/internal/eval_hub/ @ruivieira @julpayne @gnaulak-redhat
+/internal/handlers/ @ruivieira @julpayne
+/internal/storage/ @ruivieira @julpayne @nbs-rh
+/pkg/ @ruivieira @julpayne @scheruku-rh @nbs-rh
+
+# K8s runtime
+/internal/runtimes/ @ruivieira @julpayne @scheruku-rh
+
+# Sidecar
+/eval_runtime_sidecar/ @ruivieira @julpayne @nbs-rh @scheruku-rh
+
+# Python server
+/src/ @ruivieira @julpayne @gnaulak-redhat
+/python-server/ @ruivieira @julpayne @gnaulak-redhat
+
+# MCP
+/python-mcp/ @ruivieira @julpayne @gnaulak-redhat
+
+# Config and providers
+/config/ @ruivieira @julpayne @gnaulak-redhat
+
+# CI workflows
+/.github/workflows/ @ruivieira @julpayne @gnaulak-redhat
+
+# Tests
+/tests/ @ruivieira @julpayne @scheruku-rh @nbs-rh


### PR DESCRIPTION
## What and why

Adds `.github/CODEOWNERS` to ensure automatic review assignment and clear ownership across the repository.

Ownership is mapped by area based on historical contribution patterns:

- **Global fallback**: @ruivieira @julpayne
- **Go service** (`cmd/`, `internal/`, `pkg/`): @ruivieira @julpayne
- **K8s runtime** (`internal/runtimes/`): @ruivieira @julpayne @scheruku-rh
- **Sidecar** (`eval_runtime_sidecar/`): @ruivieira @julpayne @nbs-rh @scheruku-rh
- **Python server** (`src/`, `python-server/`, `python-mcp/`): @ruivieira @julpayne @gnaulak-redhat
- **Config/providers** (`config/`): @ruivieira @julpayne @gnaulak-redhat
- **CI workflows** (`.github/workflows/`): @ruivieira @julpayne @gnaulak-redhat
- **Tests**: @ruivieira @julpayne @scheruku-rh @nbs-rh

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership rules to clarify review requirements across key areas.
  * Set a global fallback so all pull requests require approval from designated maintainers.
  * Added path-specific ownership coverage for service code, runtime components, configuration, workflows, and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->