### PR TITLE
test(health): update health endpoint tests to accept 403 response code for non-GET methods

### DIFF
--- a/tests/features/health.feature
+++ b/tests/features/health.feature
@@ -28,19 +28,20 @@ Feature: Health Check Endpoint
     And the response should contain "message_code" with value "_header"
 
   @negative
+  # 405 comes from the service, 403 comes from the proxy
   Scenario: Health endpoint rejects non-GET methods
     Given I set the header "X-Tenant" to "{{env:X_TENANT|test-tenant}}"
     And I set the header "X-User" to "{{env:X_USER|test-user}}"
     And the service is running
     When I send a POST request to "/api/v1/health"
-    Then the response code should be 405
+    Then the response code should be 405 or 403
     When I send a PUT request to "/api/v1/health"
-    Then the response code should be 405
+    Then the response code should be 405 or 403
     When I send a DELETE request to "/api/v1/health"
-    Then the response code should be 405
+    Then the response code should be 405 or 403
 
   @negative
   Scenario: Healthz endpoint rejects non-GET methods
     Given the service is running
     When I send a POST request to "/healthz"
-    Then the response code should be 405
+    Then the response code should be 405 or 403


### PR DESCRIPTION
## What and why

Modified the health check feature tests to allow for a 403 response code in addition to the existing 405 for non-GET requests. This change reflects the behavior of the service and proxy more accurately.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually
