### PR TITLE
fix(health): serve /healthz on the main API again

### DIFF
--- a/internal/eval_hub/server/metrics_server.go
+++ b/internal/eval_hub/server/metrics_server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"log/slog"
 	"net"
 	"net/http"
@@ -10,7 +9,6 @@ import (
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
-	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -28,17 +26,6 @@ func NewMetricsServer(logger *slog.Logger, promConfig *config.PrometheusConfig) 
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", withRequestID(promhttp.Handler()))
-	// /healthz is the kubelet probe endpoint. It lives here (plain HTTP, 0.0.0.0:8081) so
-	// the kubelet can reach it via the pod IP without going through kube-rbac-proxy.
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(handlers.HealthzResponse{Status: handlers.STATUS_HEALTHY})
-	})
 
 	return &MetricsServer{
 		httpServer: &http.Server{

--- a/internal/eval_hub/server/metrics_server_test.go
+++ b/internal/eval_hub/server/metrics_server_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -68,40 +67,6 @@ func TestMetricsServerHandler(t *testing.T) {
 
 		if w.Code != http.StatusNotFound {
 			t.Errorf("expected 404 for /api/v1/health, got %d", w.Code)
-		}
-	})
-
-	t.Run("GET /healthz returns 200 with status=healthy", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Errorf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
-		}
-		var body map[string]any
-		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-			t.Fatalf("decode /healthz body: %v", err)
-		}
-		if body["status"] != "healthy" {
-			t.Errorf("status: got %v, want healthy", body["status"])
-		}
-		for _, disallowed := range []string{"build", "build_date", "git_hash", "timestamp"} {
-			if _, ok := body[disallowed]; ok {
-				t.Errorf("/healthz must not expose %q", disallowed)
-			}
-		}
-	})
-
-	t.Run("POST /healthz returns 405", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest(http.MethodPost, "/healthz", strings.NewReader(""))
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-
-		if w.Code != http.StatusMethodNotAllowed {
-			t.Errorf("expected 405, got %d", w.Code)
 		}
 	})
 }

