### PR TITLE
fix(tests/postgres): update installation process for PostgreSQL on Linux

### DIFF
--- a/tests/postgres/Makefile
+++ b/tests/postgres/Makefile
@@ -9,7 +9,12 @@ install-postgres:
 	brew install postgresql@${POSTGRES_VERSION}
 else ifeq ($(UNAME), Linux)
 install-postgres:
-	sudo apt-get install postgresql-${POSTGRES_VERSION}
+	sudo apt-get update
+	sudo apt-get install -y gnupg2 lsb-release ubuntu-keyring
+	curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
+	echo "deb [signed-by=/etc/apt/trusted.gpg.d/apt.postgresql.org.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
+	sudo apt-get update
+	sudo apt-get install -y postgresql-${POSTGRES_VERSION}
 else
 install-postgres:
 	echo "Unsupported platform: ${UNAME}"

--- a/tests/postgres/Makefile
+++ b/tests/postgres/Makefile
@@ -10,9 +10,9 @@ install-postgres:
 else ifeq ($(UNAME), Linux)
 install-postgres:
 	sudo apt-get update
-	sudo apt-get install -y gnupg2 lsb-release ubuntu-keyring
-	curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
-	echo "deb [signed-by=/etc/apt/trusted.gpg.d/apt.postgresql.org.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
+	sudo apt-get install -y ca-certificates curl gnupg lsb-release
+	curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
+	echo "deb [signed-by=/etc/apt/trusted.gpg.d/apt.postgresql.org.gpg] http://apt.postgresql.org/pub/repos/apt $$(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
 	sudo apt-get update
 	sudo apt-get install -y postgresql-${POSTGRES_VERSION}
 else


### PR DESCRIPTION
## What and why

Enhanced the Makefile to include necessary steps for installing PostgreSQL on Linux, including adding the PostgreSQL GPG key and repository. This ensures a smoother installation process by updating the package list and installing required dependencies.

Note that this only shows up on a linux machine (so mainly in the github workflows).

Assisted-by: Copilot
Assisted-by: coderabbitai

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually
