### PR TITLE
update schema for message_origin change

### DIFF
--- a/tests/features/schema_test.go
+++ b/tests/features/schema_test.go
@@ -18,7 +18,8 @@ func TestEvaluationJobResourceSchemaFiles(t *testing.T) {
 			"state": "pending",
 			"message": {
 				"message": "Evaluation job created",
-				"message_code": "evaluation_job_created"
+				"message_code": "evaluation_job_created",
+				"message_origin": "server"
 			}
 		},
 		"results": {},
@@ -52,7 +53,8 @@ func TestEvaluationJobResourceSchemaFiles(t *testing.T) {
 			"state": "pending",
 			"message": {
 				"message": "Evaluation job created",
-				"message_code": "evaluation_job_created"
+				"message_code": "evaluation_job_created",
+				"message_origin": "server"
 			}
 		},
 		"results": {},

--- a/tests/features/test_data/schemas/evaluation_job_resource_connected.schema.json
+++ b/tests/features/test_data/schemas/evaluation_job_resource_connected.schema.json
@@ -44,6 +44,9 @@
       },
       "description": "Benchmarks to run. Mutually exclusive with collection."
     },
+    "collection": {
+      "$ref": "#/$defs/CollectionRef"
+    },
     "pass_criteria": {
       "$ref": "#/$defs/PassCriteria"
     },
@@ -102,20 +105,7 @@
           "type": "string"
         },
         "message": {
-          "type": "object",
-          "required": [
-            "message",
-            "message_code"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "message": {
-              "type": "string"
-            },
-            "message_code": {
-              "type": "string"
-            }
-          }
+          "$ref": "#/$defs/MessageInfo"
         },
         "benchmarks": {
           "type": "array"
@@ -155,6 +145,87 @@
           "type": "object",
           "additionalProperties": true,
           "description": "Model-specific parameters."
+        },
+        "card_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Optional model card URL."
+        }
+      }
+    },
+    "MessageInfo": {
+      "type": "object",
+      "required": [
+        "message",
+        "message_code"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "message_code": {
+          "type": "string"
+        },
+        "message_origin": {
+          "type": "string",
+          "enum": [
+            "server",
+            "runtime"
+          ],
+          "description": "Origin of the status or error message."
+        }
+      }
+    },
+    "CollectionRef": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Collection identifier."
+        },
+        "benchmarks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EvaluationBenchmarkConfig"
+          },
+          "description": "Optional benchmark overrides for the collection."
+        }
+      }
+    },
+    "BenchmarkHardwareConfig": {
+      "type": "object",
+      "required": [
+        "hardware_profile_ref"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "hardware_profile_ref": {
+          "$ref": "#/$defs/HardwareProfileRef"
+        }
+      }
+    },
+    "HardwareProfileRef": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "HardwareProfile custom resource name."
+        },
+        "namespace": {
+          "type": "string",
+          "minLength": 1,
+          "description": "HardwareProfile namespace; defaults to job tenant when omitted."
         }
       }
     },
@@ -200,6 +271,9 @@
         },
         "pass_criteria": {
           "$ref": "#/$defs/PassCriteria"
+        },
+        "hardware_config": {
+          "$ref": "#/$defs/BenchmarkHardwareConfig"
         },
         "parameters": {
           "type": "object",

--- a/tests/features/test_data/schemas/evaluation_job_resource_disconnected.schema.json
+++ b/tests/features/test_data/schemas/evaluation_job_resource_disconnected.schema.json
@@ -44,6 +44,9 @@
       },
       "description": "Benchmarks to run. Mutually exclusive with collection."
     },
+    "collection": {
+      "$ref": "#/$defs/CollectionRef"
+    },
     "pass_criteria": {
       "$ref": "#/$defs/PassCriteria"
     },
@@ -102,20 +105,7 @@
           "type": "string"
         },
         "message": {
-          "type": "object",
-          "required": [
-            "message",
-            "message_code"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "message": {
-              "type": "string"
-            },
-            "message_code": {
-              "type": "string"
-            }
-          }
+          "$ref": "#/$defs/MessageInfo"
         },
         "benchmarks": {
           "type": "array"
@@ -155,6 +145,87 @@
           "type": "object",
           "additionalProperties": true,
           "description": "Model-specific parameters."
+        },
+        "card_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Optional model card URL."
+        }
+      }
+    },
+    "MessageInfo": {
+      "type": "object",
+      "required": [
+        "message",
+        "message_code"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "message_code": {
+          "type": "string"
+        },
+        "message_origin": {
+          "type": "string",
+          "enum": [
+            "server",
+            "runtime"
+          ],
+          "description": "Origin of the status or error message."
+        }
+      }
+    },
+    "CollectionRef": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Collection identifier."
+        },
+        "benchmarks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EvaluationBenchmarkConfig"
+          },
+          "description": "Optional benchmark overrides for the collection."
+        }
+      }
+    },
+    "BenchmarkHardwareConfig": {
+      "type": "object",
+      "required": [
+        "hardware_profile_ref"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "hardware_profile_ref": {
+          "$ref": "#/$defs/HardwareProfileRef"
+        }
+      }
+    },
+    "HardwareProfileRef": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "HardwareProfile custom resource name."
+        },
+        "namespace": {
+          "type": "string",
+          "minLength": 1,
+          "description": "HardwareProfile namespace; defaults to job tenant when omitted."
         }
       }
     },
@@ -201,6 +272,9 @@
         },
         "pass_criteria": {
           "$ref": "#/$defs/PassCriteria"
+        },
+        "hardware_config": {
+          "$ref": "#/$defs/BenchmarkHardwareConfig"
         },
         "parameters": {
           "type": "object",


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes #

Assisted-by: <!-- Cursor, Claude etc -->

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation job schemas now support collections as an alternative input.
  * Added optional model card links and benchmark hardware configuration details.
  * Status messages can identify whether they originated from the server or runtime.

* **Tests**
  * Expanded schema validation coverage for status message origin data in connected and disconnected responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->