### PR TITLE
docs(security): document CodeQL stale language analysis cleanup

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,19 +39,21 @@ GitHub treats `neutral` as a passing required check, but the warning remains unt
 
 **Cleanup (maintainers):**
 
-1. List leftover analyses for the missing category on `main` (replace `/language:ruby` as needed):
+1. List leftover analyses for the missing category on `main` (replace `/language:ruby` as needed). Only the newest analysis in each set is deletable (`deletable: true`); older IDs in the same chain cannot be deleted directly:
 
    ```bash
    gh api 'repos/eval-hub/eval-hub/code-scanning/analyses?ref=refs/heads/main&per_page=100' --paginate \
-     --jq '.[] | select(.category == "/language:ruby") | {id, category, created_at, commit_sha, deletable, results_count}'
+     --jq '[.[] | select(.category == "/language:ruby" and .deletable == true)] | sort_by(.created_at) | reverse | .[0] | {id, category, created_at, commit_sha, deletable, results_count}'
    ```
 
-2. Delete the reported analysis ID (listing alone does not remove it):
+2. Delete that deletable analysis ID (listing alone does not remove it):
 
    ```bash
    gh api -X DELETE 'repos/eval-hub/eval-hub/code-scanning/analyses/<ANALYSIS_ID>?confirm_delete=true'
    ```
 
-3. List again. GitHub only exposes the tip of each analysis chain, so another ID for the same category may appear. Repeat delete until the filter returns nothing.
+   A successful delete returns `next_analysis_url` and `confirm_delete_url` for the previous analysis in the set. Use `confirm_delete_url` (or DELETE with `?confirm_delete=true`) to keep removing analyses until both URLs are `null`. Prefer `confirm_delete_url` when clearing a leftover language entirely; `next_analysis_url` stops before the last analysis in the set.
+
+3. List again with the same filter. If another deletable analysis remains for the category, repeat steps 2–3 until the filter returns nothing (or `null`).
 
 4. Re-run checks on open PRs (or push a new commit). Existing PRs keep the old warning until Code scanning runs again against the cleaned `main` configuration.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,37 @@ Maintainers will acknowledge the report, investigate, and coordinate remediation
 
 This repository runs automated security checks in CI, including:
 
+- CodeQL analysis for Go and Python (`.github/workflows/codeql.yml`)
 - Gosec static analysis for Go code
 - OpenSSF Scorecard for repository security posture
 
 Results may appear under the repository **Security** tab when SARIF upload is enabled.
+
+### Neutral CodeQL / “configuration not found” on pull requests
+
+If a PR shows a grey (neutral) **CodeQL** / **Code scanning results** check with a warning like:
+
+> Code scanning cannot determine the alerts introduced by this pull request, because 1 configuration present on `refs/heads/main` was not found: Actions workflow (`codeql.yml`) — `/language:<lang>`
+
+then `main` still has a stored Code scanning analysis for a language (or category) that the current workflow no longer uploads on pull requests. That often happens after a language is removed from the CodeQL matrix (for example, dropping `ruby` while leaving old `/language:ruby` analyses on `main`).
+
+GitHub treats `neutral` as a passing required check, but the warning remains until the leftover analyses are deleted.
+
+**Cleanup (maintainers):**
+
+1. List leftover analyses for the missing category on `main` (replace `/language:ruby` as needed):
+
+   ```bash
+   gh api 'repos/eval-hub/eval-hub/code-scanning/analyses?ref=refs/heads/main&per_page=100' --paginate \
+     --jq '.[] | select(.category == "/language:ruby") | {id, category, created_at, commit_sha, deletable, results_count}'
+   ```
+
+2. Delete the reported analysis ID (listing alone does not remove it):
+
+   ```bash
+   gh api -X DELETE 'repos/eval-hub/eval-hub/code-scanning/analyses/<ANALYSIS_ID>?confirm_delete=true'
+   ```
+
+3. List again. GitHub only exposes the tip of each analysis chain, so another ID for the same category may appear. Repeat delete until the filter returns nothing.
+
+4. Re-run checks on open PRs (or push a new commit). Existing PRs keep the old warning until Code scanning runs again against the cleaned `main` configuration.


### PR DESCRIPTION
## Summary
- Document the neutral CodeQL / “configuration not found” PR warning caused by leftover Code scanning analyses (e.g. `/language:ruby` after the language was dropped from the matrix).
- Add maintainer steps to list, delete (iteratively), and re-check open PRs in `SECURITY.md`.

## Test plan
- [ ] Confirm the new section reads clearly under **Automated Security Checks** in `SECURITY.md`
- [ ] Optionally follow the listed `gh api` commands against a leftover category and confirm the warning clears on a subsequent PR check run


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded security check documentation to include CodeQL analysis and clarify where results may appear.
  * Added guidance for resolving neutral CodeQL checks caused by missing configuration or outdated scan entries.
  * Documented steps for maintainers to clean up stale code-scanning results and rerun checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->