### PR TITLE
test(fvt): Add PVC testcases

### DIFF
--- a/tests/features/README.md
+++ b/tests/features/README.md
@@ -93,6 +93,7 @@ When running in local server mode, the tests will:
 | `@hardware_profile` | Hardware profile API and Kubernetes Job adapter resource tests in `evaluation_jobs.feature`; require pipeline env vars (see below). |
 | `@metrics` | Prometheus `/metrics` scrape tests in `metrics.feature`; in cluster/remote mode require `METRICS_URL` (see below). |
 | `@logs` | Evaluation job log collection scenarios in `evaluation_local_jobs.feature` and `evaluation_jobs.feature` |
+| `@pvc` | Evaluation jobs that mount offline test data from a PersistentVolumeClaim (`evaluation_jobs.feature`). Defaults: claim `evalhub-offline-test-data`, `sub_path` `staging`. Override with `TEST_DATA_PVC_CLAIM_NAME` / `TEST_DATA_PVC_SUB_PATH`. Missing-PVC negative case uses `TEST_DATA_PVC_MISSING_CLAIM_NAME` (default `evalhub-offline-test-data-does-not-exist`) and waits up to 2m30s for operator failure sync. Opt in with `GODOG_TAGS="@pvc"`. |
 | `@gha-wheel-sanity` | Local-runtime wheel validation scenario run by `scripts/gha_wheel_sanity_test.sh` during GHA wheel checks |
 
 ### Metrics tests (`@metrics`)

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1268,3 +1268,68 @@ Feature: Evaluation Jobs
     And the response body should contain "Evaluation completed successfully"
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
+
+  # Requires PVC evalhub-offline-test-data in the tenant namespace with offline data under staging/
+  # (tokenizer + datasets). Override with TEST_DATA_PVC_CLAIM_NAME / TEST_DATA_PVC_SUB_PATH if needed.
+  @pvc
+  Scenario: Evaluation job with PVC test data completes successfully
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_pvc.json"
+    Then the response code should be 202
+    And the response should contain the value "evaluation_job_created" at path "$.status.message.message_code"
+    And the response should contain the value "pending" at path "$.status.state"
+    And the response should contain the value "arc_easy" at path "$.benchmarks[0].id"
+    And the response should contain the value "lm_evaluation_harness" at path "$.benchmarks[0].provider_id"
+    And the response should contain the value "/test_data/tokenizer" at path "$.benchmarks[0].parameters.tokenizer"
+    And the response should contain the value "{{env:TEST_DATA_PVC_CLAIM_NAME|evalhub-offline-test-data}}" at path "$.benchmarks[0].test_data_ref.pvc.claim_name"
+    And the response should contain the value "{{env:TEST_DATA_PVC_SUB_PATH|staging}}" at path "$.benchmarks[0].test_data_ref.pvc.sub_path"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the response should contain the value "completed" at path "$.status.state"
+    And the response should contain the value "completed" at path "$.status.benchmarks[0].status"
+    And the response should contain the value "arc_easy" at path "$.status.benchmarks[0].id"
+    And the response should contain "results"
+    And the array at path "results.benchmarks" in the response should have length 1
+    And the response should contain the value "arc_easy" at path "$.results.benchmarks[0].id"
+    And the response should contain at least the value "0.2" at path "$.results.benchmarks[0].metrics.acc"
+    And the response should contain at least the value "0.2" at path "$.results.benchmarks[0].metrics.acc_norm"
+    And the response should contain the value "{{env:TEST_DATA_PVC_CLAIM_NAME|evalhub-offline-test-data}}" at path "$.benchmarks[0].test_data_ref.pvc.claim_name"
+    And the response should contain the value "{{env:TEST_DATA_PVC_SUB_PATH|staging}}" at path "$.benchmarks[0].test_data_ref.pvc.sub_path"
+    And the response should contain the value "/test_data/tokenizer" at path "$.benchmarks[0].parameters.tokenizer"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+
+  @pvc
+  @negative
+  Scenario: Cannot create evaluation job with both PVC and S3 test data
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_pvc_and_s3.json"
+    Then the response code should be 400
+    And the response should contain the value "request_validation_failed" at path "$.message_code"
+    And the response should contain the value "s3 and pvc are mutually exclusive" at path "$.message"
+
+  # Requires trustyai-service-operator eval-job failure reconciler (unschedulable PVC → FAILED after ~2m grace).
+  # Default missing claim: evalhub-offline-test-data-does-not-exist (override with TEST_DATA_PVC_MISSING_CLAIM_NAME).
+  @pvc
+  @negative
+  Scenario: Evaluation job with missing PVC fails after scheduling grace
+    Given the service is running
+    And I set the wait deadline to "2m30s"
+    And I set the wait interval to "10s"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_pvc_missing.json"
+    Then the response code should be 202
+    And the response should contain the value "pending" at path "$.status.state"
+    And the response should contain the value "{{env:TEST_DATA_PVC_MISSING_CLAIM_NAME|evalhub-offline-test-data-does-not-exist}}" at path "$.benchmarks[0].test_data_ref.pvc.claim_name"
+    And I wait for the evaluation job status to be "failed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the response should contain the value "failed" at path "$.status.state"
+    And the response should contain the value "failed" at path "$.status.benchmarks[0].status"
+    And the response should contain the value "arc_easy" at path "$.status.benchmarks[0].id"
+    And the response should contain the value "not found" at path "$.status.message.message"
+    And the response should contain the value "{{env:TEST_DATA_PVC_MISSING_CLAIM_NAME|evalhub-offline-test-data-does-not-exist}}" at path "$.status.message.message"
+    And the response should contain the value "not found" at path "$.status.benchmarks[0].error_message.message"
+    And the response should contain the value "{{env:TEST_DATA_PVC_MISSING_CLAIM_NAME|evalhub-offline-test-data-does-not-exist}}" at path "$.status.benchmarks[0].error_message.message"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204

