### PR TITLE
fix: preserve model URL path when redirecting adapter through sidecar

### DIFF
--- a/internal/eval_hub/runtimes/k8s/job_config_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_config_test.go
@@ -829,6 +829,36 @@ func TestRewriteModelURLForSidecar(t *testing.T) {
 			modelURL:       "http://llm-inference.apps.example.com/llm/my-model/v1/",
 			want:           "http://localhost:8080/llm/my-model/v1",
 		},
+		{
+			name:           "empty sidecar URL is invalid — missing host",
+			sidecarBaseURL: "",
+			modelURL:       "http://llm-inference.apps.example.com/v1",
+			wantErr:        true,
+		},
+		{
+			name:           "sidecar URL without host is invalid",
+			sidecarBaseURL: "/relative/path",
+			modelURL:       "http://llm-inference.apps.example.com/v1",
+			wantErr:        true,
+		},
+		{
+			name:           "malformed sidecar URL fails url.Parse",
+			sidecarBaseURL: "http://host%GG/path",
+			modelURL:       "http://llm-inference.apps.example.com/v1",
+			wantErr:        true,
+		},
+		{
+			name:           "malformed model URL fails url.Parse",
+			sidecarBaseURL: "http://localhost:8080",
+			modelURL:       "http://host%GG/v1",
+			wantErr:        true,
+		},
+		{
+			name:           "query and fragment from model URL are preserved",
+			sidecarBaseURL: "http://localhost:8080",
+			modelURL:       "http://llm-inference.apps.example.com/llm/my-model/v1?timeout=30#section",
+			want:           "http://localhost:8080/llm/my-model/v1?timeout=30#section",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/eval_hub/runtimes/k8s/job_config_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_config_test.go
@@ -791,6 +791,102 @@ func TestBuildJobConfigBenchmarkIndexPropagated(t *testing.T) {
 	}
 }
 
