### PR TITLE
fix(storage): serialize concurrent evaluation job status updates

### DIFF
--- a/internal/eval_hub/storage/sql/evaluations.go
+++ b/internal/eval_hub/storage/sql/evaluations.go
@@ -58,22 +58,32 @@ func (s *sqlStorage) GetEvaluationJob(id string) (*api.EvaluationJobResource, er
 }
 
 func (s *sqlStorage) getEvaluationJobTransactional(txn *sql.Tx, id string) (*api.EvaluationJobResource, error) {
-	// Build the SELECT query
-	query := shared.EntityQuery{Resource: api.Resource{ID: id, Tenant: s.tenant}}
-	selectQuery, selectArgs, queryArgs := s.statementsFactory.CreateEvaluationGetEntityStatement(&query)
+	return s.scanEvaluationJobTransactional(txn, id, false)
+}
 
-	// Query the database
+func (s *sqlStorage) getEvaluationJobTransactionalForUpdate(txn *sql.Tx, id string) (*api.EvaluationJobResource, error) {
+	return s.scanEvaluationJobTransactional(txn, id, true)
+}
+
+func (s *sqlStorage) scanEvaluationJobTransactional(txn *sql.Tx, id string, forUpdate bool) (*api.EvaluationJobResource, error) {
+	query := shared.EntityQuery{Resource: api.Resource{ID: id, Tenant: s.tenant}}
+	var selectQuery string
+	var selectArgs, queryArgs []any
+	if forUpdate {
+		selectQuery, selectArgs, queryArgs = s.statementsFactory.CreateEvaluationGetEntityForUpdateStatement(&query)
+	} else {
+		selectQuery, selectArgs, queryArgs = s.statementsFactory.CreateEvaluationGetEntityStatement(&query)
+	}
+
 	err := s.queryRow(txn, selectQuery, selectArgs...).Scan(queryArgs...)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, se.NewServiceError(messages.ResourceNotFound, "Type", "evaluation job", "ResourceId", id)
 		}
-		// For now we differentiate between no rows found and other errors but this might be confusing
 		s.logger.Error("Failed to get evaluation job", "error", err, "id", id)
 		return nil, se.WithRollback(se.NewServiceError(messages.DatabaseOperationFailed, "Type", "evaluation job", "ResourceId", id, "Error", err.Error()))
 	}
 
