### PR TITLE
ci: add dependency review and tighten workflow token permissions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,2 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 tone_instructions: "Use conventional commit format for all commit messages"
-
-remote_config:
-  repository: "openshift/coderabbit"
-  ref: "main"
-  path: ".coderabbit.yaml"

--- a/.github/workflows/ci-python-mcp.yml
+++ b/.github/workflows/ci-python-mcp.yml
@@ -12,6 +12,9 @@ on:
       - 'Makefile'
       - '.github/workflows/ci-python-mcp.yml'
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   test-mcp-wheel:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-python-server.yml
+++ b/.github/workflows/ci-python-server.yml
@@ -12,6 +12,9 @@ on:
       - 'Makefile'
       - '.github/workflows/ci-python-server.yml'
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   test-server-wheel:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   quality-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,7 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/publish-python-mcp.yml
+++ b/.github/workflows/publish-python-mcp.yml
@@ -16,6 +16,9 @@ on:
         type: boolean
         default: true
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   build-mcp-binaries:
     name: Build MCP Go binaries

--- a/.github/workflows/publish-python-server.yml
+++ b/.github/workflows/publish-python-server.yml
@@ -16,6 +16,9 @@ on:
         type: boolean
         default: true
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   build-binaries:
     name: Build Go binaries

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -5,11 +5,13 @@ on:
     tags: [ 'v*' ]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## What and why

Hardens CI/CD supply-chain posture based on StepSecurity / OpenSSF Scorecard findings:

- https://app.stepsecurity.io/securerepo
- Scorecard Token-Permissions alerts (e.g. https://github.com/eval-hub/eval-hub/security/code-scanning/89)

### Dependency Review

- Add `.github/workflows/dependency-review.yml` to scan dependency manifests on pull requests for known-vulnerable package versions (can block merges when configured as a required check).
- Harden the runner (egress audit) and check out with `persist-credentials: false`, matching other workflows.

### GITHUB_TOKEN least privilege

- Set top-level `contents: read` on workflows that were missing permissions: `ci.yml`, `ci-python-mcp.yml`, `ci-python-server.yml`, `commitlint.yml`, `publish-python-mcp.yml`, `publish-python-server.yml`.
- In `release-mcp.yml`, move `contents: write` from the workflow level to the `build-release` job that creates the GitHub release.

### CodeRabbit config

- Remove invalid/unused `remote` configuration from `.coderabbit.yaml`.

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually — YAML structure reviewed; workflow permission patterns match existing secure workflows (`ci-mcp.yml`, `scorecard.yml`, etc.)
