### PR TITLE
fix(test): use testhelpers.NewValidator to match updated signature

### DIFF
--- a/internal/eval_hub/handlers/evaluations_test.go
+++ b/internal/eval_hub/handlers/evaluations_test.go
@@ -306,7 +306,7 @@ func TestHandleCreateEvaluationMarksFailedWhenRuntimeErrors(t *testing.T) {
 	// note that the fake storage only implements the functions that are used in this test
 	storage := &fakeStorage{providerConfigs: providerConfigs}
 	runtime := &fakeRuntime{err: errors.New("runtime failed")}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 
 	h := handlers.New(storage, validate, runtime, nil, nil)
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "test-user", "")
@@ -351,7 +351,7 @@ func TestHandleCreateEvaluationSucceedsWhenRuntimeOk(t *testing.T) {
 	}
 	storage := &fakeStorage{providerConfigs: providerConfigs}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-2", logger, "test-user", "test-tenant")
 
@@ -386,7 +386,7 @@ func TestHandleCancelEvaluationWithSoftDeleteDoesNotCleanupResources(t *testing.
 		},
 	}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-3", logger, "test-user", "test-tenant")
 
@@ -428,7 +428,7 @@ func TestHandleDeleteEvaluationCleansUpResources(t *testing.T) {
 		},
 	}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-4", logger, "test-user", "test-tenant")
 