-	// Unmarshal the entity JSON into EvaluationJobConfig
 	var evaluationJobEntity EvaluationJobEntity
 	err = json.Unmarshal([]byte(query.EntityJSON), &evaluationJobEntity)
 	if err != nil {
@@ -152,7 +162,7 @@ func (s *sqlStorage) UpdateEvaluationJobStatus(id string, state api.OverallState
 	s.logger.Debug("Updating evaluation job status", "id", id, "state", state, "message", message)
 	err := s.withTransaction("update evaluation job status", id, func(txn *sql.Tx) error {
 		// get the evaluation job
-		evaluationJob, err := s.getEvaluationJobTransactional(txn, id)
+		evaluationJob, err := s.getEvaluationJobTransactionalForUpdate(txn, id)
 		if err != nil {
 			return err
 		}
@@ -337,6 +347,9 @@ func (s *sqlStorage) updateBenchmarkStatus(job *api.EvaluationJobResource, runSt
 		if benchmark.ID == runStatus.BenchmarkStatusEvent.ID &&
 			benchmark.ProviderID == runStatus.BenchmarkStatusEvent.ProviderID &&
 			benchmark.BenchmarkIndex == runStatus.BenchmarkStatusEvent.BenchmarkIndex {
+			if api.IsBenchmarkTerminalState(benchmark.Status) && !api.IsBenchmarkTerminalState(benchmarkStatus.Status) {
+				return
+			}
 			job.Status.Benchmarks[index] = *benchmarkStatus
 			return
 		}
@@ -374,7 +387,7 @@ func (s *sqlStorage) UpdateEvaluationJob(id string, runStatus *api.StatusEvent) 
 	return s.withTransaction("update evaluation job", id, func(txn *sql.Tx) error {
 		s.logger.Info("Updating evaluation job", "id", id, "status", runStatus.BenchmarkStatusEvent.Status, "runStatus", runStatus)
 
-		job, err := s.getEvaluationJobTransactional(txn, id)
+		job, err := s.getEvaluationJobTransactionalForUpdate(txn, id)
 		if err != nil {
 			return err
 		}

--- a/internal/eval_hub/storage/sql/evaluations.go
+++ b/internal/eval_hub/storage/sql/evaluations.go
@@ -391,6 +391,8 @@ func (s *sqlStorage) UpdateEvaluationJob(id string, runStatus *api.StatusEvent) 
 		if err != nil {
 			return err
 		}
+		// Test hook: no-op unless a test installs a callback (see test_hooks.go).
+		invokeEvaluationJobUpdateAfterLockedReadHook(id, runStatus.BenchmarkStatusEvent.ID)
 
 		// Guard: reject benchmark updates if job is already in a terminal state.
 		// We pass OverallStateRunning as the target to leverage checkEvaluationJobState's terminal-state check.

--- a/internal/eval_hub/storage/sql/evaluations_test.go
+++ b/internal/eval_hub/storage/sql/evaluations_test.go
@@ -194,23 +194,68 @@ func testUpdateEvaluationJob_ConcurrentBenchmarkCompletions(t *testing.T, driver
 		t.Fatalf("complete truthfulqa_mc1: %v", err)
 	}
 
-	var wg sync.WaitGroup
-	errs := make(chan error, 2)
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		errs <- completeBenchmark("toxigen", 0)
-	}()
-	go func() {
-		defer wg.Done()
-		errs <- completeBenchmark("bigbench_hhh_alignment_multiple_choice", 2)
-	}()
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		if err != nil {
-			t.Fatalf("concurrent completion: %v", err)
+	// Hold the first UpdateEvaluationJob transaction after its locked read so a
+	// second update must contend on the same row (postgres FOR UPDATE). Only the
+	// first hook invocation blocks; later ones return immediately so a missing
+	// FOR UPDATE lets the second update finish and fail the contention check.
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	var holdGate sync.Mutex
+	var holdingTxn bool
+	t.Cleanup(func() {
+		sql.SetEvaluationJobUpdateAfterLockedReadHook(nil)
+		select {
+		case <-release:
+		default:
+			close(release)
 		}
+	})
+	sql.SetEvaluationJobUpdateAfterLockedReadHook(func(_, _ string) {
+		holdGate.Lock()
+		if holdingTxn {
+			holdGate.Unlock()
+			return
+		}
+		holdingTxn = true
+		holdGate.Unlock()
+		close(locked)
+		<-release
+	})
+
+	doneFirst := make(chan error, 1)
+	doneSecond := make(chan error, 1)
+	go func() {
+		doneFirst <- completeBenchmark("toxigen", 0)
+	}()
+
+	select {
+	case <-locked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first transaction to acquire row lock")
+	}
+
+	go func() {
+		doneSecond <- completeBenchmark("bigbench_hhh_alignment_multiple_choice", 2)
+	}()
+
+	if driver == "postgres" || driver == "pgx" {
+		select {
+		case err := <-doneFirst:
+			t.Fatalf("first update completed while holding row lock: %v", err)
+		case err := <-doneSecond:
+			t.Fatalf("second update completed before row lock released (FOR UPDATE not contending): %v", err)
+		case <-time.After(1 * time.Second):
+			// Expected: second txn is blocked on SELECT ... FOR UPDATE.
+		}
+	}
+
+	close(release)
+
+	if err := <-doneFirst; err != nil {
+		t.Fatalf("complete toxigen: %v", err)
+	}
+	if err := <-doneSecond; err != nil {
+		t.Fatalf("complete bigbench: %v", err)
 	}
 
 	final, err := store.GetEvaluationJob(jobID)

--- a/internal/eval_hub/storage/sql/evaluations_test.go
+++ b/internal/eval_hub/storage/sql/evaluations_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -65,6 +66,168 @@ func TestGetEvaluationJobs_Postgres(t *testing.T) {
 	testUpdateEvaluationJob_PersistsPhase(t, drivers[1], databaseName)
 	testUpdateEvaluationJob_PersistsAdditionalInfo(t, drivers[1], databaseName)
 	testEvaluationsStorage(t, drivers[1], databaseName)
+	testUpdateBenchmarkStatus_RejectsTerminalDowngrade(t, drivers[1], databaseName)
+	testUpdateEvaluationJob_ConcurrentBenchmarkCompletions(t, drivers[1], databaseName)
+}
+
+func TestUpdateBenchmarkStatus_RejectsTerminalDowngrade(t *testing.T) {
+	testUpdateBenchmarkStatus_RejectsTerminalDowngrade(t, drivers[0], getDBName())
+}
+
+func TestUpdateEvaluationJob_ConcurrentBenchmarkCompletions(t *testing.T) {
+	testUpdateEvaluationJob_ConcurrentBenchmarkCompletions(t, drivers[0], getDBName())
+}
+
+func testUpdateBenchmarkStatus_RejectsTerminalDowngrade(t *testing.T, driver string, databaseName string) {
+	store, err := getTestStorage(t, driver, databaseName)
+	if err != nil {
+		t.Fatalf("failed to create storage: %v", err)
+	}
+
+	jobID := common.GUID()
+	now := time.Now()
+	config := &api.EvaluationJobConfig{
+		Model: api.ModelRef{URL: "http://test.com", Name: "test"},
+		Benchmarks: []api.EvaluationBenchmarkConfig{
+			{Ref: api.Ref{ID: "b1"}, ProviderID: "prov1"},
+			{Ref: api.Ref{ID: "b2"}, ProviderID: "prov2"},
+		},
+	}
+	job := &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{
+			Resource: api.Resource{
+				ID:        jobID,
+				Tenant:    api.Tenant(getTenant("team-a")),
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+		Status: &api.EvaluationJobStatus{
+			EvaluationJobState: api.EvaluationJobState{State: api.OverallStateRunning},
+		},
+		EvaluationJobConfig: *config,
+	}
+	if err := store.CreateEvaluationJob(job); err != nil {
+		t.Fatalf("CreateEvaluationJob: %v", err)
+	}
+
+	if err := store.UpdateEvaluationJob(jobID, &api.StatusEvent{
+		BenchmarkStatusEvent: &api.BenchmarkStatusEvent{
+			ID: "b1", ProviderID: "prov1", BenchmarkIndex: 0,
+			Status: api.StateCompleted, CompletedAt: api.DateTimeToString(now),
+		},
+	}); err != nil {
+		t.Fatalf("UpdateEvaluationJob completed: %v", err)
+	}
+
+	if err := store.UpdateEvaluationJob(jobID, &api.StatusEvent{
+		BenchmarkStatusEvent: &api.BenchmarkStatusEvent{
+			ID: "b1", ProviderID: "prov1", BenchmarkIndex: 0,
+			Status: api.StateRunning, Phase: api.JobPhasePersistingArtifacts,
+		},
+	}); err != nil {
+		t.Fatalf("UpdateEvaluationJob running: %v", err)
+	}
+
+	final, err := store.GetEvaluationJob(jobID)
+	if err != nil {
+		t.Fatalf("GetEvaluationJob: %v", err)
+	}
+	if len(final.Status.Benchmarks) != 1 {
+		t.Fatalf("expected 1 benchmark status, got %d", len(final.Status.Benchmarks))
+	}
+	if final.Status.Benchmarks[0].ID != "b1" {
+		t.Fatalf("benchmark id = %s, want b1", final.Status.Benchmarks[0].ID)
+	}
+	if final.Status.Benchmarks[0].Status != api.StateCompleted {
+		t.Fatalf("benchmark status = %s, want completed", final.Status.Benchmarks[0].Status)
+	}
+	if final.Status.State != api.OverallStateRunning {
+		t.Fatalf("overall state = %s, want running", final.Status.State)
+	}
+}
+
+func testUpdateEvaluationJob_ConcurrentBenchmarkCompletions(t *testing.T, driver string, databaseName string) {
+	store, err := getTestStorage(t, driver, databaseName)
+	if err != nil {
+		t.Fatalf("failed to create storage: %v", err)
+	}
+
+	jobID := common.GUID()
+	now := time.Now()
+	config := &api.EvaluationJobConfig{
+		Model: api.ModelRef{URL: "http://test.com", Name: "test"},
+		Benchmarks: []api.EvaluationBenchmarkConfig{
+			{Ref: api.Ref{ID: "toxigen"}, ProviderID: "garak"},
+			{Ref: api.Ref{ID: "truthfulqa_mc1"}, ProviderID: "garak"},
+			{Ref: api.Ref{ID: "bigbench_hhh_alignment_multiple_choice"}, ProviderID: "garak"},
+		},
+	}
+	job := &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{
+			Resource: api.Resource{
+				ID:        jobID,
+				Tenant:    api.Tenant(getTenant("team-a")),
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+		Status: &api.EvaluationJobStatus{
+			EvaluationJobState: api.EvaluationJobState{State: api.OverallStateRunning},
+		},
+		EvaluationJobConfig: *config,
+	}
+	if err := store.CreateEvaluationJob(job); err != nil {
+		t.Fatalf("CreateEvaluationJob: %v", err)
+	}
+
+	completeBenchmark := func(id string, index int) error {
+		return store.UpdateEvaluationJob(jobID, &api.StatusEvent{
+			BenchmarkStatusEvent: &api.BenchmarkStatusEvent{
+				ID: id, ProviderID: "garak", BenchmarkIndex: index,
+				Status: api.StateCompleted, CompletedAt: api.DateTimeToString(now),
+			},
+		})
+	}
+
+	if err := completeBenchmark("truthfulqa_mc1", 1); err != nil {
+		t.Fatalf("complete truthfulqa_mc1: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errs <- completeBenchmark("toxigen", 0)
+	}()
+	go func() {
+		defer wg.Done()
+		errs <- completeBenchmark("bigbench_hhh_alignment_multiple_choice", 2)
+	}()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent completion: %v", err)
+		}
+	}
+
+	final, err := store.GetEvaluationJob(jobID)
+	if err != nil {
+		t.Fatalf("GetEvaluationJob: %v", err)
+	}
+	if final.Status.State != api.OverallStateCompleted {
+		t.Fatalf("overall state = %s, want completed", final.Status.State)
+	}
+	if len(final.Status.Benchmarks) != 3 {
+		t.Fatalf("expected 3 benchmark statuses, got %d", len(final.Status.Benchmarks))
+	}
+	for _, benchmark := range final.Status.Benchmarks {
+		if benchmark.Status != api.StateCompleted {
+			t.Fatalf("benchmark %s status = %s, want completed", benchmark.ID, benchmark.Status)
+		}
+	}
 }
 
 func testGetEvaluationJobs_TenantFilter(t *testing.T, driver string, databaseName string) {

--- a/internal/eval_hub/storage/sql/export_test.go
+++ b/internal/eval_hub/storage/sql/export_test.go
@@ -3,3 +3,4 @@ package sql
 var ApplyPatches = applyPatches
 var GetPassCriteriaThreshold = getPassCriteriaThreshold
 var GetIsolationLevel = getIsolationLevel
+var SetEvaluationJobUpdateAfterLockedReadHook = setEvaluationJobUpdateAfterLockedReadHook

--- a/internal/eval_hub/storage/sql/postgres/statements.go
+++ b/internal/eval_hub/storage/sql/postgres/statements.go
@@ -81,6 +81,11 @@ func (s *postgresStatementsFactory) CreateEvaluationGetEntityStatement(query *sh
 	return `SELECT id, created_at, updated_at, tenant_id, owner, status, experiment_id, entity FROM evaluations WHERE id = $1 AND tenant_id = $2;`, []any{&query.Resource.ID, query.Resource.Tenant.String()}, []any{&query.Resource.ID, &query.Resource.CreatedAt, &query.Resource.UpdatedAt, &query.Resource.Tenant, &query.Resource.Owner, &query.Status, &query.MLFlowExperimentID, &query.EntityJSON}
 }
 
+func (s *postgresStatementsFactory) CreateEvaluationGetEntityForUpdateStatement(query *shared.EntityQuery) (string, []any, []any) {
+	stmt, args, scanArgs := s.CreateEvaluationGetEntityStatement(query)
+	return strings.TrimSuffix(stmt, ";") + " FOR UPDATE;", args, scanArgs
+}
+
 // allowedFilterColumns returns the set of column/param names allowed in filter for each table.
 func (s *postgresStatementsFactory) GetAllowedFilterColumns(tableName string) []string {
 	allColumns := []string{"owner", "name", "tags"}

--- a/internal/eval_hub/storage/sql/shared/statements.go
+++ b/internal/eval_hub/storage/sql/shared/statements.go
@@ -18,6 +18,7 @@ type SQLStatementsFactory interface {
 	// evaluations operations
 	CreateEvaluationAddEntityStatement(evaluation *api.EvaluationJobResource, entity string) (string, []any)
 	CreateEvaluationGetEntityStatement(query *EntityQuery) (string, []any, []any)
+	CreateEvaluationGetEntityForUpdateStatement(query *EntityQuery) (string, []any, []any)
 
 	// collections operations
 	CreateCollectionAddEntityStatement(collection *api.CollectionResource, entity string) (string, []any)

--- a/internal/eval_hub/storage/sql/sqlite/statements.go
+++ b/internal/eval_hub/storage/sql/sqlite/statements.go
@@ -102,6 +102,11 @@ func (s *sqliteStatementsFactory) CreateEvaluationGetEntityStatement(query *shar
 	return fmt.Sprintf(`SELECT id, created_at, updated_at, tenant_id, owner, status, experiment_id, entity FROM evaluations WHERE %s;`, where), whereArgs, []any{&query.Resource.ID, &query.Resource.CreatedAt, &query.Resource.UpdatedAt, &query.Resource.Tenant, &query.Resource.Owner, &query.Status, &query.MLFlowExperimentID, &query.EntityJSON}
 }
 
+func (s *sqliteStatementsFactory) CreateEvaluationGetEntityForUpdateStatement(query *shared.EntityQuery) (string, []any, []any) {
+	// SQLite serializes writers via SetMaxOpenConns(1); FOR UPDATE is unsupported.
+	return s.CreateEvaluationGetEntityStatement(query)
+}
+
 // entityFilterCondition returns the SQL condition and args for a filter key.
 func (s *sqliteStatementsFactory) CreateEntityFilterCondition(key string, value any, index int, tableName string) (condition string, args []any) {
 	switch key {

--- a/internal/eval_hub/storage/sql/test_hooks.go
+++ b/internal/eval_hub/storage/sql/test_hooks.go
@@ -1,0 +1,23 @@
+package sql
+
+import "sync"
+
+var (
+	evaluationJobUpdateTestHookMu      sync.RWMutex
+	evaluationJobUpdateAfterLockedRead func(jobID, benchmarkID string)
+)
+
+func setEvaluationJobUpdateAfterLockedReadHook(fn func(jobID, benchmarkID string)) {
+	evaluationJobUpdateTestHookMu.Lock()
+	defer evaluationJobUpdateTestHookMu.Unlock()
+	evaluationJobUpdateAfterLockedRead = fn
+}
+
+func invokeEvaluationJobUpdateAfterLockedReadHook(jobID, benchmarkID string) {
+	evaluationJobUpdateTestHookMu.RLock()
+	fn := evaluationJobUpdateAfterLockedRead
+	evaluationJobUpdateTestHookMu.RUnlock()
+	if fn != nil {
+		fn(jobID, benchmarkID)
+	}
+}


### PR DESCRIPTION
## Summary

- Lock evaluation job rows with `SELECT FOR UPDATE` in `UpdateEvaluationJob` and `UpdateEvaluationJobStatus` to prevent write-skew when multiple replicas process near-simultaneous benchmark completion events.
- Reject terminal-to-non-terminal benchmark status downgrades (e.g. stale `running` after `completed`).
- Add regression tests for concurrent benchmark completions and terminal downgrade protection.

Fixes the race described in GitLab [atris/test-results #260 / RHOAI 3.5](https://gitlab.cee.redhat.com/atris/test-results/-/work_items/260) `evalhub-tests #130`, where jobs could remain stuck in `running` despite all benchmarks completing.

## Test plan

- [x] `go test ./internal/eval_hub/storage/sql/...`
- [x] `make fmt lint`
- [ ] Re-run `evalhub-tests` on a 2-replica EvalHub deployment with a multi-benchmark collection job


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented completed/terminal benchmarks from being downgraded by later non-terminal updates.
  * Improved coordination of evaluation/job status updates to safely handle concurrent benchmark completions using row-level locking where supported.
* **Tests**
  * Added Postgres-focused regression coverage for terminal downgrade rejection.
  * Added concurrency regression testing to ensure simultaneous benchmark completions resolve to the correct completed overall evaluation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->