+func TestRewriteModelURLForSidecar(t *testing.T) {
+	tests := []struct {
+		name           string
+		sidecarBaseURL string
+		modelURL       string
+		want           string
+		wantErr        bool
+	}{
+		{
+			name:           "preserves deep KServe path prefix",
+			sidecarBaseURL: "http://localhost:8080",
+			modelURL:       "http://llm-inference.apps.example.com/llm/llama-3-1-8b-instruct/v1",
+			want:           "http://localhost:8080/llm/llama-3-1-8b-instruct/v1",
+		},
+		{
+			name:           "model URL with no path — no path added",
+			sidecarBaseURL: "http://localhost:8080",
+			modelURL:       "http://llm-inference.apps.example.com",
+			want:           "http://localhost:8080",
+		},
+		{
+			name:           "model URL with /v1 only",
+			sidecarBaseURL: "http://localhost:8080",
+			modelURL:       "http://llm-inference.apps.example.com/v1",
+			want:           "http://localhost:8080/v1",
+		},
+		{
+			name:           "custom sidecar port preserved",
+			sidecarBaseURL: "http://localhost:9090",
+			modelURL:       "http://llm-inference.apps.example.com/llm/my-model/v1",
+			want:           "http://localhost:9090/llm/my-model/v1",
+		},
+		{
+			name:           "trailing slash on model URL stripped",
+			sidecarBaseURL: "http://localhost:8080",
+			modelURL:       "http://llm-inference.apps.example.com/llm/my-model/v1/",
+			want:           "http://localhost:8080/llm/my-model/v1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := rewriteModelURLForSidecar(tc.sidecarBaseURL, tc.modelURL)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("rewriteModelURLForSidecar(%q, %q) = %q, want %q", tc.sidecarBaseURL, tc.modelURL, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildJobConfigModelURLPreservesRealURLAndTargetURL(t *testing.T) {
+	// buildJobConfig does NOT rewrite model.url — that happens in k8s_runtime.go
+	// via rewriteModelURLForSidecar. Verify modelTargetURL holds the real upstream URL
+	// and sidecarBaseURL is plain localhost for the runtime to use.
+	evaluation := &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{Resource: api.Resource{ID: "job-rewrite"}},
+		EvaluationJobConfig: api.EvaluationJobConfig{
+			Model: api.ModelRef{
+				URL:  "http://llm-inference.apps.example.com/llm/llama-3-1-8b-instruct/v1",
+				Name: "llama-3-1-8b-instruct",
+			},
+			Benchmarks: []api.EvaluationBenchmarkConfig{{Ref: api.Ref{ID: "bench-1"}}},
+		},
+	}
+	provider := &api.ProviderResource{
+		Resource: api.Resource{ID: "provider-1"},
+		ProviderConfig: api.ProviderConfig{
+			Runtime: &api.Runtime{K8s: &api.K8sRuntime{Image: "adapter:latest"}},
+		},
+	}
+
+	cfg, err := buildJobConfig(evaluation, provider, &evaluation.Benchmarks[0], 0, nil, nil)
+	if err != nil {
+		t.Fatalf("buildJobConfig: %v", err)
+	}
+
+	// modelTargetURL must hold the real upstream URL for the sidecar proxy config.
+	wantTargetURL := "http://llm-inference.apps.example.com/llm/llama-3-1-8b-instruct/v1"
+	if cfg.modelTargetURL != wantTargetURL {
+		t.Errorf("modelTargetURL = %q, want %q (real upstream)", cfg.modelTargetURL, wantTargetURL)
+	}
+
+	// sidecarBaseURL is plain localhost — the runtime rewrites model.url using this + model path.
+	if cfg.sidecarBaseURL != "http://localhost:8080" {
+		t.Errorf("sidecarBaseURL = %q, want http://localhost:8080", cfg.sidecarBaseURL)
+	}
+}
+
 func intPtr(value int) *int {
 	return &value
 }

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
@@ -220,7 +221,14 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 	// Always redirect the adapter through the sidecar model proxy so all model traffic
 	// (open and authenticated) flows through the sidecar. This gives a single forwarding
 	// path and allows SA token injection for models that need it.
-	jobConfig.jobSpec.Model.URL = jobConfig.sidecarBaseURL
+	// Redirect the adapter to the sidecar, preserving the full path from the user's model URL.
+	// The sidecar Rewrite function swaps only scheme+host from its configured target, so
+	// whatever path the adapter sends is forwarded verbatim to the real upstream model host.
+	rewrittenModelURL, err := rewriteModelURLForSidecar(jobConfig.sidecarBaseURL, jobConfig.modelTargetURL)
+	if err != nil {
+		return fmt.Errorf("job %s benchmark %s: rewriting model URL for sidecar: %w", evaluation.Resource.ID, benchmarkID, err)
+	}
+	jobConfig.jobSpec.Model.URL = rewrittenModelURL
 
 	var secretInfo modelSecretInfo
 	if jobConfig.modelAuthSecretRef != "" {
@@ -369,4 +377,32 @@ func buildBenchmarkFailureStatus(benchmark *api.EvaluationBenchmarkConfig, bench
 
 func (r *K8sRuntime) Name() string {
 	return "kubernetes"
+}
+
+// rewriteModelURLForSidecar returns a URL with the scheme and host of sidecarBaseURL
+// but the path (and any query/fragment) of modelURL. This lets the adapter call the
+// sidecar at localhost while preserving the full path prefix from the user's model URL
+// (e.g. /llm/llama-3-1-8b-instruct/v1 for a KServe Gateway API ingress route).
+// The sidecar Rewrite function forwards the incoming path verbatim to the real model
+// host (it only swaps scheme+host), so the full path is preserved end-to-end.
+func rewriteModelURLForSidecar(sidecarBaseURL, modelURL string) (string, error) {
+	sidecar, err := url.Parse(strings.TrimSuffix(sidecarBaseURL, "/"))
+	if err != nil {
+		return "", fmt.Errorf("invalid sidecar base URL %q: %w", sidecarBaseURL, err)
+	}
+	if sidecar.Host == "" {
+		return "", fmt.Errorf("invalid sidecar base URL %q: missing host", sidecarBaseURL)
+	}
+	model, err := url.Parse(strings.TrimSuffix(modelURL, "/"))
+	if err != nil {
+		return "", fmt.Errorf("invalid model URL %q: %w", modelURL, err)
+	}
+	out := &url.URL{
+		Scheme:   sidecar.Scheme,
+		Host:     sidecar.Host,
+		Path:     model.Path,
+		RawQuery: model.RawQuery,
+		Fragment: model.Fragment,
+	}
+	return out.String(), nil
 }


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

**Current behavior (before the fix)**
When a user sets the model URL to `https://gateway-host/llm/llama-3-1-8b-instruct/v1` in an eval job request:
1. buildJobConfig() stores that as modelTargetURL and sets sidecarBaseURL = http://localhost:8080.
2. k8s_runtime.go then sets jobSpec.Model.URL = sidecarBaseURL, so the adapter receives http://localhost:8080 as the model base URL.
3. The adapter appends /v1/completions → http://localhost:8080/v1/completions.
4. The sidecar receives POST /v1/completions and its Rewrite function swaps only the host → forwards to https://gateway-host/v1/completions.
5. The gateway returns 404 — there is no route at /v1/completions. The valid route is /llm/llama-3-1-8b-instruct/v1/completions. The /llm/llama-3-1-8b-instruct prefix was dropped in step 2.

Root cause: jobSpec.Model.URL was set to the bare sidecar host, discarding the path from the user's model URL. The sidecar only rewrites the host — it cannot reconstruct a path it never received.

The fix preserves the user's path by rewriting modelTargetURL against sidecarBaseURL instead of replacing it entirely.

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

With the fix:
```
cat job.json 
{
  "id": "07d998aa-7e5b-463f-997f-af0ceea06682",
  "provider_id": "lm_evaluation_harness",
  "benchmark_id": "arc_easy",
  "benchmark_index": 0,
  "model": {
    "url": "http://localhost:8080/llm/llama-3-1-8b-instruct/v1",
    "name": "meta-llama/Llama-3.1-8B-Instruct",
    "auth": {
      "secret_ref": "vllm-api-key"
    }
  },
  "num_examples": 10,
  "parameters": {
    "limit": 5,
    "num_fewshot": 3,
    "tokenizer": "google/flan-t5-small"
  },
  "experiment_name": "my-test-experiment",
  "tags": [
    {
      "key": "environment",
      "value": "test"
    }
  ],
  "callback_url": "http://localhost:8080"
}
```
Logs show the model calls are successful now:
```
{"level":"info","ts":"2026-07-10T11:19:14.176Z","caller":"handlers/model.go:44","msg":"Model proxy enabled","url":"http://llm-inference.apps.rhoai-test-pool-t5gtx.aws.rh-ods.com/llm/llama-3-1-8b-instruct/v1"}
{"level":"info","ts":"2026-07-10T11:19:14.176Z","caller":"server/server.go:121","msg":"Sidecar server starting","port":8080}
{"level":"info","ts":"2026-07-10T11:19:36.490Z","caller":"proxy/model_proxy.go:130","msg":"Proxying model request","request_id":"6b280f27-a407-4f58-aeeb-1679b1f687b9","method":"POST","url":"http://llm-inference.apps.rhoai-test-pool-t5gtx.aws.rh-ods.com/llm/llama-3-1-8b-instruct/v1/completions","headers":{"Accept":["*/*"],"Accept-Encoding":["gzip, deflate"],"Authorization":["Bearer ***"],"Content-Length":["280"],"Content-Type":["application/json"],"User-Agent":["python-requests/2.32.5"],"X-Global-Transaction-Id":["6b280f27-a407-4f58-aeeb-1679b1f687b9"]}}
{"level":"info","ts":"2026-07-10T11:19:36.684Z","caller":"proxy/model_proxy.go:135","msg":"Response from model proxy","request_id":"6b280f27-a407-4f58-aeeb-1679b1f687b9","method":"POST","url":"http://llm-inference.apps.rhoai-test-pool-t5gtx.aws.rh-ods.com/llm/llama-3-1-8b-instruct/v1/completions","status":200}
```


## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model request routing through the sidecar while preserving the original URL’s path, query parameters, and fragments.
  * Added validation with clearer error handling when model or sidecar URLs are invalid or missing required components.

* **Tests**
  * Added coverage for URL rewriting across common formats, ports, paths (including deep prefixes), and trailing slashes.
  * Confirmed the original upstream model URL is retained while sidecar routing is configured separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->