### PR TITLE
ci: add OpenSSF Scorecard workflow and security policy

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
+        with:
+          sarif_file: scorecard-results.sarif
+          category: openssf-scorecard

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/eval-hub/eval-hub.svg)](https://pkg.go.dev/github.com/eval-hub/eval-hub)
 [![Go Report Card](https://goreportcard.com/badge/github.com/eval-hub/eval-hub)](https://goreportcard.com/report/github.com/eval-hub/eval-hub)
 [![codecov](https://codecov.io/github/eval-hub/eval-hub/graph/badge.svg?token=LHJACCNC9A)](https://codecov.io/github/eval-hub/eval-hub)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/eval-hub/eval-hub/badge)](https://scorecard.dev/viewer/?uri=github.com/eval-hub/eval-hub)
 [![TrustyAI Operator ConfigMap Sync](https://github.com/eval-hub/eval-hub/actions/workflows/check-trustyai-service-operator-configmap-sync.yml/badge.svg)](https://github.com/eval-hub/eval-hub/actions/workflows/check-trustyai-service-operator-configmap-sync.yml)
 [![license](https://img.shields.io/badge/License-Apache2.0-blue.svg?plastic)](https://github.com/eval-hub/eval-hub/blob/main/LICENSE)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied on the `main` branch and included in subsequent releases.
+Older release branches may receive backports when maintainers determine they remain supported.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Use [GitHub private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) for this repository:
+
+1. Open the repository **Security** tab.
+2. Click **Report a vulnerability**.
+3. Include affected versions, impact, and steps to reproduce where possible.
+
+Maintainers will acknowledge the report, investigate, and coordinate remediation and disclosure.
+
+## Automated Security Checks
+
+This repository runs automated security checks in CI, including:
+
+- Gosec static analysis for Go code
+- OpenSSF Scorecard for repository security posture
+
+Results may appear under the repository **Security** tab when SARIF upload is enabled.


### PR DESCRIPTION
## Summary
- Add a scheduled OpenSSF Scorecard workflow that publishes results to scorecard.dev and uploads SARIF to the GitHub Security tab.
- Add `SECURITY.md` with supported-version guidance and private vulnerability reporting instructions.
- Add an OpenSSF Scorecard badge to `README.md`.

## Test plan
- [x] Merge to `main` and confirm the Scorecard workflow runs successfully via `workflow_dispatch` or the weekly schedule.
- [ ] Verify SARIF results appear under **Security** → **Code scanning** with category `openssf-scorecard`.
- [x] Confirm the README badge links to the eval-hub Scorecard viewer page.
- [x] Enable **Private vulnerability reporting** in repository settings if not already enabled.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated OpenSSF Scorecard assessments to improve security monitoring.
  * Security findings are published to the repository’s Security tab and retained as downloadable reports.
  * Added a security policy covering supported versions and private vulnerability reporting.

* **Documentation**
  * Added an OpenSSF Scorecard status badge to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->