### PR TITLE
test: replace limit with num_examples

### DIFF
--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -469,7 +469,7 @@ Feature: Collections Endpoint
                     "threshold": 0.5
                 },
                 "parameters": {
-                    "limit": 10,
+                    "num_examples": 10,
                     "num_fewshot": 0,
                     "tokenizer": "google/flan-t5-small"
                 }
@@ -485,7 +485,7 @@ Feature: Collections Endpoint
                     "threshold": 0.5
                 },
                 "parameters": {
-                    "limit": 10,
+                    "num_examples": 10,
                     "num_fewshot": 0,
                     "tokenizer": "google/flan-t5-small"
                 }
@@ -544,7 +544,6 @@ Feature: Collections Endpoint
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "limit": 5,
               "tokenizer": "google/flan-t5-small"
             }
           },

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -68,7 +68,7 @@ Feature: Evaluation Jobs
     And the response should contain the value "arc_easy" at path "$.benchmarks[0].id"
     And the response should contain the value "garak|lm_evaluation_harness" at path "$.benchmarks[0].provider_id"
     And the response should contain the value "3" at path "$.benchmarks[0].parameters.num_fewshot"
-    And the response should contain the value "5" at path "$.benchmarks[0].parameters.limit"
+    And the response should contain the value "10" at path "$.benchmarks[0].parameters.num_examples"
     And the response should contain the value "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}" at path "$.benchmarks[0].parameters.tokenizer"
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
     Then the response code should be 200
@@ -78,7 +78,7 @@ Feature: Evaluation Jobs
     And the response should contain the value "arc_easy" at path "$.benchmarks[0].id"
     And the response should contain the value "garak|lm_evaluation_harness" at path "$.benchmarks[0].provider_id"
     And the response should contain the value "3" at path "$.benchmarks[0].parameters.num_fewshot"
-    And the response should contain the value "5" at path "$.benchmarks[0].parameters.limit"
+    And the response should contain the value "10" at path "$.benchmarks[0].parameters.num_examples"
     And the response should contain the value "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}" at path "$.benchmarks[0].parameters.tokenizer"
     And the response should not contain the value "collection" at path "$.collection"
     And I wait for the evaluation job status to be "completed"
@@ -430,42 +430,42 @@ Feature: Evaluation Jobs
               "id": "leaderboard_ifeval",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 1
+                "num_examples": 1
               }
             },
             {
               "id": "leaderboard_bbh",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 2
+                "num_examples": 2
               }
             },
             {
               "id": "leaderboard_gpqa",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 1
+                "num_examples": 1
               }
             },
             {
               "id": "leaderboard_mmlu_pro",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 2
+                "num_examples": 2
               }
             },
             {
               "id": "leaderboard_musr",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 1
+                "num_examples": 1
               }
             },
             {
               "id": "leaderboard_math_hard",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 2
+                "num_examples": 2
               }
             }
           ]
@@ -499,12 +499,12 @@ Feature: Evaluation Jobs
     And the response should contain the value "leaderboard_mmlu_pro" at path "$.results.benchmarks[*].id"
     And the response should contain the value "leaderboard_musr" at path "$.results.benchmarks[*].id"
     And the response should contain the value "leaderboard_math_hard" at path "$.results.benchmarks[*].id"
-    And the response should equal the value "1" at path "$.collection.benchmarks[0].parameters.limit"
-    And the response should equal the value "2" at path "$.collection.benchmarks[1].parameters.limit"
-    And the response should equal the value "1" at path "$.collection.benchmarks[2].parameters.limit"
-    And the response should equal the value "2" at path "$.collection.benchmarks[3].parameters.limit"
-    And the response should equal the value "1" at path "$.collection.benchmarks[4].parameters.limit"
-    And the response should equal the value "2" at path "$.collection.benchmarks[5].parameters.limit"
+    And the response should equal the value "1" at path "$.collection.benchmarks[0].parameters.num_examples"
+    And the response should equal the value "2" at path "$.collection.benchmarks[1].parameters.num_examples"
+    And the response should equal the value "1" at path "$.collection.benchmarks[2].parameters.num_examples"
+    And the response should equal the value "2" at path "$.collection.benchmarks[3].parameters.num_examples"
+    And the response should equal the value "1" at path "$.collection.benchmarks[4].parameters.num_examples"
+    And the response should equal the value "2" at path "$.collection.benchmarks[5].parameters.num_examples"
     # TODO: Add specific metric validations once we verify actual response structure
 
   # This scenario requires HuggingFace authentication for all benchmarks to run
