### PR TITLE
feat(providers): add deepeval provider configuration

### DIFF
--- a/config/providers/deepeval.yaml
+++ b/config/providers/deepeval.yaml
@@ -1,0 +1,110 @@
+id: deepeval
+name: DeepEval
+title: DeepEval
+description: LLM-as-judge evaluation framework with metrics for faithfulness, relevancy, hallucination, correctness, and summarization
+runtime:
+  k8s:
+    image: quay.io/evalhub/community-deepeval:latest
+    image_pull_policy: always
+    entrypoint:
+      - python
+      - main.py
+    cpu_request: 100m
+    memory_request: 256Mi
+    cpu_limit: 500m
+    memory_limit: 1Gi
+  local: null
+
+benchmarks:
+  - id: deepeval-faithfulness
+    name: Faithfulness
+    description: >
+      Tests if LLM output is faithful to the provided context. Measures whether
+      claims in the output are supported by the retrieval context.
+    category: rag-evaluation
+    metrics:
+      - faithfulness_score
+      - claims_count
+      - supported_claims_count
+    tags:
+      - deepeval
+      - rag
+      - faithfulness
+    primary_score:
+      metric: faithfulness_score
+      lower_is_better: false
+    pass_criteria:
+      threshold: 0.5
+
+  - id: deepeval-relevancy
+    name: Answer Relevancy
+    description: >
+      Tests if LLM output is relevant to the input query. Evaluates whether the
+      generated answer addresses the user's question.
+    category: rag-evaluation
+    metrics:
+      - relevancy_score
+    tags:
+      - deepeval
+      - rag
+      - relevancy
+    primary_score:
+      metric: relevancy_score
+      lower_is_better: false
+    pass_criteria:
+      threshold: 0.5
+
+  - id: deepeval-hallucination
+    name: Hallucination
+    description: >
+      Tests for hallucinated content in LLM output. Detects statements that are
+      not grounded in the provided context.
+    category: safety
+    metrics:
+      - hallucination_score
+      - hallucination_detected
+    tags:
+      - deepeval
+      - safety
+      - hallucination
+    primary_score:
+      metric: hallucination_score
+      lower_is_better: true
+    pass_criteria:
+      threshold: 0.3
+
+  - id: deepeval-correctness
+    name: Correctness
+    description: >
+      Tests factual correctness of LLM answers against expected output.
+      Compares generated answers to ground-truth references.
+    category: accuracy
+    metrics:
+      - correctness_score
+    tags:
+      - deepeval
+      - accuracy
+      - correctness
+    primary_score:
+      metric: correctness_score
+      lower_is_better: false
+    pass_criteria:
+      threshold: 0.5
+
+  - id: deepeval-summarization
+    name: Summarization
+    description: >
+      Tests summarization quality of LLM output. Evaluates alignment with
+      the source text and coverage of key information.
+    category: nlp
+    metrics:
+      - summarization_score
+    tags:
+      - deepeval
+      - nlp
+      - summarization
+    primary_score:
+      metric: summarization_score
+      lower_is_better: false
+    pass_criteria:
+      threshold: 0.5


### PR DESCRIPTION
## What and why

Moves the DeepEval provider definition from [eval-hub-contrib](https://github.com/eval-hub/eval-hub-contrib/tree/main/adapters/deepeval) into eval-hub as a first-class built-in provider, so it is discovered and served alongside the other providers without requiring any external sync.

The YAML has been adapted to the canonical provider format:

- Added `title` field (required by `ProviderConfig`)
- Fixed `image_pull_policy` casing (`Always` → `always`, per schema validation)
- Removed contrib-specific fields not present in the schema (`type: builtin`, `parameters`)
- Added `primary_score` and `pass_criteria` to all five benchmarks, following the pattern of ragas and garak

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tested manually — `go run ./cmd/validate_configs/...` loads `deepeval` cleanly alongside all existing providers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeepEval evaluation support with configurable Kubernetes runtime settings.
  * Introduced benchmark definitions for Faithfulness, Answer Relevancy, Hallucination, Correctness, and Summarization.
  * Added scoring criteria and pass thresholds for each benchmark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->