### PR TITLE
chore: cleanup unused insecure_skip_verify from config and code for OCI calls

### DIFF
--- a/internal/eval_hub/config/sidecar_config.go
+++ b/internal/eval_hub/config/sidecar_config.go
@@ -32,9 +32,8 @@ type SidecarModelConfig struct {
 // Whether the OCI reverse proxy runs is determined from the job spec (exports.oci), not from
 // the presence of this block; when nil, the sidecar uses defaults for registry TLS.
 type SidecarOCIConfig struct {
-	CACertPath         string        `mapstructure:"ca_cert_path,omitempty" json:"ca_cert_path,omitempty"`                 // optional PEM CA for registry TLS
-	InsecureSkipVerify bool          `mapstructure:"insecure_skip_verify,omitempty" json:"insecure_skip_verify,omitempty"` // skip TLS verify for registry (e.g. self-signed)
-	HTTPTimeout        time.Duration `mapstructure:"http_timeout,omitempty" json:"http_timeout,omitempty"`                 // HTTP client timeout for registry requests (e.g. 30s)
+	CACertPath  string        `mapstructure:"ca_cert_path,omitempty" json:"ca_cert_path,omitempty"` // optional PEM CA for registry TLS
+	HTTPTimeout time.Duration `mapstructure:"http_timeout,omitempty" json:"http_timeout,omitempty"` // HTTP client timeout for registry requests (e.g. 30s)
 }
 
 type EvalHubClientConfig struct {

--- a/internal/eval_hub/evalcards/oci_factory.go
+++ b/internal/eval_hub/evalcards/oci_factory.go
@@ -29,21 +29,19 @@ type DockerConfigSecretGetter interface {
 }
 
 // NewOCIHTTPClient creates an HTTP client for OCI registry export using optional sidecar.oci TLS
-// settings. Cluster registries often use private CAs or self-signed certs; this mirrors the
-// sidecar OCI proxy TLS configuration for eval-hub's outbound export calls.
+// settings. Cluster registries often use private CAs; this mirrors the sidecar OCI proxy TLS
+// configuration for eval-hub's outbound export calls. TLS verification is always enabled.
 func NewOCIHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger *slog.Logger) (*http.Client, error) {
 	timeout := defaultOCIHTTPTimeout
 	caCertPath := ""
-	insecureSkipVerify := false
 	if serviceConfig != nil && serviceConfig.Sidecar != nil && serviceConfig.Sidecar.OCI != nil {
 		oci := serviceConfig.Sidecar.OCI
 		if oci.HTTPTimeout > 0 {
 			timeout = oci.HTTPTimeout
 		}
 		caCertPath = oci.CACertPath
-		insecureSkipVerify = oci.InsecureSkipVerify
 	}
-	tlsConfig, err := buildOCIHTTPClientTLS(caCertPath, insecureSkipVerify, logger)
+	tlsConfig, err := buildOCIHTTPClientTLS(caCertPath, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -62,22 +60,12 @@ func NewOCIHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger *
 
 // buildOCIHTTPClientTLS loads registry TLS settings for the export HTTP client. It falls back to
 // the cluster service CA bundle and, when absent, to system roots so export works in dev and prod.
-func buildOCIHTTPClientTLS(caCertPath string, insecureSkipVerify bool, logger *slog.Logger) (*tls.Config, error) {
-	if caCertPath == "" && !insecureSkipVerify {
+func buildOCIHTTPClientTLS(caCertPath string, logger *slog.Logger) (*tls.Config, error) {
+	if caCertPath == "" {
 		caCertPath = defaultOCICACertPath
 	}
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
-	}
-	if insecureSkipVerify {
-		if logger != nil {
-			logger.Warn("OCI TLS verification disabled", "insecure_skip_verify", true)
-		}
-		tlsConfig.InsecureSkipVerify = true
-		return tlsConfig, nil
-	}
-	if caCertPath == "" {
-		return nil, nil
 	}
 	caPEM, err := os.ReadFile(caCertPath) // #nosec G304 -- CA path from service configuration
 	if err != nil {

--- a/internal/eval_hub/evalcards/oci_http_client_test.go
+++ b/internal/eval_hub/evalcards/oci_http_client_test.go
@@ -32,11 +32,12 @@ func TestNewOCIHTTPClientDefaults(t *testing.T) {
 func TestNewOCIHTTPClientAppliesConfig(t *testing.T) {
 	t.Parallel()
 
+	caPath := writeTestCACert(t)
 	cfg := &config.Config{
 		Sidecar: &config.SidecarConfig{
 			OCI: &config.SidecarOCIConfig{
-				HTTPTimeout:        45 * time.Second,
-				InsecureSkipVerify: true,
+				HTTPTimeout: 45 * time.Second,
+				CACertPath:  caPath,
 			},
 		},
 	}
@@ -48,8 +49,11 @@ func TestNewOCIHTTPClientAppliesConfig(t *testing.T) {
 		t.Fatalf("timeout = %v, want 45s", client.Timeout)
 	}
 	transport, ok := client.Transport.(*http.Transport)
-	if !ok || transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
-		t.Fatal("expected insecure TLS config from sidecar.oci settings")
+	if !ok || transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs == nil {
+		t.Fatal("expected TLS config with custom root CAs from sidecar.oci settings")
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("expected TLS verification to remain enabled")
 	}
 }
 
@@ -57,7 +61,7 @@ func TestBuildOCIHTTPClientTLSMissingCAUsesSystemRoots(t *testing.T) {
 	t.Parallel()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	tlsConfig, err := buildOCIHTTPClientTLS(filepath.Join(t.TempDir(), "missing-ca.crt"), false, logger)
+	tlsConfig, err := buildOCIHTTPClientTLS(filepath.Join(t.TempDir(), "missing-ca.crt"), logger)
 	if err != nil {
 		t.Fatalf("buildOCIHTTPClientTLS() err = %v", err)
 	}
@@ -73,7 +77,7 @@ func TestBuildOCIHTTPClientTLSInvalidPEM(t *testing.T) {
 	if err := os.WriteFile(caPath, []byte("not-a-cert"), 0o600); err != nil {
 		t.Fatalf("WriteFile() err = %v", err)
 	}
-	if _, err := buildOCIHTTPClientTLS(caPath, false, nil); err == nil {
+	if _, err := buildOCIHTTPClientTLS(caPath, nil); err == nil {
 		t.Fatal("expected error for invalid CA PEM")
 	}
 }
@@ -82,7 +86,7 @@ func TestBuildOCIHTTPClientTLSValidCA(t *testing.T) {
 	t.Parallel()
 
 	caPath := writeTestCACert(t)
-	tlsConfig, err := buildOCIHTTPClientTLS(caPath, false, nil)
+	tlsConfig, err := buildOCIHTTPClientTLS(caPath, nil)
 	if err != nil {
 		t.Fatalf("buildOCIHTTPClientTLS() err = %v", err)
 	}
@@ -124,7 +128,7 @@ func TestNewOCIHTTPClientWithOTELEnabled(t *testing.T) {
 func TestBuildOCIHTTPClientTLSReadError(t *testing.T) {
 	t.Parallel()
 
-	if _, err := buildOCIHTTPClientTLS(t.TempDir(), false, nil); err == nil {
+	if _, err := buildOCIHTTPClientTLS(t.TempDir(), nil); err == nil {
 		t.Fatal("expected read error when CA path is a directory")
 	}
 }

--- a/internal/eval_runtime_sidecar/config/sidecar_runtime_config_test.go
+++ b/internal/eval_runtime_sidecar/config/sidecar_runtime_config_test.go
@@ -65,7 +65,6 @@ func TestLoadSidecarRuntimeConfig_OCISnakeCase(t *testing.T) {
   "eval_hub": { "base_url": "https://eval.example" },
   "oci": {
     "ca_cert_path": "/etc/certs/ca.pem",
-    "insecure_skip_verify": true,
     "http_timeout": 30000000000
   }
 }`
@@ -81,9 +80,6 @@ func TestLoadSidecarRuntimeConfig_OCISnakeCase(t *testing.T) {
 	}
 	if cfg.Sidecar.OCI.CACertPath != "/etc/certs/ca.pem" {
 		t.Errorf("oci.ca_cert_path = %q", cfg.Sidecar.OCI.CACertPath)
-	}
-	if !cfg.Sidecar.OCI.InsecureSkipVerify {
-		t.Error("oci.insecure_skip_verify should be true")
 	}
 	if cfg.Sidecar.OCI.HTTPTimeout != 30_000_000_000 {
 		t.Errorf("oci.http_timeout = %v", cfg.Sidecar.OCI.HTTPTimeout)

--- a/internal/eval_runtime_sidecar/proxy/http_client.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client.go
@@ -44,6 +44,7 @@ func newHTTPClient(timeout time.Duration, tlsConfig *tls.Config, isOTELEnabled b
 // When insecureSkipVerify is true, custom CA files are not read: verification is off, so loading a CA
 // would not affect trust and skipping avoids failing on missing paths in local/test environments.
 // When caCertPath is empty and insecureSkipVerify is false, system roots are used (default *tls.Config).
+// OCI callers always pass insecureSkipVerify=false; skip-verify is not supported for registry TLS.
 func buildTLSConfig(caCertPath string, insecureSkipVerify bool, logger *slog.Logger, certLabel string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
@@ -164,8 +165,8 @@ func NewModelHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger
 
 // NewOCIHTTPClient creates an HTTP client for the OCI registry from config (TLS, timeout).
 // Registry host comes from the job spec, not this config. When Sidecar.OCI is nil, defaults
-// are used; non-nil sidecar.oci in sidecar_config.json supplies optional CA, insecure, and
-// http_timeout overrides.
+// are used; non-nil sidecar.oci in sidecar_config.json supplies optional CA and http_timeout
+// overrides. TLS verification is always enabled.
 // Returns (nil, nil) only when Sidecar is nil.
 func NewOCIHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger *slog.Logger) (*http.Client, error) {
 	if serviceConfig == nil || serviceConfig.Sidecar == nil {
@@ -180,11 +181,7 @@ func NewOCIHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger *
 	if ociConfig != nil && ociConfig.CACertPath != "" {
 		caCertPath = ociConfig.CACertPath
 	}
-	insecureSkipVerify := DefaultInsecureSkipVerify
-	if ociConfig != nil && ociConfig.InsecureSkipVerify {
-		insecureSkipVerify = ociConfig.InsecureSkipVerify
-	}
-	tlsConfig, err := buildTLSConfig(caCertPath, insecureSkipVerify, logger, "OCI")
+	tlsConfig, err := buildTLSConfig(caCertPath, false, logger, "OCI")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What and why

cleanup unused insecure_skip_verify from config and code for OCI calls

Closes #

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [X] refactor / chore
- [ ] test / ci

## Testing

- [X] Tests added or updated
- [ ] Tested manually

## Breaking changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * OCI connections now always verify TLS certificates.
  * Removed support for disabling TLS verification through OCI configuration.
  * Custom CA certificates remain supported for trusted private registries.

* **Configuration**
  * OCI settings now support CA certificate paths and HTTP timeouts without the insecure verification option.

* **Bug Fixes**
  * Updated OCI client behavior and validation to consistently enforce secure certificate verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->