--- a/tests/features/jsonnet_test.go
+++ b/tests/features/jsonnet_test.go
@@ -550,6 +550,134 @@ func TestEvaluateEvaluationJobJsonnetConnected(t *testing.T) {
 	}
 }
 
+func TestEvaluateEvaluationJobPvcJsonnet(t *testing.T) {
+	tc := &scenarioConfig{
+		values: map[string]string{},
+		jsonnetHarnessEnv: map[string]string{
+			"ENVIRONMENT_ID": "connected",
+		},
+	}
+	path, err := filepath.Abs(filepath.Join(testDataRoot(), "evaluation_job_pvc.jsonnet"))
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	out, err := tc.evaluateJsonnetFile(path)
+	if err != nil {
+		t.Fatalf("evaluateJsonnetFile: %v", err)
+	}
+	t.Logf("PVC job: %s", out)
+	var job struct {
+		Name       string `json:"name"`
+		Benchmarks []struct {
+			ID          string         `json:"id"`
+			Parameters  map[string]any `json:"parameters"`
+			TestDataRef struct {
+				PVC struct {
+					ClaimName string `json:"claim_name"`
+					SubPath   string `json:"sub_path"`
+				} `json:"pvc"`
+			} `json:"test_data_ref"`
+		} `json:"benchmarks"`
+	}
+	if err := json.Unmarshal([]byte(out), &job); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if job.Name != "test-evaluation-job-pvc" {
+		t.Errorf("name = %q, want test-evaluation-job-pvc", job.Name)
+	}
+	if len(job.Benchmarks) != 1 {
+		t.Fatalf("benchmarks = %#v, want one benchmark", job.Benchmarks)
+	}
+	b := job.Benchmarks[0]
+	if b.ID != "arc_easy" {
+		t.Errorf("benchmark id = %q, want arc_easy", b.ID)
+	}
+	if b.Parameters["tokenizer"] != "/test_data/tokenizer" {
+		t.Errorf("tokenizer = %v, want /test_data/tokenizer", b.Parameters["tokenizer"])
+	}
+	if b.TestDataRef.PVC.ClaimName != "evalhub-offline-test-data" {
+		t.Errorf("claim_name = %q, want evalhub-offline-test-data", b.TestDataRef.PVC.ClaimName)
+	}
+	if b.TestDataRef.PVC.SubPath != "staging" {
+		t.Errorf("sub_path = %q, want staging", b.TestDataRef.PVC.SubPath)
+	}
+}
+
+func TestEvaluateEvaluationJobPvcAndS3Jsonnet(t *testing.T) {
+	tc := &scenarioConfig{
+		values:            map[string]string{},
+		jsonnetHarnessEnv: map[string]string{},
+	}
+	path, err := filepath.Abs(filepath.Join(testDataRoot(), "evaluation_job_pvc_and_s3.jsonnet"))
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	out, err := tc.evaluateJsonnetFile(path)
+	if err != nil {
+		t.Fatalf("evaluateJsonnetFile: %v", err)
+	}
+	var job struct {
+		Benchmarks []struct {
+			TestDataRef struct {
+				PVC *struct {
+					ClaimName string `json:"claim_name"`
+				} `json:"pvc"`
+				S3 *struct {
+					Bucket string `json:"bucket"`
+				} `json:"s3"`
+			} `json:"test_data_ref"`
+		} `json:"benchmarks"`
+	}
+	if err := json.Unmarshal([]byte(out), &job); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(job.Benchmarks) != 1 {
+		t.Fatalf("benchmarks = %#v, want one", job.Benchmarks)
+	}
+	ref := job.Benchmarks[0].TestDataRef
+	if ref.PVC == nil || ref.S3 == nil {
+		t.Fatalf("test_data_ref = %+v, want both pvc and s3 set for negative payload", ref)
+	}
+}
+
+func TestEvaluateEvaluationJobPvcMissingJsonnet(t *testing.T) {
+	tc := &scenarioConfig{
+		values:            map[string]string{},
+		jsonnetHarnessEnv: map[string]string{},
+	}
+	path, err := filepath.Abs(filepath.Join(testDataRoot(), "evaluation_job_pvc_missing.jsonnet"))
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	out, err := tc.evaluateJsonnetFile(path)
+	if err != nil {
+		t.Fatalf("evaluateJsonnetFile: %v", err)
+	}
+	var job struct {
+		Benchmarks []struct {
+			TestDataRef struct {
+				PVC struct {
+					ClaimName string `json:"claim_name"`
+					SubPath   string `json:"sub_path"`
+				} `json:"pvc"`
+			} `json:"test_data_ref"`
+		} `json:"benchmarks"`
+	}
+	if err := json.Unmarshal([]byte(out), &job); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(job.Benchmarks) != 1 {
+		t.Fatalf("benchmarks = %#v, want one", job.Benchmarks)
+	}
+	pvc := job.Benchmarks[0].TestDataRef.PVC
+	if pvc.ClaimName != "evalhub-offline-test-data-does-not-exist" {
+		t.Errorf("claim_name = %q, want evalhub-offline-test-data-does-not-exist", pvc.ClaimName)
+	}
+	if pvc.SubPath != "" {
+		t.Errorf("sub_path = %q, want empty", pvc.SubPath)
+	}
+}
+
 func TestEvaluateEvaluationJobJsonnetWithQueue(t *testing.T) {
 	queueJobJson := `
 	{

--- a/tests/features/test_data/evaluation_job_pvc.jsonnet
+++ b/tests/features/test_data/evaluation_job_pvc.jsonnet
@@ -1,0 +1,14 @@
+local test = import 'test.libsonnet';
+
+test.mergeOptional(
+  test.mergeOptional(
+    {
+      model: test.model(),
+      name: 'test-evaluation-job-pvc',
+      benchmarks: [test.pvcArcEasyBenchmark()],
+      tags: ['environment', 'pvc'],
+    },
+    test.experiment('my-test-experiment'),
+  ),
+  test.queue(),
+)

--- a/tests/features/test_data/evaluation_job_pvc_and_s3.jsonnet
+++ b/tests/features/test_data/evaluation_job_pvc_and_s3.jsonnet
@@ -1,0 +1,28 @@
+local test = import 'test.libsonnet';
+
+{
+  model: test.model(),
+  name: 'test-evaluation-job-pvc-and-s3',
+  benchmarks: [
+    {
+      id: 'arc_easy',
+      provider_id: 'lm_evaluation_harness',
+      parameters: {
+        tokenizer: '/test_data/tokenizer',
+        num_examples: 10,
+        limit: 5,
+      },
+      test_data_ref: {
+        pvc: {
+          claim_name: test.env('TEST_DATA_PVC_CLAIM_NAME', 'evalhub-offline-test-data'),
+          sub_path: test.env('TEST_DATA_PVC_SUB_PATH', 'staging'),
+        },
+        s3: {
+          bucket: test.env('TEST_DATA_S3_BUCKET', 'mlpipeline'),
+          key: test.env('TEST_DATA_S3_KEY', 'offline'),
+          secret_ref: test.env('TEST_DATA_S3_SECRET_REF', 'minio-test'),
+        },
+      },
+    },
+  ],
+}

--- a/tests/features/test_data/evaluation_job_pvc_missing.jsonnet
+++ b/tests/features/test_data/evaluation_job_pvc_missing.jsonnet
@@ -1,0 +1,30 @@
+local test = import 'test.libsonnet';
+
+// Non-existent PVC — job should fail after operator scheduling grace (~2m).
+test.mergeOptional(
+  test.mergeOptional(
+    {
+      model: test.model(),
+      name: 'test-evaluation-job-pvc-missing',
+      benchmarks: [
+        {
+          id: 'arc_easy',
+          provider_id: 'lm_evaluation_harness',
+          parameters: {
+            tokenizer: '/test_data/tokenizer',
+            num_examples: 5,
+            limit: 5,
+          },
+          test_data_ref: {
+            pvc: {
+              claim_name: test.env('TEST_DATA_PVC_MISSING_CLAIM_NAME', 'evalhub-offline-test-data-does-not-exist'),
+            },
+          },
+        },
+      ],
+      tags: ['environment', 'pvc', 'negative'],
+    },
+    test.experiment('my-test-experiment'),
+  ),
+  test.queue(),
+)

--- a/tests/features/test_data/jsonnet/test.libsonnet
+++ b/tests/features/test_data/jsonnet/test.libsonnet
@@ -39,6 +39,15 @@ local harness = std.parseJson(std.extVar('harness'));
       },
     },
 
+  // PVC test data reference (mounts claim read-only at /test_data).
+  pvcTestDataRef()::
+    {
+      pvc: {
+        claim_name: $.env('TEST_DATA_PVC_CLAIM_NAME', 'evalhub-offline-test-data'),
+        sub_path: $.env('TEST_DATA_PVC_SUB_PATH', 'staging'),
+      },
+    },
+
   // Evaluation/collection benchmark with disconnected-aware tokenizer and optional test_data_ref.
   benchmark(id, providerId, parameters)::
     local base = {
@@ -50,9 +59,28 @@ local harness = std.parseJson(std.extVar('harness'));
     };
     if harness.disconnected then base + { test_data_ref: $.testDataRef() } else base,
 
+  // Benchmark that always mounts offline data from a PVC (tokenizer under /test_data).
+  pvcBenchmark(id, providerId, parameters)::
+    {
+      id: id,
+      provider_id: providerId,
+      parameters: {
+        tokenizer: '/test_data/tokenizer',
+      } + parameters,
+      test_data_ref: $.pvcTestDataRef(),
+    },
+
   // arc_easy benchmark with common FVT defaults; extra parameters override or extend.
   arcEasyBenchmark(parameters={})::
     $.benchmark('arc_easy', 'lm_evaluation_harness', {
+      num_examples: 10,
+      num_fewshot: 3,
+      limit: 5,
+    } + parameters),
+
+  // arc_easy with PVC offline test data (claim_name + staging sub_path by default).
+  pvcArcEasyBenchmark(parameters={})::
+    $.pvcBenchmark('arc_easy', 'lm_evaluation_harness', {
       num_examples: 10,
       num_fewshot: 3,
       limit: 5,


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coverage for evaluation jobs using offline test data from Kubernetes persistent volumes (PVCs).
  * Added validation for conflicting PVC and S3 test-data sources.
  * Added handling and verification for missing PVC claims, including failure reporting and cleanup.

* **Documentation**
  * Documented PVC evaluation-job test scenarios, configuration variables, and test-tag usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->