### PR TITLE
chore: restrict CodeQL, PyPI publish, and Codecov upload to the canonical repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
         make clean build test-all-coverage
 
     - name: Upload coverage reports to Codecov
+      # Only upload from the canonical repo, not forks
+      if: github.repository == 'eval-hub/eval-hub'
       continue-on-error: ${{ github.actor == 'dependabot[bot]' }}  # Don't fail CI on Dependabot PRs since they can't access secrets
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,8 @@ permissions:
 jobs:
   analyze:
     name: Analyze
+    # Only run on the canonical repo, not forks
+    if: github.repository == 'eval-hub/eval-hub'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/publish-python-mcp.yml
+++ b/.github/workflows/publish-python-mcp.yml
@@ -198,8 +198,10 @@ jobs:
   publish-mcp:
     name: Publish to PyPI
     needs: [build-mcp-wheels, validate-mcp-wheels]
+    # Only run on the canonical repo, not forks.
     if: >-
-      !failure() && !cancelled()
+      github.repository == 'eval-hub/eval-hub'
+      && !failure() && !cancelled()
       && (
         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
         || (github.event_name == 'workflow_dispatch' && inputs.publish-pypi)

--- a/.github/workflows/publish-python-server.yml
+++ b/.github/workflows/publish-python-server.yml
@@ -218,7 +218,8 @@ jobs:
     needs: [build-wheels, validate-wheels]
     # Publish clean versions to PyPI only on actual tag pushes.
     # The event_name check prevents workflow_dispatch targeting a tag ref from triggering this.
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    # Only run on the canonical repo, not forks.
+    if: github.repository == 'eval-hub/eval-hub' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -248,7 +249,8 @@ jobs:
   check-testpypi-age:
     name: Check TestPyPI release age
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Only run on the canonical repo, not forks.
+    if: github.repository == 'eval-hub/eval-hub' && github.ref == 'refs/heads/main' && github.event_name == 'push'
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
     steps:
@@ -286,8 +288,10 @@ jobs:
     # workflow_dispatch against a tag cannot publish a clean release version here.
     # Manual dispatch always publishes; automatic main pushes only publish if
     # the last TestPyPI release is older than 7 days.
+    # Only run on the canonical repo, not forks.
     if: >-
-      !failure() && !cancelled()
+      github.repository == 'eval-hub/eval-hub'
+      && !failure() && !cancelled()
       && (
         (github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/') && inputs.publish-test-pypi)
         || (github.ref == 'refs/heads/main' && needs.check-testpypi-age.outputs.should_publish == 'true')


### PR DESCRIPTION
## What and why

Restrict sensitive GitHub Actions jobs/steps so they only run on the canonical repository (`eval-hub/eval-hub`), not on forks:

- **CodeQL** (`codeql.yml`): analyze job only runs on the canonical repo
- **PyPI publish** (`publish-python-server.yml`, `publish-python-mcp.yml`): PyPI and TestPyPI publish jobs (and the TestPyPI age check) only run on the canonical repo
- **Codecov upload** (`ci.yml`): coverage upload step only runs on the canonical repo (tests still run on forks)

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually