### PR TITLE
chore(dependencies): update eval-hub-sdk version to 0.4.3 in pyproject.toml

### DIFF
--- a/examples/local-lighteval/pyproject.toml
+++ b/examples/local-lighteval/pyproject.toml
@@ -13,5 +13,5 @@ demo = [
     "ipykernel>=7.2.0",
     "ipywidgets>=8.1.8",
     "oras>=0.2.41",
-    "eval-hub-sdk[client]>=0.1.7",
+    "eval-hub-sdk[client]>=0.4.3",
 ]


### PR DESCRIPTION
## What and why

- local mode is only available in version `0.4.3` or later

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the local evaluation example to use a newer evaluation toolkit version, improving compatibility and access to recent capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->