@@ -522,42 +522,42 @@ Feature: Evaluation Jobs
               "id": "truthfulqa_mc1",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 5
+                "num_examples": 5
               }
             },
             {
               "id": "toxigen",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 3
+                "num_examples": 3
               }
             },
             {
               "id": "winogender",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 1
+                "num_examples": 1
               }
             },
             {
               "id": "crows_pairs_english",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 4
+                "num_examples": 4
               }
             },
             {
               "id": "bbq",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 2
+                "num_examples": 2
               }
             },
             {
               "id": "ethics_cm",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 6
+                "num_examples": 6
               }
             }
           ]
@@ -591,12 +591,12 @@ Feature: Evaluation Jobs
     And the response should contain the value "crows_pairs_english" at path "$.results.benchmarks[*].id"
     And the response should contain the value "bbq" at path "$.results.benchmarks[*].id"
     And the response should contain the value "ethics_cm" at path "$.results.benchmarks[*].id"
-    And the response should equal the value "5" at path "$.collection.benchmarks[0].parameters.limit"
-    And the response should equal the value "3" at path "$.collection.benchmarks[1].parameters.limit"
-    And the response should equal the value "1" at path "$.collection.benchmarks[2].parameters.limit"
-    And the response should equal the value "4" at path "$.collection.benchmarks[3].parameters.limit"
-    And the response should equal the value "2" at path "$.collection.benchmarks[4].parameters.limit"
-    And the response should equal the value "6" at path "$.collection.benchmarks[5].parameters.limit"
+    And the response should equal the value "5" at path "$.collection.benchmarks[0].parameters.num_examples"
+    And the response should equal the value "3" at path "$.collection.benchmarks[1].parameters.num_examples"
+    And the response should equal the value "1" at path "$.collection.benchmarks[2].parameters.num_examples"
+    And the response should equal the value "4" at path "$.collection.benchmarks[3].parameters.num_examples"
+    And the response should equal the value "2" at path "$.collection.benchmarks[4].parameters.num_examples"
+    And the response should equal the value "6" at path "$.collection.benchmarks[5].parameters.num_examples"
   # TODO: Add specific metric validations once we verify actual response structure
 
   @negative
@@ -672,7 +672,6 @@ Feature: Evaluation Jobs
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "limit": 5,
               "tokenizer": "google/flan-t5-small"
             }
           }
@@ -814,7 +813,7 @@ Feature: Evaluation Jobs
               "id": "toxigen",
               "provider_id": "invalid_provider",
               "parameters": {
-                "limit": 5
+                "num_examples": 5
               }
             }
           ]
@@ -842,7 +841,7 @@ Feature: Evaluation Jobs
               "id": "",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 5
+                "num_examples": 5
               }
             }
           ]
@@ -870,7 +869,7 @@ Feature: Evaluation Jobs
               "id": null,
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 5
+                "num_examples": 5
               }
             }
           ]
@@ -899,7 +898,7 @@ Feature: Evaluation Jobs
               "id": "toxigen_typo",
               "provider_id": "lm_evaluation_harness",
               "parameters": {
-                "limit": 5
+                "num_examples": 5
               }
             }
           ]
@@ -955,7 +954,6 @@ Feature: Evaluation Jobs
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "limit": 5,
               "tokenizer": "google/flan-t5-small"
             }
           }
@@ -988,7 +986,6 @@ Feature: Evaluation Jobs
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "limit": 5,
               "tokenizer": "google/flan-t5-small"
             }
           }
@@ -1094,7 +1091,6 @@ Feature: Evaluation Jobs
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "limit": 5,
               "tokenizer": "google/flan-t5-small"
             }
           }
@@ -1127,7 +1123,6 @@ Feature: Evaluation Jobs
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "limit": 5,
               "tokenizer": "google/flan-t5-small"
             }
           }

--- a/tests/features/evaluations.feature
+++ b/tests/features/evaluations.feature
@@ -401,7 +401,7 @@ Feature: Evaluations Endpoint
     And the response should contain the value "arc_easy" at path "$.status.benchmarks[0].id"
     And the response should contain the value "arc_easy" at path "$.results.benchmarks[0].id"
     And the response should contain the value "lm_evaluation_harness" at path "$.results.benchmarks[0].provider_id"
