### PR TITLE
fix(server): move /healthz to metrics server for kubelet probe access

### DIFF
--- a/internal/eval_hub/server/metrics_server.go
+++ b/internal/eval_hub/server/metrics_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -26,6 +28,17 @@ func NewMetricsServer(logger *slog.Logger, promConfig *config.PrometheusConfig) 
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", withRequestID(promhttp.Handler()))
+	// /healthz is the kubelet probe endpoint. It lives here (plain HTTP, 0.0.0.0:8081) so
+	// the kubelet can reach it via the pod IP without going through kube-rbac-proxy.
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(handlers.HealthzResponse{Status: handlers.STATUS_HEALTHY})
+	})
 
 	return &MetricsServer{
 		httpServer: &http.Server{

--- a/internal/eval_hub/server/metrics_server_test.go
+++ b/internal/eval_hub/server/metrics_server_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -67,6 +68,40 @@ func TestMetricsServerHandler(t *testing.T) {
 
 		if w.Code != http.StatusNotFound {
 			t.Errorf("expected 404 for /api/v1/health, got %d", w.Code)
+		}
+	})
+
+	t.Run("GET /healthz returns 200 with status=healthy", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode /healthz body: %v", err)
+		}
+		if body["status"] != "healthy" {
+			t.Errorf("status: got %v, want healthy", body["status"])
+		}
+		for _, disallowed := range []string{"build", "build_date", "git_hash", "timestamp"} {
+			if _, ok := body[disallowed]; ok {
+				t.Errorf("/healthz must not expose %q", disallowed)
+			}
+		}
+	})
+
+	t.Run("POST /healthz returns 405", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPost, "/healthz", strings.NewReader(""))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
 		}
 	})
 }

--- a/internal/eval_hub/server/server.go
+++ b/internal/eval_hub/server/server.go
@@ -208,20 +208,8 @@ func (s *Server) handle(router *http.ServeMux, pattern string, handler http.Hand
 }
 
 func (s *Server) setupHealthRoutes(h *handlers.Handlers, router *http.ServeMux) {
-	// /healthz is for kubelet probes: unauthenticated, status-only (no build/version details).
-	s.handleFunc(router, "/healthz", func(w http.ResponseWriter, r *http.Request) {
-		ctx := s.newExecutionContext(r)
-		resp := NewRespWrapper(w, ctx)
-		req := s.newRequestWrapper(w, r)
-		switch req.Method() {
-		case http.MethodGet:
-			h.HandleHealthz(ctx, req, resp)
-		default:
-			resp.ErrorWithMessageCode(ctx.RequestID, messages.MethodNotAllowed, "Method", req.Method(), "Api", req.URI())
-		}
-	})
-
 	// /api/v1/health is the detailed health check; requires identity headers in cluster mode.
+	// /healthz (kubelet probe) is served by the metrics server on port 8081 (plain HTTP, no auth).
 	s.handleFunc(router, "/api/v1/health", func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)

--- a/internal/eval_hub/server/server_identity_test.go
+++ b/internal/eval_hub/server/server_identity_test.go
@@ -24,26 +24,6 @@ func TestClusterModeRequiresIdentityHeaders(t *testing.T) {
 		t.Fatalf("SetupRoutes: %v", err)
 	}
 
-	t.Run("healthz does not require identity headers", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("healthz: got status %d body %s", w.Code, w.Body.String())
-		}
-		var body map[string]any
-		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-			t.Fatalf("decode healthz body: %v", err)
-		}
-		if body["status"] != "healthy" {
-			t.Fatalf("healthz status: got %v want healthy", body["status"])
-		}
-		if _, ok := body["git_hash"]; ok {
-			t.Fatal("healthz must not expose git_hash")
-		}
-	})
-
 	t.Run("health requires identity headers", func(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)

--- a/internal/eval_hub/server/server_test.go
+++ b/internal/eval_hub/server/server_test.go
@@ -154,7 +154,6 @@ func TestServerSetupRoutes(t *testing.T) {
 		status int
 		body   string
 	}{
-		{http.MethodGet, "/healthz", http.StatusOK, ""},
 		{http.MethodGet, "/api/v1/health", http.StatusOK, ""},
 		{http.MethodGet, "/openapi.yaml", http.StatusOK, ""},
 		{http.MethodGet, "/docs", http.StatusOK, ""},
@@ -171,7 +170,6 @@ func TestServerSetupRoutes(t *testing.T) {
 		// Providers
 		{http.MethodGet, "/api/v1/evaluations/providers", http.StatusOK, ""},
 		// Error cases
-		{http.MethodPost, "/healthz", http.StatusMethodNotAllowed, ""},
 		{http.MethodPost, "/api/v1/health", http.StatusMethodNotAllowed, ""},
 		{http.MethodGet, "/nonexistent", http.StatusNotFound, ""},
 


### PR DESCRIPTION
## What and why

Moves the `/healthz` endpoint from the API server (`127.0.0.1:8444`, loopback-only) to the metrics server (`0.0.0.0:8081`, plain HTTP). The kubelet reaches pods via their pod IP, so it cannot connect to the loopback address, making the previous registration unreachable for startup and readiness probes.

The metrics server is the correct home: it is already unauthenticated and reachable from outside the container. The handler reuses `handlers.HealthzResponse` and `handlers.STATUS_HEALTHY` to keep the response structure consistent.

Relates to trustyai-service-operator operator probe change (operator PR targeting `http://:8081/healthz`).

## Type

- [x] fix

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

`GET /healthz` is no longer registered on the API server (loopback, port 8444). It is now exclusively on the metrics server (port 8081). Any client currently hitting `127.0.0.1:8444/healthz` directly (e.g. in integration tests or scripts) will need to switch to port 8081.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a lightweight `/healthz` endpoint to the metrics server.
  * `GET /healthz` returns a JSON health status of `healthy`.
  * Requests using other HTTP methods receive a `405 Method Not Allowed` response.

* **Changes**
  * Detailed health information remains available through `/api/v1/health`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->