### PR TITLE
chore(ci): post Codecov status when head report is missing

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,13 @@ coverage:
   range: 50..75 # The first number represents the cut-over from red to yellow, and the second represents the cut-over from yellow to green.
   round: down # up, down, nearest
   precision: 1 # 0 - 5
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        if_not_found: success
+    patch:
+      default:
+        target: auto
+        if_not_found: success


### PR DESCRIPTION
## Summary
- Explicitly enable Codecov `project` and `patch` status checks in `codecov.yml`.
- Set `if_not_found: success` so Codecov posts a passing check when there is no head coverage report, instead of leaving the required `codecov/patch` status pending (seen on Actions-only Dependabot PRs such as #764).

## Test plan
- [x] Validated `codecov.yml` with `curl --data-binary @codecov.yml https://codecov.io/validate`
- [ ] Confirm a follow-up Actions-only Dependabot PR receives a `codecov/patch` status (pass) after coverage upload
- [ ] Confirm a normal Go-changing PR still gets a meaningful `codecov/patch` result


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage checks to use automatic targets.
  * Added a 1% project coverage threshold.
  * Coverage checks now pass when coverage data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->