### PR TITLE
test: enhance password handling in config tests

### DIFF
--- a/internal/eval_hub/config/loader_test.go
+++ b/internal/eval_hub/config/loader_test.go
@@ -194,7 +194,7 @@ secrets:
 
 	t.Run("loading config from secrets directory", func(t *testing.T) {
 		// create a secret and store in /tmp/db_password
-		secret := "mysecret"
+		secret := testPassword()
 		secretPath := "/tmp/db_password"
 		err := os.WriteFile(secretPath, []byte(secret), 0600)
 		if err != nil {
@@ -250,11 +250,15 @@ func TestRedactedJSON(t *testing.T) {
 	}
 
 	t.Run("redacts password with [redacted]", func(t *testing.T) {
+		password := testPassword()
 		v := outer{
-			Database: inner{Password: "s3cret", Driver: "pgx"},
+			Database: inner{Password: password, Driver: "pgx"},
 			Name:     "test",
 		}
 		result := config.RedactedJSON(v, []string{"database.password"})
+		if contains(result, password) {
+			t.Fatalf("Expected password %q to be redacted, got %s", password, result)
+		}
 		if !contains(result, `"password":"[redacted]"`) {
 			t.Fatalf("Expected password to be [redacted], got %s", result)
 		}
@@ -264,14 +268,15 @@ func TestRedactedJSON(t *testing.T) {
 	})
 
 	t.Run("sanitises URL by stripping password", func(t *testing.T) {
+		password := testPassword()
 		v := outer{
 			Database: inner{
-				URL:    "postgres://user:p4ss@db-host:5432/evalhub",
+				URL:    fmt.Sprintf("postgres://user:%s@db-host:5432/evalhub", password),
 				Driver: "pgx",
 			},
 		}
 		result := config.RedactedJSON(v, []string{"database.url"})
-		if contains(result, "p4ss") {
+		if contains(result, password) {
 			t.Fatalf("Password should be stripped from URL, got %s", result)
 		}
 		if !contains(result, "user@db-host:5432") {
@@ -280,22 +285,24 @@ func TestRedactedJSON(t *testing.T) {
 	})
 
 	t.Run("no redacted fields returns full JSON", func(t *testing.T) {
+		password := testPassword()
 		v := outer{
-			Database: inner{Password: "s3cret"},
+			Database: inner{Password: password},
 			Name:     "test",
 		}
 		result := config.RedactedJSON(v, nil)
-		if !contains(result, "s3cret") {
+		if !contains(result, password) {
 			t.Fatalf("Expected unredacted output, got %s", result)
 		}
 	})
 
 	t.Run("non-existent field path is a no-op", func(t *testing.T) {
+		password := testPassword()
 		v := outer{
-			Database: inner{Password: "s3cret"},
+			Database: inner{Password: password},
 		}
 		result := config.RedactedJSON(v, []string{"database.missing"})
-		if !contains(result, "s3cret") {
+		if !contains(result, password) {
 			t.Fatalf("Expected password to be untouched, got %s", result)
 		}
 	})
@@ -452,4 +459,8 @@ func providerIDs(providers map[string]api.ProviderResource) []string {
 
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
+}
+
+func testPassword() string {
+	return fmt.Sprintf("pw-%d", time.Now().UnixNano())
 }

--- a/internal/eval_hub/config/loader_test.go
+++ b/internal/eval_hub/config/loader_test.go
@@ -256,13 +256,13 @@ func TestRedactedJSON(t *testing.T) {
 			Name:     "test",
 		}
 		result := config.RedactedJSON(v, []string{"database.password"})
-		if contains(result, password) {
+		if strings.Contains(result, password) {
 			t.Fatalf("Expected password %q to be redacted, got %s", password, result)
 		}
-		if !contains(result, `"password":"[redacted]"`) {
+		if !strings.Contains(result, `"password":"[redacted]"`) {
 			t.Fatalf("Expected password to be [redacted], got %s", result)
 		}
-		if !contains(result, `"name":"test"`) {
+		if !strings.Contains(result, `"name":"test"`) {
 			t.Fatalf("Expected name to be preserved, got %s", result)
 		}
 	})
@@ -276,10 +276,10 @@ func TestRedactedJSON(t *testing.T) {
 			},
 		}
 		result := config.RedactedJSON(v, []string{"database.url"})
-		if contains(result, password) {
+		if strings.Contains(result, password) {
 			t.Fatalf("Password should be stripped from URL, got %s", result)
 		}
-		if !contains(result, "user@db-host:5432") {
+		if !strings.Contains(result, "user@db-host:5432") {
 			t.Fatalf("Expected sanitised URL with user and host, got %s", result)
 		}
 	})
@@ -291,7 +291,7 @@ func TestRedactedJSON(t *testing.T) {
 			Name:     "test",
 		}
 		result := config.RedactedJSON(v, nil)
-		if !contains(result, password) {
+		if !strings.Contains(result, password) {
 			t.Fatalf("Expected unredacted output, got %s", result)
 		}
 	})
@@ -302,7 +302,7 @@ func TestRedactedJSON(t *testing.T) {
 			Database: inner{Password: password},
 		}
 		result := config.RedactedJSON(v, []string{"database.missing"})
-		if !contains(result, password) {
+		if !strings.Contains(result, password) {
 			t.Fatalf("Expected password to be untouched, got %s", result)
 		}
 	})
@@ -455,10 +455,6 @@ func providerIDs(providers map[string]api.ProviderResource) []string {
 		ids = append(ids, id)
 	}
 	return ids
-}
-
-func contains(s, substr string) bool {
-	return strings.Contains(s, substr)
 }
 
 func testPassword() string {


### PR DESCRIPTION


## What and why

Updated the loader tests to use dynamically generated passwords via the testPassword function, ensuring better test isolation and variability. Adjusted assertions to verify that passwords are properly redacted in JSON outputs, enhancing the robustness of the redaction functionality.

This should also help Snyk see that there are no hard-coded passwords in the code/tests.

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for secret handling by using dynamically generated passwords instead of hardcoded values.
  * Strengthened validation of JSON redaction and URL sanitization by parameterizing inputs and asserting expected sanitized outputs.
  * Added/updated checks to confirm secrets remain unchanged when redaction does not apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->