### PR TITLE
fix(health): add /healthz probe endpoint and gate /api/v1/health

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,8 +217,10 @@ When running locally:
 
 Cluster traffic reaches eval-hub through **kube-rbac-proxy**, which handles Bearer token authentication and RBAC authorization. Forwarded requests include:
 
-- **`X-Tenant`** — tenant namespace; required on evaluation API routes in cluster mode only
+- **`X-Tenant`** — tenant namespace; required on evaluation API routes and detailed `/api/v1/health` in cluster mode only
 - **`X-User`** — authenticated caller identity; required in cluster mode; used for resource ownership
+
+**`GET /healthz`** is unauthenticated and returns only `{"status":"healthy"}` for kubelet probes (no build/version details). It does not require identity headers.
 
 eval-hub does not perform in-process TokenReview/SAR; it trusts these headers from the proxy and applies tenant/user scoping in storage and handlers.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,7 +45,7 @@ Domain types are largely **`pkg/api`** structs; errors to clients are shaped via
 
 Evaluation handlers take **`ExecutionContext`** (not raw `*http.Request` alone): request ID, tenant, user, logger, cancelable context, and service config. That keeps logging fields consistent and avoids threading globals. Basic routes (health, OpenAPI) may use plain `http` handlers.
 
-In cluster deployments, **kube-rbac-proxy** performs authentication and authorization, then forwards API requests to eval-hub with **`X-Tenant`** (namespace) and **`X-User`** (authenticated identity). eval-hub requires both headers on evaluation API routes in cluster mode; **local mode** (`--local`) does not require them. eval-hub does not validate Bearer tokens itself.
+In cluster deployments, **kube-rbac-proxy** performs authentication and authorization, then forwards API requests to eval-hub with **`X-Tenant`** (namespace) and **`X-User`** (authenticated identity). eval-hub requires both headers on evaluation API routes and on detailed **`GET /api/v1/health`** in cluster mode; **local mode** (`--local`) does not require them. **`GET /healthz`** is unauthenticated (status only) for kubelet probes and must not go through the proxy for auth. eval-hub does not validate Bearer tokens itself.
 
 ---
 

--- a/OTEL.md
+++ b/OTEL.md
@@ -89,6 +89,7 @@ Every API route registered via `server.handle()` is wrapped with `otelhttp.NewHa
 
 Routes **without** child handler spans (otelhttp parent span only):
 
+- `/healthz`
 - `/api/v1/health`
 - OpenAPI and docs routes
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ exclude (
 The API is available at `http://localhost:8080`. Verify it is running:
 
 ```bash
+curl http://localhost:8080/healthz
 curl http://localhost:8080/api/v1/health
 ```
 
@@ -156,7 +157,8 @@ All endpoints are versioned under `/api/v1`. Full specification at [eval-hub.git
 | `/api/v1/evaluations/providers` | GET, POST | List or create providers |
 | `/api/v1/evaluations/providers/{id}` | GET, PUT, PATCH, DELETE | Manage a provider |
 | `/api/v1/evaluations/jobs/{id}/events` | POST | Submit job events |
-| `/api/v1/health` | GET | Health check |
+| `/healthz` | GET | Probe health check (status only; for kubelet) |
+| `/api/v1/health` | GET | Detailed health check (requires identity headers in cluster mode) |
 | `/metrics` | GET | Prometheus metrics |
 
 Detailed API documentation: [eval-hub.github.io/eval-hub](https://eval-hub.github.io/eval-hub/)

--- a/internal/eval_hub/config/config.go
+++ b/internal/eval_hub/config/config.go
@@ -45,9 +45,9 @@ func (c *Config) IsPrometheusEnabled() bool {
 	return (c != nil) && (c.Prometheus != nil) && c.Prometheus.Enabled
 }
 
-// RequiresIdentityHeaders reports whether evaluation API routes require X-Tenant and X-User.
-// Cluster mode (not --local): kube-rbac-proxy sets these headers. Local mode does not require
-// or enforce them.
+// RequiresIdentityHeaders reports whether evaluation API routes and detailed /api/v1/health
+// require X-Tenant and X-User. Cluster mode (not --local): kube-rbac-proxy sets these headers.
+// Local mode does not require or enforce them. /healthz never requires identity headers.
 func (c *Config) RequiresIdentityHeaders() bool {
 	return (c != nil) && (c.Service != nil) && !c.Service.LocalMode
 }

--- a/internal/eval_hub/handlers/health.go
+++ b/internal/eval_hub/handlers/health.go
@@ -22,6 +22,11 @@ type HealthResponse struct {
 	GitHash   string    `json:"git_hash,omitempty"`
 }
 
+// HealthzResponse is the minimal payload for kubelet probes (no version/build details).
+type HealthzResponse struct {
+	Status string `json:"status"`
+}
+
 func (h *Handlers) HandleHealth(ctx *executioncontext.ExecutionContext, r http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper, build string, buildDate string, gitHash string) {
 	// We do not want to flood logs with health checks from readiness and liveness probes,
 	// so all health checks are set to log at debug level. The logger is overridden with this
@@ -38,4 +43,11 @@ func (h *Handlers) HandleHealth(ctx *executioncontext.ExecutionContext, r http_w
 		GitHash:   gitHash,
 	}
 	w.WriteJSON(healthInfo, 200)
+}
+
+// HandleHealthz responds with a minimal healthy status for kubelet probes.
+// It must not expose build/version details and must not require identity headers.
+func (h *Handlers) HandleHealthz(ctx *executioncontext.ExecutionContext, r http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper) {
+	ctx.Ctx = context.WithValue(ctx.Ctx, logging.LogLevelKey, slog.LevelDebug)
+	w.WriteJSON(HealthzResponse{Status: STATUS_HEALTHY}, 200)
 }

--- a/internal/eval_hub/handlers/health_test.go
+++ b/internal/eval_hub/handlers/health_test.go
@@ -53,5 +53,37 @@ func TestHandleHealth(t *testing.T) {
 			}
 		}
 	})