--- a/internal/eval_hub/server/server.go
+++ b/internal/eval_hub/server/server.go
@@ -208,8 +208,20 @@ func (s *Server) handle(router *http.ServeMux, pattern string, handler http.Hand
 }
 
 func (s *Server) setupHealthRoutes(h *handlers.Handlers, router *http.ServeMux) {
+	// /healthz is for kubelet probes: unauthenticated, status-only (no build/version details).
+	s.handleFunc(router, "/healthz", func(w http.ResponseWriter, r *http.Request) {
+		ctx := s.newExecutionContext(r)
+		resp := NewRespWrapper(w, ctx)
+		req := s.newRequestWrapper(w, r)
+		switch req.Method() {
+		case http.MethodGet:
+			h.HandleHealthz(ctx, req, resp)
+		default:
+			resp.ErrorWithMessageCode(ctx.RequestID, messages.MethodNotAllowed, "Method", req.Method(), "Api", req.URI())
+		}
+	})
+
 	// /api/v1/health is the detailed health check; requires identity headers in cluster mode.
-	// /healthz (kubelet probe) is served by the metrics server on port 8081 (plain HTTP, no auth).
 	s.handleFunc(router, "/api/v1/health", func(w http.ResponseWriter, r *http.Request) {
 		ctx := s.newExecutionContext(r)
 		resp := NewRespWrapper(w, ctx)

--- a/internal/eval_hub/server/server_identity_test.go
+++ b/internal/eval_hub/server/server_identity_test.go
@@ -24,6 +24,28 @@ func TestClusterModeRequiresIdentityHeaders(t *testing.T) {
 		t.Fatalf("SetupRoutes: %v", err)
 	}
 
+	t.Run("healthz does not require identity headers", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("healthz: got status %d body %s", w.Code, w.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode healthz body: %v", err)
+		}
+		if body["status"] != "healthy" {
+			t.Fatalf("healthz status: got %v want healthy", body["status"])
+		}
+		for _, field := range []string{"build", "build_date", "git_hash", "timestamp", "version"} {
+			if _, ok := body[field]; ok {
+				t.Fatalf("healthz must not expose %q", field)
+			}
+		}
+	})
+
 	t.Run("health requires identity headers", func(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)

--- a/internal/eval_hub/server/server_test.go
+++ b/internal/eval_hub/server/server_test.go
@@ -154,6 +154,7 @@ func TestServerSetupRoutes(t *testing.T) {
 		status int
 		body   string
 	}{
+		{http.MethodGet, "/healthz", http.StatusOK, ""},
 		{http.MethodGet, "/api/v1/health", http.StatusOK, ""},
 		{http.MethodGet, "/openapi.yaml", http.StatusOK, ""},
 		{http.MethodGet, "/docs", http.StatusOK, ""},
@@ -170,6 +171,7 @@ func TestServerSetupRoutes(t *testing.T) {
 		// Providers
 		{http.MethodGet, "/api/v1/evaluations/providers", http.StatusOK, ""},
 		// Error cases
+		{http.MethodPost, "/healthz", http.StatusMethodNotAllowed, ""},
 		{http.MethodPost, "/api/v1/health", http.StatusMethodNotAllowed, ""},
 		{http.MethodGet, "/nonexistent", http.StatusNotFound, ""},
 
@@ -236,6 +238,52 @@ func TestServerSetupRoutes(t *testing.T) {
 			t.Errorf("Expected status %d for %s when deleting evaluation job %s, got %d", http.StatusNoContent, path, id, w.Code)
 		}
 	}
+}
+
+func TestHealthzEndpoint(t *testing.T) {
+	srv, err := createServer(t, 8080)
+	if err != nil {
+		t.Fatalf("createServer: %v", err)
+	}
+	handler, err := srv.SetupRoutes()
+	if err != nil {
+		t.Fatalf("SetupRoutes: %v", err)
+	}
+
+	t.Run("GET returns healthy status without build metadata", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("got status %d body %s", w.Code, w.Body.String())
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type: got %q want application/json", ct)
+		}
+
+		var body map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["status"] != "healthy" {
+			t.Errorf("status: got %v want healthy", body["status"])
+		}
+		for _, field := range []string{"build", "build_date", "git_hash", "timestamp", "version"} {
+			if _, ok := body[field]; ok {
+				t.Errorf("/healthz must not expose %q", field)
+			}
+		}
+	})
+
+	t.Run("POST returns 405", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/healthz", strings.NewReader(""))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("got status %d want 405", w.Code)
+		}
+	})
 }
 
 func TestServerShutdown(t *testing.T) {

--- a/tests/features/health.feature
+++ b/tests/features/health.feature
@@ -3,6 +3,11 @@ Feature: Health Check Endpoint
   I want to check the health of the service
   So that I can verify the service is running
 
+  Scenario: Get healthz status for probes
+    Given the service is running
+    When I send a GET request to "/healthz"
+    Then the response code should be 200
+
   Scenario: Get health status
     Given I set the header "X-Tenant" to "{{env:X_TENANT|test-tenant}}"
     And I set the header "X-User" to "{{env:X_USER|test-user}}"
@@ -32,4 +37,10 @@ Feature: Health Check Endpoint
     When I send a PUT request to "/api/v1/health"
     Then the response code should be 405
     When I send a DELETE request to "/api/v1/health"
+    Then the response code should be 405
+
+  @negative
+  Scenario: Healthz endpoint rejects non-GET methods
+    Given the service is running
+    When I send a POST request to "/healthz"
     Then the response code should be 405


### PR DESCRIPTION
## Summary
- Move `GET /healthz` back onto the main eval-hub ServeMux (unauthenticated, status-only)
- Remove `/healthz` from the metrics server so that port serves `/metrics` only
- Cover the endpoint in `server_test.go` (and identity/FVT), not `metrics_server_test.go`

Reverts the placement from #726 while keeping the authenticated `/api/v1/health` behavior from #724.

## Test plan
- [x] `make fmt lint`
- [x] `go test ./internal/eval_hub/server/ ./internal/eval_hub/handlers/`
- [x] Pre-commit `make test test-fvt`
- [ ] Operator probes should target main API `/healthz` (not metrics `:8081`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an unauthenticated `GET /healthz` endpoint for service health probes.
  * Health responses report a healthy status without exposing build or version details.
  * Non-GET requests to `/healthz` return `405 Method Not Allowed`.

* **Changes**
  * Metrics serving is now limited to the `/metrics` endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->