### PR TITLE
chore(deps): update pre-commit hooks and swagger version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.4
+    rev: v4.16.5
     hooks:
       - id: commitizen
         stages: [commit-msg]
@@ -39,11 +39,11 @@ repos:
         types: [go]
         pass_filenames: false
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.16.3
+    rev: v8.30.0
     hooks:
       - id: gitleaks
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.52.2
+    rev: v2.12.2
     hooks:
       - id: golangci-lint
   - repo: https://github.com/jumanjihouse/pre-commit-hooks

--- a/internal/eval_hub/handlers/openapi.go
+++ b/internal/eval_hub/handlers/openapi.go
@@ -80,8 +80,10 @@ func (h *Handlers) HandleOpenAPI(ctx *executioncontext.ExecutionContext, r http_
 func (h *Handlers) HandleDocs(ctx *executioncontext.ExecutionContext, r http_wrappers.RequestWrapper, w http_wrappers.ResponseWrapper) {
 	// Get the base URL for the OpenAPI spec (so without the "/docs" path)
 	baseURL := strings.TrimSuffix(r.URI(), r.Path())
+	// be safe against XSS attacks
+	baseURL = template.HTMLEscapeString(baseURL)
 
-	swaggerVersion := "5.32.4"
+	swaggerVersion := "5.32.9"
 	if r.Header("SWAGGER_VERSION") != "" {
 		swaggerVersion = r.Header("SWAGGER_VERSION")
 	}

--- a/internal/eval_hub/handlers/openapi.go
+++ b/internal/eval_hub/handlers/openapi.go
@@ -81,7 +81,7 @@ func (h *Handlers) HandleDocs(ctx *executioncontext.ExecutionContext, r http_wra
 	// Get the base URL for the OpenAPI spec (so without the "/docs" path)
 	baseURL := strings.TrimSuffix(r.URI(), r.Path())
 	// be safe against XSS attacks
-	baseURL = template.HTMLEscapeString(baseURL)
+	baseURL = template.JSEscapeString(baseURL)
 
 	swaggerVersion := "5.32.9"
 	if r.Header("SWAGGER_VERSION") != "" {


### PR DESCRIPTION
## What and why

- Bumped commitizen from v4.16.4 to v4.16.5.
- Updated gitleaks from v8.16.3 to v8.30.0.
- Upgraded golangci-lint from v1.52.2 to v2.12.2.
- Updated swagger version from 5.32.4 to 5.32.9.
- Added HTML escaping for base URL in HandleDocs to mitigate XSS risks.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually
