### PR TITLE
fvt: update evaluation job FVT schemas for message_origin

### DIFF
--- a/tests/features/schema_test.go
+++ b/tests/features/schema_test.go
@@ -106,6 +106,39 @@ func TestEvaluationJobResourceSchemaFiles(t *testing.T) {
 			payload: disconnectedSample,
 		},
 		{
+			name:   "connected response with message_origin",
+			schema: "schemas/evaluation_job_resource_connected.schema.json",
+			payload: `{
+				"resource": {
+					"id": "00000000-0000-0000-0000-000000000001",
+					"tenant": "test-tenant",
+					"created_at": "2026-01-01T00:00:00Z",
+					"owner": "test-user"
+				},
+				"status": {
+					"state": "pending",
+					"message": {
+						"message": "Evaluation job created",
+						"message_code": "evaluation_job_created",
+						"message_origin": "server"
+					}
+				},
+				"results": {},
+				"name": "test-evaluation-job",
+				"model": {
+					"name": "test",
+					"url": "http://test.com"
+				},
+				"benchmarks": [{
+					"id": "arc_easy",
+					"provider_id": "lm_evaluation_harness",
+					"parameters": {
+						"tokenizer": "google/flan-t5-small"
+					}
+				}]
+			}`,
+		},
+		{
 			name:     "request body rejected by response schema",
 			schema:   "schemas/evaluation_job_resource_connected.schema.json",
 			payload:  requestOnlySample,

--- a/tests/features/test_data/schemas/evaluation_job_resource_connected.schema.json
+++ b/tests/features/test_data/schemas/evaluation_job_resource_connected.schema.json
@@ -114,6 +114,14 @@
             },
             "message_code": {
               "type": "string"
+            },
+            "message_origin": {
+              "type": "string",
+              "enum": [
+                "server",
+                "runtime"
+              ],
+              "description": "Origin of the status message (server or runtime adapter)."
             }
           }
         },

--- a/tests/features/test_data/schemas/evaluation_job_resource_disconnected.schema.json
+++ b/tests/features/test_data/schemas/evaluation_job_resource_disconnected.schema.json
@@ -114,6 +114,14 @@
             },
             "message_code": {
               "type": "string"
+            },
+            "message_origin": {
+              "type": "string",
+              "enum": [
+                "server",
+                "runtime"
+              ],
+              "description": "Origin of the status message (server or runtime adapter)."
             }
           }
         },


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->
- Add optional `message_origin` (`server` | `runtime`) to FVT JSON schemas for evaluation job responses
- Fixes connected-cluster FVT failure where POST `/api/v1/evaluations/jobs` responses include `status.message.message_origin`
- Update disconnected schema for consistency
- Add schema unit test covering responses with `message_origin: server`

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->
