### PR TITLE
chore(dependabot): remove `ruby` and disable lighteval container checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     schedule:
       interval: daily
 
-  - package-ecosystem: docker
-    directory: /containers/lighteval
-    schedule:
-      interval: daily
+#  - package-ecosystem: docker
+#    directory: /containers/lighteval
+#    schedule:
+#      interval: daily
 
   - package-ecosystem: gomod
     directory: /

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go", "python", "ruby"]
+        language: ["go", "python"]
         # CodeQL supports [ $supported-codeql-languages ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 


### PR DESCRIPTION
## What and why

- remove checks for `ruby` in the codeql check
- remove docker checks for the lighteval container

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually
