### PR TITLE
test(fvt): treat model endpoint 401 as reachable

### DIFF
--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -1737,9 +1737,10 @@ func checkModelEndpoint() {
 		_ = resp.Body.Close()
 		logDebug("Model endpoint preflight GET %s returned HTTP %d\n", modelURL, status)
 
-		// 401/404 on the OpenAI-compatible base URL (/v1) still means the server is up;
-		// unauthenticated GET often cannot list models.
-		reachableWithoutAuth := status == http.StatusUnauthorized || status == http.StatusNotFound
+		// 401 on the OpenAI-compatible base URL (/v1) still means the server is up;
+		// unauthenticated GET often cannot list models. Do not treat 404 as reachable
+		// (that can mask a bad MODEL_URL).
+		reachableWithoutAuth := status == http.StatusUnauthorized
 
 		if shouldRetry() && notReadyStatus(status) {
 			logDebug("WARNING: Model endpoint %s is not ready (HTTP %d), waiting %s before retrying\n", modelURL, status, retryDelay)
@@ -1749,7 +1750,7 @@ func checkModelEndpoint() {
 			modelEndpointConnectivity = modelEndpointReachable
 			return
 		} else if reachableWithoutAuth {
-			logDebug("Model endpoint %s is reachable (HTTP %d; auth/path expected for /v1 base URL)\n", modelURL, status)
+			logDebug("Model endpoint %s is reachable (HTTP %d; auth expected for /v1 base URL)\n", modelURL, status)
 			modelEndpointConnectivity = modelEndpointReachable
 			return
 		} else {

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -1732,20 +1732,30 @@ func checkModelEndpoint() {
 			modelEndpointConnectivity = modelEndpointUnreachable
 			return
 		}
-		defer resp.Body.Close()
+		status := resp.StatusCode
 		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		logDebug("Model endpoint preflight GET %s returned HTTP %d\n", modelURL, status)
 
-		if shouldRetry() && notReadyStatus(resp.StatusCode) {
-			logDebug("WARNING: Model endpoint %s is not ready (code %d), waiting for %d before retrying\n", modelURL, resp.StatusCode, retryDelay)
+		// 401/404 on the OpenAI-compatible base URL (/v1) still means the server is up;
+		// unauthenticated GET often cannot list models.
+		reachableWithoutAuth := status == http.StatusUnauthorized || status == http.StatusNotFound
+
+		if shouldRetry() && notReadyStatus(status) {
+			logDebug("WARNING: Model endpoint %s is not ready (HTTP %d), waiting %s before retrying\n", modelURL, status, retryDelay)
 			time.Sleep(retryDelay)
-		} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			logDebug("WARNING: Model endpoint %s returned non-2xx status %d, treating as unreachable\n", modelURL, resp.StatusCode)
-			logDebug("Evaluation job scenarios will be skipped.\n")
-			modelEndpointConnectivity = modelEndpointUnreachable
+		} else if status >= 200 && status < 300 {
+			logDebug("Model endpoint %s is reachable (HTTP %d)\n", modelURL, status)
+			modelEndpointConnectivity = modelEndpointReachable
+			return
+		} else if reachableWithoutAuth {
+			logDebug("Model endpoint %s is reachable (HTTP %d; auth/path expected for /v1 base URL)\n", modelURL, status)
+			modelEndpointConnectivity = modelEndpointReachable
 			return
 		} else {
-			logDebug("Model endpoint %s is reachable (status: %d)\n", modelURL, resp.StatusCode)
-			modelEndpointConnectivity = modelEndpointReachable
+			logDebug("WARNING: Model endpoint %s returned HTTP %d, treating as unreachable\n", modelURL, status)
+			logDebug("Evaluation job scenarios will be skipped.\n")
+			modelEndpointConnectivity = modelEndpointUnreachable
 			return
 		}
 		numRetries++

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -1742,7 +1742,7 @@ func checkModelEndpoint() {
 		// (that can mask a bad MODEL_URL).
 		reachableWithoutAuth := status == http.StatusUnauthorized
 
-		if shouldRetry() && notReadyStatus(status) {
+		if numRetries < maxRetries-1 && notReadyStatus(status) {
 			logDebug("WARNING: Model endpoint %s is not ready (HTTP %d), waiting %s before retrying\n", modelURL, status, retryDelay)
 			time.Sleep(retryDelay)
 		} else if status >= 200 && status < 300 {


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

- FVT model check does an unauthenticated GET on MODEL_URL.
- Auth-protected OpenAI-compatible /v1 endpoints often return 401 even when the server is up; that was treated as unreachable and skipped evaluation job scenarios.
- Treat 401 as reachable. Keep 404 (and other non-2xx) as unreachable 

Closes # https://redhat.atlassian.net/browse/RHOAIENG-77913

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model endpoint availability checks during preflight validation.
  * Retryable “not ready” responses are handled more accurately.
  * Successful responses and authentication-required responses on compatible endpoints are recognized as reachable.
  * Other unsuccessful responses now correctly mark endpoints as unreachable and skip affected evaluation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->