-    And the response should contain the value "5" at path "$.benchmarks[0].parameters.limit"
+    And the response should contain the value "10" at path "$.benchmarks[0].parameters.num_examples"
     And the response should contain the value "google/flan-t5-small" at path "$.benchmarks[0].parameters.tokenizer"
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204

--- a/tests/features/jsonnet_test.go
+++ b/tests/features/jsonnet_test.go
@@ -692,7 +692,6 @@ func TestEvaluateEvaluationJobJsonnetWithQueue(t *testing.T) {
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "limit": 5,
               "tokenizer": "google/flan-t5-small"
             }
           }

--- a/tests/features/mcp.feature
+++ b/tests/features/mcp.feature
@@ -395,7 +395,6 @@ Feature: MCP Tools
             "provider_id": "lm_evaluation_harness",
             "parameters": {
               "num_fewshot": 0,
-              "limit": 5,
               "num_examples": 10
             }
           }
@@ -494,7 +493,6 @@ Feature: MCP Tools
             "provider_id": "lm_evaluation_harness",
             "parameters": {
               "num_fewshot": 0,
-              "limit": 3,
               "num_examples": 3
             }
           },
@@ -503,7 +501,6 @@ Feature: MCP Tools
             "provider_id": "lm_evaluation_harness",
             "parameters": {
               "num_fewshot": 0,
-              "limit": 3,
               "num_examples": 3
             }
           }
@@ -546,7 +543,6 @@ Feature: MCP Tools
             "provider_id": "lm_evaluation_harness",
             "parameters": {
               "num_fewshot": 0,
-              "limit": 5,
               "num_examples": 5
             }
           }
@@ -591,7 +587,6 @@ Feature: MCP Tools
             "provider_id": "lm_evaluation_harness",
             "parameters": {
               "num_fewshot": 0,
-              "limit": 5,
               "num_examples": 5
             }
           }

--- a/tests/features/schema_test.go
+++ b/tests/features/schema_test.go
@@ -33,7 +33,6 @@ func TestEvaluationJobResourceSchemaFiles(t *testing.T) {
 			"id": "arc_easy",
 			"provider_id": "lm_evaluation_harness",
 			"parameters": {
-				"limit": 5,
 				"num_examples": 10,
 				"num_fewshot": 3,
 				"tokenizer": "google/flan-t5-small"
@@ -67,7 +66,6 @@ func TestEvaluationJobResourceSchemaFiles(t *testing.T) {
 			"id": "arc_easy",
 			"provider_id": "lm_evaluation_harness",
 			"parameters": {
-				"limit": 5,
 				"num_examples": 10,
 				"num_fewshot": 3,
 				"tokenizer": "/test_data/tokenizer"

--- a/tests/features/test_data/collection.json
+++ b/tests/features/test_data/collection.json
@@ -9,7 +9,6 @@
       "parameters": {
         "num_examples": 10,
         "num_fewshot": 3,
-        "limit": 5,
         "tokenizer": "google/flan-t5-small",
         "weight": 3
       }

--- a/tests/features/test_data/collection_multi_benchmark.jsonnet
+++ b/tests/features/test_data/collection_multi_benchmark.jsonnet
@@ -6,13 +6,11 @@ local test = import 'test.libsonnet';
   category: 'test',
   benchmarks: [
     test.benchmark('arc_easy', 'lm_evaluation_harness', {
-      limit: 5,
       num_examples: 10,
     }),
     test.benchmark('arc_easy', 'lm_evaluation_harness', {
       num_examples: 15,
       num_fewshot: 3,
-      limit: 5,
     }),
   ],
 }

--- a/tests/features/test_data/collection_threshold_zero.jsonnet
+++ b/tests/features/test_data/collection_threshold_zero.jsonnet
@@ -13,7 +13,7 @@ local thresholdZeroBenchmark() =
       threshold: 0.5,
     },
     parameters: {
-      limit: 10,
+      num_examples: 10,
       num_fewshot: 0,
       tokenizer: test.defaultTokenizer(),
     },

--- a/tests/features/test_data/evaluation_job_missing_model.json
+++ b/tests/features/test_data/evaluation_job_missing_model.json
@@ -5,7 +5,7 @@
       "provider_id": "garak",
       "parameters": {
         "num_fewshot": 3,
-        "limit": 5,
+        "num_examples": 5,
         "tokenizer": "google/flan-t5-small"
       }
     }

--- a/tests/features/test_data/evaluation_job_missing_name.json
+++ b/tests/features/test_data/evaluation_job_missing_name.json
@@ -10,7 +10,6 @@
       "parameters": {
         "num_examples": 10,
         "num_fewshot": 3,
-        "limit": 5,
         "tokenizer": "google/flan-t5-small"
       }
     }