+}
 
+func TestHandleHealthz(t *testing.T) {
+	h := handlers.New(nil, nil, nil, nil, nil, nil)
+
+	r := createMockRequest("GET", "/healthz")
+	w := httptest.NewRecorder()
+	ctx := createExecutionContext()
+	h.HandleHealthz(ctx, r, &MockResponseWrapper{w})
+
+	if w.Code != 200 {
+		t.Errorf("Expected status code %d, got %d", 200, w.Code)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("Expected Content-Type application/json, got %s", contentType)
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if response["status"] != "healthy" {
+		t.Errorf("Expected status 'healthy', got %v", response["status"])
+	}
+
+	for _, field := range []string{"build", "build_date", "git_hash", "timestamp", "version"} {
+		if _, ok := response[field]; ok {
+			t.Errorf("healthz response must not include %q", field)
+		}
+	}
 }

--- a/internal/eval_hub/server/server.go
+++ b/internal/eval_hub/server/server.go
@@ -208,10 +208,27 @@ func (s *Server) handle(router *http.ServeMux, pattern string, handler http.Hand
 }
 
 func (s *Server) setupHealthRoutes(h *handlers.Handlers, router *http.ServeMux) {
+	// /healthz is for kubelet probes: unauthenticated, status-only (no build/version details).
+	s.handleFunc(router, "/healthz", func(w http.ResponseWriter, r *http.Request) {
+		ctx := s.newExecutionContext(r)
+		resp := NewRespWrapper(w, ctx)
+		req := s.newRequestWrapper(w, r)
+		switch req.Method() {
+		case http.MethodGet:
+			h.HandleHealthz(ctx, req, resp)
+		default:
+			resp.ErrorWithMessageCode(ctx.RequestID, messages.MethodNotAllowed, "Method", req.Method(), "Api", req.URI())
+		}
+	})
+
+	// /api/v1/health is the detailed health check; requires identity headers in cluster mode.
 	s.handleFunc(router, "/api/v1/health", func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)
 		req := s.newRequestWrapper(w, r)
+		if !s.canContinueRequest(ctx, resp) {
+			return
+		}
 		switch req.Method() {
 		case http.MethodGet:
 			h.HandleHealth(ctx, req, resp, s.serviceConfig.Service.Build, s.serviceConfig.Service.BuildDate, s.serviceConfig.Service.GitHash)

--- a/internal/eval_hub/server/server_identity_test.go
+++ b/internal/eval_hub/server/server_identity_test.go
@@ -24,13 +24,46 @@ func TestClusterModeRequiresIdentityHeaders(t *testing.T) {
 		t.Fatalf("SetupRoutes: %v", err)
 	}
 
-	t.Run("health does not require identity headers", func(t *testing.T) {
+	t.Run("healthz does not require identity headers", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("healthz: got status %d body %s", w.Code, w.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode healthz body: %v", err)
+		}
+		if body["status"] != "healthy" {
+			t.Fatalf("healthz status: got %v want healthy", body["status"])
+		}
+		if _, ok := body["git_hash"]; ok {
+			t.Fatal("healthz must not expose git_hash")
+		}
+	})
+
+	t.Run("health requires identity headers", func(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
 		w := httptest.NewRecorder()
 		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("health without headers: got status %d body %s", w.Code, w.Body.String())
+		}
+		assertMessageCode(t, w, "missing_tenant_header")
+	})
+
+	t.Run("health succeeds with identity headers", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+		req.Header.Set("X-Tenant", "test-tenant")
+		req.Header.Set("X-User", "test-user")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
 		if w.Code != http.StatusOK {
-			t.Fatalf("health: got status %d body %s", w.Code, w.Body.String())
+			t.Fatalf("health with headers: got status %d body %s", w.Code, w.Body.String())
 		}
 	})
 

--- a/internal/eval_hub/server/server_test.go
+++ b/internal/eval_hub/server/server_test.go
@@ -154,6 +154,7 @@ func TestServerSetupRoutes(t *testing.T) {
 		status int
 		body   string
 	}{
+		{http.MethodGet, "/healthz", http.StatusOK, ""},
 		{http.MethodGet, "/api/v1/health", http.StatusOK, ""},
 		{http.MethodGet, "/openapi.yaml", http.StatusOK, ""},
 		{http.MethodGet, "/docs", http.StatusOK, ""},
@@ -170,6 +171,7 @@ func TestServerSetupRoutes(t *testing.T) {
 		// Providers
 		{http.MethodGet, "/api/v1/evaluations/providers", http.StatusOK, ""},
 		// Error cases
+		{http.MethodPost, "/healthz", http.StatusMethodNotAllowed, ""},
 		{http.MethodPost, "/api/v1/health", http.StatusMethodNotAllowed, ""},
 		{http.MethodGet, "/nonexistent", http.StatusNotFound, ""},
 

--- a/tests/features/health.feature
+++ b/tests/features/health.feature
@@ -3,15 +3,10 @@ Feature: Health Check Endpoint
   I want to check the health of the service
   So that I can verify the service is running
 
-  Scenario: Get healthz status for probes
-    Given the service is running
-    When I send a GET request to "/healthz"
-    Then the response code should be 200
-    And the response should be JSON
-    And the response should contain "status" with value "healthy"
-
   Scenario: Get health status
-    Given the service is running
+    Given I set the header "X-Tenant" to "{{env:X_TENANT|test-tenant}}"
+    And I set the header "X-User" to "{{env:X_USER|test-user}}"
+    And the service is running
     When I send a GET request to "/api/v1/health"
     Then the response code should be 200
     And the response should be JSON
@@ -19,17 +14,22 @@ Feature: Health Check Endpoint
     And the response should contain "timestamp"
 
   @negative
-  Scenario: Health endpoint rejects non-GET methods
+  @cluster
+  Scenario: Health endpoint rejects non-authenticated requests
     Given the service is running
+    When I send a GET request to "/api/v1/health"
+    Then the response code should be 400
+    And the response should contain "message_code" with value "missing_"
+    And the response should contain "message_code" with value "_header"
+
+  @negative
+  Scenario: Health endpoint rejects non-GET methods
+    Given I set the header "X-Tenant" to "{{env:X_TENANT|test-tenant}}"
+    And I set the header "X-User" to "{{env:X_USER|test-user}}"
+    And the service is running
     When I send a POST request to "/api/v1/health"
     Then the response code should be 405
     When I send a PUT request to "/api/v1/health"
     Then the response code should be 405
     When I send a DELETE request to "/api/v1/health"
-    Then the response code should be 405
-
-  @negative
-  Scenario: Healthz endpoint rejects non-GET methods
-    Given the service is running
-    When I send a POST request to "/healthz"
     Then the response code should be 405

--- a/tests/features/health.feature
+++ b/tests/features/health.feature
@@ -3,6 +3,13 @@ Feature: Health Check Endpoint
   I want to check the health of the service
   So that I can verify the service is running
 
+  Scenario: Get healthz status for probes
+    Given the service is running
+    When I send a GET request to "/healthz"
+    Then the response code should be 200
+    And the response should be JSON
+    And the response should contain "status" with value "healthy"
+
   Scenario: Get health status
     Given the service is running
     When I send a GET request to "/api/v1/health"
@@ -19,4 +26,10 @@ Feature: Health Check Endpoint
     When I send a PUT request to "/api/v1/health"
     Then the response code should be 405
     When I send a DELETE request to "/api/v1/health"
+    Then the response code should be 405
+
+  @negative
+  Scenario: Healthz endpoint rejects non-GET methods
+    Given the service is running
+    When I send a POST request to "/healthz"
     Then the response code should be 405


### PR DESCRIPTION
## Summary
- Add unauthenticated `GET /healthz` on the main API returning status only for kubelet probes (no build/version details)
- Require identity headers (`X-Tenant`, `X-User`) on detailed `GET /api/v1/health` in cluster mode
- Update docs/README/FVT/unit tests; supersedes draft approach in #665 (metrics-server `/healthz`)

Resolves [RHOAIENG-77661](https://redhat.atlassian.net/browse/RHOAIENG-77661)

## Test plan
- [x] `make fmt lint`
- [x] `go test ./internal/eval_hub/server/ ./internal/eval_hub/handlers/`
- [x] Default FVT tags (`~@ignore && ~@mlflow && ~@cluster && ~@local_runtime`) including `health.feature`
- [ ] Operator/deployment: point liveness/readiness at `/healthz` on the eval-hub container (out of repo)

## Breaking changes
Cluster callers must authenticate to use `/api/v1/health`. Kubelet probes should use `/healthz`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an unauthenticated `/healthz` endpoint for lightweight kubelet health probes.
  * `/healthz` returns `200 OK` with only `{"status":"healthy"}` and accepts GET requests only.
  * Detailed `/api/v1/health` checks now require tenant and user identity headers in cluster mode.

* **Documentation**
  * Updated API, authentication, architecture, local development, and tracing documentation to describe the new health-check behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->