### PR TITLE
ci: add golangci-lint workflow and replace Go Report Card badge

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,44 @@
+name: golangci-lint
+
+on:
+  push:
+    branches: [ main, develop ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main, develop ]
+
+permissions:
+  contents: read
+  # Required by golangci-lint-action when only-new-issues is enabled
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        # Needed for only-new-issues / merge_group --new-from-rev
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Set up Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version-file: "go.mod"
+        cache: true
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+      with:
+        # Keep in sync with .pre-commit-config.yaml
+        version: v2.12.2
+        # Existing findings are not cleaned up yet; fail only on newly introduced issues.
+        only-new-issues: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/eval-hub/eval-hub/actions/workflows/ci.yml/badge.svg)](https://github.com/eval-hub/eval-hub/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/eval-hub/eval-hub.svg)](https://pkg.go.dev/github.com/eval-hub/eval-hub)
-[![Go Report Card](https://goreportcard.com/badge/github.com/eval-hub/eval-hub)](https://goreportcard.com/report/github.com/eval-hub/eval-hub)
+[![golangci-lint](https://github.com/eval-hub/eval-hub/actions/workflows/golangci-lint.yml/badge.svg)](https://github.com/eval-hub/eval-hub/actions/workflows/golangci-lint.yml)
 [![codecov](https://codecov.io/github/eval-hub/eval-hub/graph/badge.svg?token=LHJACCNC9A)](https://codecov.io/github/eval-hub/eval-hub)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/eval-hub/eval-hub/badge)](https://scorecard.dev/viewer/?uri=github.com/eval-hub/eval-hub)
 [![TrustyAI Operator ConfigMap Sync](https://github.com/eval-hub/eval-hub/actions/workflows/check-trustyai-service-operator-configmap-sync.yml/badge.svg)](https://github.com/eval-hub/eval-hub/actions/workflows/check-trustyai-service-operator-configmap-sync.yml)


### PR DESCRIPTION
## Summary
- Replace the retired Go Report Card README badge with a green/red GitHub Actions status badge for golangci-lint
- Add a dedicated `golangci-lint` workflow (pinned actions, harden-runner, Go version from `go.mod`, version aligned with pre-commit `v2.12.2`)
- Enable `only-new-issues` so CI gates new findings without failing on the existing ~91 lint issues

## Test plan
- [ ] Confirm the new workflow appears under Actions after push/PR
- [ ] Confirm the README golangci-lint badge links to the workflow and shows a status once the first run completes
- [ ] Confirm a PR that introduces a new golangci-lint finding fails the `golangci-lint` check
- [ ] Confirm unrelated doc-only changes do not fail on legacy findings


Made with [Cursor](https://cursor.com)