--- a/tests/features/test_data/evaluation_job_pvc_and_s3.jsonnet
+++ b/tests/features/test_data/evaluation_job_pvc_and_s3.jsonnet
@@ -10,7 +10,6 @@ local test = import 'test.libsonnet';
       parameters: {
         tokenizer: '/test_data/tokenizer',
         num_examples: 10,
-        limit: 5,
       },
       test_data_ref: {
         pvc: {

--- a/tests/features/test_data/evaluation_job_pvc_missing.jsonnet
+++ b/tests/features/test_data/evaluation_job_pvc_missing.jsonnet
@@ -13,7 +13,6 @@ test.mergeOptional(
           parameters: {
             tokenizer: '/test_data/tokenizer',
             num_examples: 5,
-            limit: 5,
           },
           test_data_ref: {
             pvc: {

--- a/tests/features/test_data/jsonnet/test.libsonnet
+++ b/tests/features/test_data/jsonnet/test.libsonnet
@@ -75,7 +75,6 @@ local harness = std.parseJson(std.extVar('harness'));
     $.benchmark('arc_easy', 'lm_evaluation_harness', {
       num_examples: 10,
       num_fewshot: 3,
-      limit: 5,
     } + parameters),
 
   // arc_easy with PVC offline test data (claim_name + staging sub_path by default).
@@ -83,7 +82,6 @@ local harness = std.parseJson(std.extVar('harness'));
     $.pvcBenchmark('arc_easy', 'lm_evaluation_harness', {
       num_examples: 10,
       num_fewshot: 3,
-      limit: 5,
     } + parameters),
 
   // Default benchmark for evaluation_job.jsonnet (disconnected vs connected FVT).
@@ -123,7 +121,7 @@ local harness = std.parseJson(std.extVar('harness'));
       },
     },
 
-  // num_examples caps runtime for OOB collection FVT without conflicting with collection limit.
+  // num_examples caps runtime for OOB collection FVT.
   oobCollectionParameterOverrides(numExamples)::
     {
       num_examples: numExamples,

--- a/tests/features/test_data/schemas/evaluation_job.schema.json
+++ b/tests/features/test_data/schemas/evaluation_job.schema.json
@@ -268,7 +268,6 @@
           "id": "arc_easy",
           "provider_id": "lm_evaluation_harness",
           "parameters": {
-            "limit": 5,
             "num_examples": 10,
             "num_fewshot": 3,
             "tokenizer": "/test_data/tokenizer"

--- a/tests/features/test_data/schemas/evaluation_job_resource_connected.schema.json
+++ b/tests/features/test_data/schemas/evaluation_job_resource_connected.schema.json
@@ -342,7 +342,6 @@
           "id": "arc_easy",
           "provider_id": "lm_evaluation_harness",
           "parameters": {
-            "limit": 5,
             "num_examples": 10,
             "num_fewshot": 3,
             "tokenizer": "google/flan-t5-small"

--- a/tests/features/test_data/schemas/evaluation_job_resource_disconnected.schema.json
+++ b/tests/features/test_data/schemas/evaluation_job_resource_disconnected.schema.json
@@ -384,7 +384,6 @@
           "id": "arc_easy",
           "provider_id": "lm_evaluation_harness",
           "parameters": {
-            "limit": 5,
             "num_examples": 10,
             "num_fewshot": 3,
             "tokenizer": "/test_data/tokenizer"


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

FVT jobs that reference a collection were setting benchmark `parameters.limit`, but that field is not applied by the adapter so, full dataset is being evaluated, jobs continue running until FVT_TIMEOUT.  So this PR replaces no-op `limit` with `num_examples`.

Closes # https://redhat.atlassian.net/browse/RHOAIENG-76767

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated evaluation and collection configurations to use `num_examples` consistently instead of the deprecated `limit` parameter.
  * Removed redundant `limit` values from benchmark configurations and validation examples.

* **Tests**
  * Updated automated scenarios, fixtures, schemas, and assertions to reflect the revised benchmark parameter format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->