@@ -457,7 +457,7 @@ func TestHandleCreateEvaluationRejectsMissingBenchmarkID(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	storage := &fakeStorage{}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 
 	req := &bodyRequest{
@@ -482,7 +482,7 @@ func TestHandleCreateEvaluationRejectsMissingBenchmarks(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	storage := &fakeStorage{}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 
 	index := 1
@@ -517,7 +517,7 @@ func TestHandleCreateEvaluationRejectsMissingProviderID(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	storage := &fakeStorage{}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 
 	req := &bodyRequest{
@@ -552,7 +552,7 @@ func TestHandleCreateEvaluationRejectsInvalidProviderID(t *testing.T) {
 	}
 	storage := &fakeStorage{providerConfigs: providerConfigs}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-invalid-provider", logger, "test-user", "test-tenant")
 
@@ -584,7 +584,7 @@ func TestHandleCreateEvaluationRejectsInvalidBenchmarkID(t *testing.T) {
 	}
 	storage := &fakeStorage{providerConfigs: providerConfigs}
 	runtime := &fakeRuntime{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	h := handlers.New(storage, validate, runtime, nil, nil)
 	ctx := executioncontext.NewExecutionContext(context.Background(), "req-invalid-benchmark", logger, "test-user", "test-tenant")
 
@@ -613,7 +613,7 @@ func TestHandleListEvaluations(t *testing.T) {
 			},
 		},
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -654,7 +654,7 @@ func TestHandleGetEvaluation(t *testing.T) {
 			},
 		},
 	}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -682,7 +682,7 @@ func TestHandleGetEvaluation(t *testing.T) {
 
 func TestHandleGetEvaluation_MissingPathParam(t *testing.T) {
 	storage := &fakeStorage{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -720,7 +720,7 @@ func TestHandleUpdateEvaluation(t *testing.T) {
 			},
 		},
 	}}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -814,7 +814,7 @@ func TestHandleUpdateEvaluationAcceptsValidPhase(t *testing.T) {
 func TestHandleUpdateEvaluationStampsRuntimeMessageOrigins(t *testing.T) {
 	t.Parallel()
 	storage := &updateEvaluationStorage{fakeStorage: &fakeStorage{}}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 

--- a/internal/eval_hub/handlers/providers_test.go
+++ b/internal/eval_hub/handlers/providers_test.go
@@ -163,7 +163,7 @@ func TestHandleListProviders_ReturnsSystemProviders(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	var storage abstractions.Storage = &fakeStorage{providerConfigs: providerConfigs}
 	storage = storage.WithTenant(api.Tenant("test-tenant"))
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	req := &providersRequest{
 		MockRequest: createMockRequest("GET", "/api/v1/evaluations/providers"),
@@ -213,7 +213,7 @@ func TestHandleListProviders_AppliesPaginationWhenLimitLessThanSystemProviders(t
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	req := &providersRequest{
 		MockRequest: createMockRequest("GET", "/api/v1/evaluations/providers"),
@@ -263,7 +263,7 @@ func TestHandleListProviders_FilterSystemProvidersWithCommaAndPipe(t *testing.T)
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	tests := []struct {
 		name            string
@@ -350,7 +350,7 @@ func TestHandleListProviders_ExcludesSystemProvidersWhenParamFalse(t *testing.T)
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	req := &providersRequest{
 		MockRequest: createMockRequest("GET", "/api/v1/evaluations/providers"),
@@ -389,7 +389,7 @@ func TestHandleListProviders_ExcludesBenchmarksWhenParamFalse(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	req := &providersRequest{
 		MockRequest: createMockRequest("GET", "/api/v1/evaluations/providers"),
@@ -428,7 +428,7 @@ func TestHandleListProviders_ReturnsUserProvidersFromStorage(t *testing.T) {
 		providers:   []api.ProviderResource{userProvider},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	req := &providersRequest{
 		MockRequest: createMockRequest("GET", "/api/v1/evaluations/providers"),
@@ -468,7 +468,7 @@ func TestHandleListProviders_ReturnsErrorWhenStorageFails(t *testing.T) {
 		err:         fmt.Errorf("storage unavailable"),
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	req := &providersRequest{
 		MockRequest: createMockRequest("GET", "/api/v1/evaluations/providers"),
@@ -488,7 +488,7 @@ func TestHandleListProviders_ReturnsErrorWhenStorageFails(t *testing.T) {
 
 func TestHandleListProviders_Returns400WhenInvalidLimit(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(&fakeStorage{}, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{}, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	req := &providersRequest{
 		MockRequest: createMockRequest("GET", "/api/v1/evaluations/providers"),
@@ -518,7 +518,7 @@ func TestHandleListProvidersReturnsEmptyForInvalidProviderID(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	req := &providersRequest{
 		MockRequest: createMockRequest("GET", "/api/v1/evaluations/providers/unknown"),
@@ -553,7 +553,7 @@ func TestHandleUpdateProvider(t *testing.T) {
 	}
 	// providerConfigs empty so getSystemProvider returns nil
 	logger := logging.FallbackLogger() // slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	body := `{"name":"Updated Name","description":"Updated desc","benchmarks":[]}`
 	req := &providersRequest{
@@ -591,7 +591,7 @@ func TestHandleUpdateProviderRejectsSystemProvider(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	body := `{"name":"Hacked","description":"","benchmarks":[]}`
 	req := &providersRequest{
@@ -625,7 +625,7 @@ func TestHandlePatchProvider(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	body := `[{"op":"replace","path":"/description","value":"Patched description"}]`
 	req := &providersRequest{
@@ -664,7 +664,7 @@ func TestHandlePatchProviderRejectsImmutablePaths(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(storage, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(storage, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	immutablePaths := []string{"/resource", "/resource/id", "/resource/tenant", "/created_at", "/updated_at"}
 	for _, path := range immutablePaths {
@@ -695,7 +695,7 @@ func TestHandlePatchProviderRejectsSystemProvider(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, validation.NewValidator(), &fakeRuntime{}, nil, nil)
+	h := handlers.New(&fakeStorage{providerConfigs: providerConfigs}, testhelpers.NewValidator(t), &fakeRuntime{}, nil, nil)
 
 	body := `[{"op":"replace","path":"/name","value":"Hacked"}]`
 	req := &providersRequest{
@@ -716,7 +716,7 @@ func TestHandlePatchProviderRejectsSystemProvider(t *testing.T) {
 
 func TestHandleCreateProvider(t *testing.T) {
 	storage := &fakeStorage{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -750,7 +750,7 @@ func TestHandleCreateProvider(t *testing.T) {
 
 func TestHandleDeleteProvider(t *testing.T) {
 	storage := &fakeStorage{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 
@@ -771,7 +771,7 @@ func TestHandleDeleteProvider(t *testing.T) {
 
 func TestHandleDeleteProvider_MissingPathParam(t *testing.T) {
 	storage := &fakeStorage{}
-	validate := validation.NewValidator()
+	validate := testhelpers.NewValidator(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handlers.New(storage, validate, &fakeRuntime{}, nil, nil)
 


### PR DESCRIPTION
NewValidator was changed to return (*validator.Validate, error) in be9cd83 but test callers were not fully updated, breaking go vet. Replace all remaining validation.NewValidator() calls with the testhelpers.NewValidator(t) wrapper that handles the error.

## What and why

Fix failing ci

Closes # NA

Assisted-by: Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated evaluation and provider handler tests to use the standard test validator setup.
  * Maintained existing test coverage and assertions for evaluation and provider operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->