### PR TITLE
chore: clean up golangci-lint findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+linters:
+  settings:
+    staticcheck:
+      # Default: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+      # Also disable ST1005 (error strings should not be capitalized).
+      checks:
+        - all
+        - "-ST1000"
+        - "-ST1003"
+        - "-ST1005"
+        - "-ST1016"
+        - "-ST1020"
+        - "-ST1021"
+        - "-ST1022"

--- a/cmd/eval_runtime_init/main.go
+++ b/cmd/eval_runtime_init/main.go
@@ -98,7 +98,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("open dest root: %w", err)
 	}
-	defer destRoot.Close()
+	defer func() { _ = destRoot.Close() }()
 
 	slog.Info("starting download", "bucket", bucket, "key", keyPrefix)
 
@@ -176,13 +176,12 @@ func downloadObject(ctx context.Context, client *s3.Client, destRoot *os.Root, b
 	if err != nil {
 		return 0, fmt.Errorf("get object %q: %w", key, err)
 	}
-	defer resp.Body.Close()
-
+	defer func() { _ = resp.Body.Close() }()
 	file, err := destRoot.Create(rel)
 	if err != nil {
 		return 0, fmt.Errorf("create file %q: %w", key, err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	written, err := io.Copy(file, resp.Body)
 	if err != nil {

--- a/cmd/eval_runtime_init/main_test.go
+++ b/cmd/eval_runtime_init/main_test.go
@@ -90,7 +90,7 @@ func TestDownloadObjectRejectsInvalidKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenRoot() = %v", err)
 	}
-	defer destRoot.Close()
+	defer func() { _ = destRoot.Close() }()
 
 	_, err = downloadObject(context.Background(), nil, destRoot, "bucket", "datasets/run-1", "datasets/run-1/../../etc/passwd")
 	if err == nil {
@@ -129,7 +129,7 @@ func TestDownloadObjectWritesNestedFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenRoot() = %v", err)
 	}
-	defer destRoot.Close()
+	defer func() { _ = destRoot.Close() }()
 
 	written, err := downloadObject(ctx, client, destRoot, "bucket", "data/", objectKey)
 	if err != nil {

--- a/cmd/evalhub_mcp/main_test.go
+++ b/cmd/evalhub_mcp/main_test.go
@@ -13,11 +13,11 @@ func TestHelpFlag(t *testing.T) {
 
 	code := run([]string{"--help"})
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	_, _ = buf.ReadFrom(r)
 	output := buf.String()
 
 	if code != 0 {
@@ -38,11 +38,11 @@ func TestVersionFlag(t *testing.T) {
 
 	code := run([]string{"--version"})
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	_, _ = buf.ReadFrom(r)
 	output := buf.String()
 
 	if code != 0 {
@@ -70,11 +70,11 @@ func TestVersionFlagWithBuildInfo(t *testing.T) {
 
 	code := run([]string{"--version"})
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	_, _ = buf.ReadFrom(r)
 	output := buf.String()
 
 	if code != 0 {

--- a/internal/eval_hub/config/loader_test.go
+++ b/internal/eval_hub/config/loader_test.go
@@ -189,7 +189,11 @@ secrets:
 			t.Fatalf("Failed to create secret: %v", err)
 		}
 		t.Cleanup(func() {
-			_ = os.Remove(secretPath)
+			t.Cleanup(func() {
+				if err := os.Remove(secretPath); err != nil && !os.IsNotExist(err) {
+					t.Errorf("remove test secret: %v", err)
+				}
+			})
 		})
 		serviceConfig, err := config.LoadConfig(logger, version, "local", time.Now().Format(time.RFC3339), "", "../../../tests/secrets")
 		if err != nil {

--- a/internal/eval_hub/config/loader_test.go
+++ b/internal/eval_hub/config/loader_test.go
@@ -32,10 +32,7 @@ func TestLoadConfig(t *testing.T) {
 	})
 
 	t.Run("setting environment variables", func(t *testing.T) {
-		os.Setenv("MLFLOW_TRACKING_URI", "http://localhost:9999")
-		t.Cleanup(func() {
-			os.Unsetenv("MLFLOW_TRACKING_URI")
-		})
+		t.Setenv("MLFLOW_TRACKING_URI", "http://localhost:9999")
 		serviceConfig, err := config.LoadConfig(logger, version, "local", time.Now().Format(time.RFC3339), "../../../tests")
 		if err != nil {
 			t.Fatalf("Failed to load config: %v", err)
@@ -76,10 +73,7 @@ database:
 			t.Fatalf("Failed to write operator config: %v", err)
 		}
 
-		os.Setenv("CONFIG_PATH", filepath.Join(operatorDir, "config.yaml"))
-		t.Cleanup(func() {
-			os.Unsetenv("CONFIG_PATH")
-		})
+		t.Setenv("CONFIG_PATH", filepath.Join(operatorDir, "config.yaml"))
 
 		serviceConfig, err := config.LoadConfig(logger, version, "local", time.Now().Format(time.RFC3339), baseDir)
 		if err != nil {
@@ -127,10 +121,7 @@ secrets:
 			t.Fatalf("Failed to write operator config: %v", err)
 		}
 
-		os.Setenv("CONFIG_PATH", filepath.Join(operatorDir, "config.yaml"))
-		t.Cleanup(func() {
-			os.Unsetenv("CONFIG_PATH")
-		})
+		t.Setenv("CONFIG_PATH", filepath.Join(operatorDir, "config.yaml"))
 
 		serviceConfig, err := config.LoadConfig(logger, version, "local", time.Now().Format(time.RFC3339), baseDir)
 		if err != nil {
@@ -177,10 +168,7 @@ secrets:
 			t.Fatalf("Failed to write operator config: %v", err)
 		}
 
-		os.Setenv("CONFIG_PATH", filepath.Join(operatorDir, "config.yaml"))
-		t.Cleanup(func() {
-			os.Unsetenv("CONFIG_PATH")
-		})
+		t.Setenv("CONFIG_PATH", filepath.Join(operatorDir, "config.yaml"))
 
 		// Should NOT fail looking for /tmp/db_password
 		serviceConfig, err := config.LoadConfig(logger, version, "local", time.Now().Format(time.RFC3339), baseDir)
@@ -201,7 +189,7 @@ secrets:
 			t.Fatalf("Failed to create secret: %v", err)
 		}
 		t.Cleanup(func() {
-			os.Remove(secretPath)
+			_ = os.Remove(secretPath)
 		})
 		serviceConfig, err := config.LoadConfig(logger, version, "local", time.Now().Format(time.RFC3339), "", "../../../tests/secrets")
 		if err != nil {
@@ -314,7 +302,9 @@ func TestLoadProviderConfigs(t *testing.T) {
 	t.Run("loads providers from explicit config dir", func(t *testing.T) {
 		dir := t.TempDir()
 		provDir := filepath.Join(dir, "providers")
-		os.MkdirAll(provDir, 0755)
+		if err := os.MkdirAll(provDir, 0755); err != nil {
+			t.Fatalf("MkdirAll providers: %v", err)
+		}
 		writeProviderYAML(t, provDir, "alpha", "Alpha Provider")
 
 		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), dir)
@@ -332,7 +322,9 @@ func TestLoadProviderConfigs(t *testing.T) {
 	t.Run("loads multiple providers from explicit dir", func(t *testing.T) {
 		dir := t.TempDir()
 		provDir := filepath.Join(dir, "providers")
-		os.MkdirAll(provDir, 0755)
+		if err := os.MkdirAll(provDir, 0755); err != nil {
+			t.Fatalf("MkdirAll providers: %v", err)
+		}
 		writeProviderYAML(t, provDir, "alpha", "Alpha")
 		writeProviderYAML(t, provDir, "beta", "Beta")
 		writeProviderYAML(t, provDir, "gamma", "Gamma")
@@ -349,9 +341,13 @@ func TestLoadProviderConfigs(t *testing.T) {
 	t.Run("fail providers with missing id", func(t *testing.T) {
 		dir := t.TempDir()
 		provDir := filepath.Join(dir, "providers")
-		os.MkdirAll(provDir, 0755)
+		if err := os.MkdirAll(provDir, 0755); err != nil {
+			t.Fatalf("MkdirAll providers: %v", err)
+		}
 		content := "name: No ID Provider\ndescription: missing id field\n"
-		os.WriteFile(filepath.Join(provDir, "noid.yaml"), []byte(content), 0600)
+		if err := os.WriteFile(filepath.Join(provDir, "noid.yaml"), []byte(content), 0600); err != nil {
+			t.Fatalf("Failed to write noid.yaml: %v", err)
+		}
 
 		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), dir)
 		if err == nil {
@@ -365,10 +361,16 @@ func TestLoadProviderConfigs(t *testing.T) {
 	t.Run("ignores non-yaml files", func(t *testing.T) {
 		dir := t.TempDir()
 		provDir := filepath.Join(dir, "providers")
-		os.MkdirAll(provDir, 0755)
+		if err := os.MkdirAll(provDir, 0755); err != nil {
+			t.Fatalf("MkdirAll providers: %v", err)
+		}
 		writeProviderYAML(t, provDir, "alpha", "Alpha")
-		os.WriteFile(filepath.Join(provDir, "readme.txt"), []byte("ignore me"), 0600)
-		os.MkdirAll(filepath.Join(provDir, "subdir"), 0755)
+		if err := os.WriteFile(filepath.Join(provDir, "readme.txt"), []byte("ignore me"), 0600); err != nil {
+			t.Fatalf("Failed to write readme.txt: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(provDir, "subdir"), 0755); err != nil {
+			t.Fatalf("MkdirAll subdir: %v", err)
+		}
 
 		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), dir)
 		if err != nil {
@@ -405,7 +407,9 @@ func TestLoadProviderConfigs(t *testing.T) {
 	t.Run("provider fields are correctly parsed", func(t *testing.T) {
 		dir := t.TempDir()
 		provDir := filepath.Join(dir, "providers")
-		os.MkdirAll(provDir, 0755)
+		if err := os.MkdirAll(provDir, 0755); err != nil {
+			t.Fatalf("MkdirAll providers: %v", err)
+		}
 		content := `id: mytest
 name: My Test Provider
 description: A test provider for unit testing
@@ -416,7 +420,9 @@ benchmarks:
     description: First benchmark
     category: safety
 `
-		os.WriteFile(filepath.Join(provDir, "mytest.yaml"), []byte(content), 0600)
+		if err := os.WriteFile(filepath.Join(provDir, "mytest.yaml"), []byte(content), 0600); err != nil {
+			t.Fatalf("Failed to write mytest.yaml: %v", err)
+		}
 
 		providers, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t), dir)
 		if err != nil {

--- a/internal/eval_hub/config/watcher.go
+++ b/internal/eval_hub/config/watcher.go
@@ -44,7 +44,7 @@ func (w *Watcher) Watch(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer watcher.Close()
+	defer func() { _ = watcher.Close() }()
 
 	providerDir := w.resolveDir("providers")
 	collectionDir := w.resolveDir("collections")

--- a/internal/eval_hub/config/watcher_test.go
+++ b/internal/eval_hub/config/watcher_test.go
@@ -50,8 +50,12 @@ func TestWatcher_ReloadsOnFileChange(t *testing.T) {
 	dir := t.TempDir()
 	provDir := filepath.Join(dir, "providers")
 	collDir := filepath.Join(dir, "collections")
-	os.MkdirAll(provDir, 0755)
-	os.MkdirAll(collDir, 0755)
+	if err := os.MkdirAll(provDir, 0755); err != nil {
+		t.Fatalf("MkdirAll providers: %v", err)
+	}
+	if err := os.MkdirAll(collDir, 0755); err != nil {
+		t.Fatalf("MkdirAll collections: %v", err)
+	}
 
 	// Write initial provider config
 	writeTestProvider(t, provDir, "alpha", "Alpha Provider")
@@ -80,10 +84,7 @@ func TestWatcher_ReloadsOnFileChange(t *testing.T) {
 
 	// Wait for the debounced reload to fire
 	deadline := time.After(3 * time.Second)
-	for {
-		if store.getLoadCalls() > 0 {
-			break
-		}
+	for store.getLoadCalls() == 0 {
 		select {
 		case <-deadline:
 			t.Fatal("Timed out waiting for reload after file change")
@@ -105,8 +106,12 @@ func TestWatcher_DebouncesMutipleEvents(t *testing.T) {
 	dir := t.TempDir()
 	provDir := filepath.Join(dir, "providers")
 	collDir := filepath.Join(dir, "collections")
-	os.MkdirAll(provDir, 0755)
-	os.MkdirAll(collDir, 0755)
+	if err := os.MkdirAll(provDir, 0755); err != nil {
+		t.Fatalf("MkdirAll providers: %v", err)
+	}
+	if err := os.MkdirAll(collDir, 0755); err != nil {
+		t.Fatalf("MkdirAll collections: %v", err)
+	}
 
 	logger := logging.FallbackLogger()
 	store := &mockStorage{}
@@ -142,7 +147,9 @@ func TestWatcher_DebouncesMutipleEvents(t *testing.T) {
 func TestWatcher_StopsOnContextCancel(t *testing.T) {
 	dir := t.TempDir()
 	provDir := filepath.Join(dir, "providers")
-	os.MkdirAll(provDir, 0755)
+	if err := os.MkdirAll(provDir, 0755); err != nil {
+		t.Fatalf("MkdirAll providers: %v", err)
+	}
 
 	logger := logging.FallbackLogger()
 	store := &mockStorage{}

--- a/internal/eval_hub/evalcards/oci_factory_test.go
+++ b/internal/eval_hub/evalcards/oci_factory_test.go
@@ -70,7 +70,7 @@ func TestOCIPublisherFactoryNewPublisher(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPublisher() err = %v", err)
 	}
-	defer publisher.Close()
+	defer func() { _ = publisher.Close() }()
 
 	cardJSON, err := json.Marshal(&cards.EvaluationCard{CardVersion: cards.CardVersion})
 	if err != nil {

--- a/internal/eval_hub/evalcards/oci_http_client_test.go
+++ b/internal/eval_hub/evalcards/oci_http_client_test.go
@@ -158,7 +158,7 @@ func writeTestCACert(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("Create() err = %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if err := pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
 		t.Fatalf("pem.Encode() err = %v", err)
 	}

--- a/internal/eval_hub/evalcards/persistence.go
+++ b/internal/eval_hub/evalcards/persistence.go
@@ -189,7 +189,7 @@ func (t *ociTarget) Export(ctx context.Context, job *api.EvaluationJobResource, 
 	if err != nil {
 		return "", err
 	}
-	defer publisher.Close()
+	defer func() { _ = publisher.Close() }()
 
 	cardJSON, err := json.Marshal(card)
 	if err != nil {

--- a/internal/eval_hub/handlers/evaluations_test.go
+++ b/internal/eval_hub/handlers/evaluations_test.go
@@ -209,23 +209,6 @@ func (s *updateEvaluationStorage) UpdateEvaluationJob(_ string, status *api.Stat
 	return s.updateErr
 }
 
-type deleteRequest struct {
-	*MockRequest
-	queryValues map[string][]string
-	pathValues  map[string]string
-}
-
-func (r *deleteRequest) Query(key string) []string {
-	if values, ok := r.queryValues[key]; ok {
-		return values
-	}
-	return []string{}
-}
-
-func (r *deleteRequest) PathValue(name string) string {
-	return r.pathValues[name]
-}
-
 func TestResolveProvider_FromMap(t *testing.T) {
 	providers := map[string]api.ProviderResource{
 		"p1": {Resource: api.Resource{ID: "p1"}},

--- a/internal/eval_hub/handlers/job_benchmarks_test.go
+++ b/internal/eval_hub/handlers/job_benchmarks_test.go
@@ -310,7 +310,7 @@ func TestGetJobBenchmarks(t *testing.T) {
 		if !reflect.DeepEqual(got[1].Parameters, want1) {
 			t.Fatalf("second benchmark parameters = %#v, want %#v", got[1].Parameters, want1)
 		}
-		if got[0].Ref.ID != "a-ref" || got[1].Ref.ID != "b-ref" {
+		if got[0].ID != "a-ref" || got[1].ID != "b-ref" {
 			t.Fatalf("Refs = %+v, %+v", got[0].Ref, got[1].Ref)
 		}
 	})

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -389,11 +389,11 @@ func TestBuildJobWithOCICredentials(t *testing.T) {
 	for _, v := range job.Spec.Template.Spec.Volumes {
 		if v.Name == ociCredentialsVolumeName {
 			foundVolume = true
-			if v.VolumeSource.Secret == nil {
+			if v.Secret == nil {
 				t.Fatalf("expected secret volume source for %s", ociCredentialsVolumeName)
 			}
-			if v.VolumeSource.Secret.SecretName != "my-pull-secret" {
-				t.Fatalf("expected secret name %q, got %q", "my-pull-secret", v.VolumeSource.Secret.SecretName)
+			if v.Secret.SecretName != "my-pull-secret" {
+				t.Fatalf("expected secret name %q, got %q", "my-pull-secret", v.Secret.SecretName)
 			}
 		}
 	}
@@ -615,7 +615,7 @@ func TestBuildJobWithS3TestData(t *testing.T) {
 		}
 		if v.Name == testDataSecretVolumeName {
 			foundSecretVolume = true
-			if v.VolumeSource.Secret == nil || v.VolumeSource.Secret.SecretName != "s3-secret" {
+			if v.Secret == nil || v.Secret.SecretName != "s3-secret" {
 				t.Fatalf("expected secret volume %q with secret %q", testDataSecretVolumeName, "s3-secret")
 			}
 		}
@@ -701,13 +701,13 @@ func TestBuildJobWithModelAuthSecret(t *testing.T) {
 	if foundVolume == nil {
 		t.Fatalf("expected projected volume %s on adapter", modelInternalAuthVolumeName)
 	}
-	if foundVolume.VolumeSource.Projected == nil {
+	if foundVolume.Projected == nil {
 		t.Fatalf("expected projected volume source for %s", modelInternalAuthVolumeName)
 	}
-	if len(foundVolume.VolumeSource.Projected.Sources) != 1 {
-		t.Fatalf("expected exactly 1 projected source (passthrough only), got %d", len(foundVolume.VolumeSource.Projected.Sources))
+	if len(foundVolume.Projected.Sources) != 1 {
+		t.Fatalf("expected exactly 1 projected source (passthrough only), got %d", len(foundVolume.Projected.Sources))
 	}
-	src := foundVolume.VolumeSource.Projected.Sources[0]
+	src := foundVolume.Projected.Sources[0]
 	if src.Secret == nil || src.Secret.Name != "model-auth-secret" {
 		t.Fatalf("expected projected source from real secret %q, got %+v", "model-auth-secret", src)
 	}
@@ -961,11 +961,11 @@ func TestBuildJobSATokenSidecarOnly(t *testing.T) {
 	for _, v := range job.Spec.Template.Spec.Volumes {
 		if v.Name == evalhubSATokenVolumeName {
 			foundPodVolume = true
-			if v.VolumeSource.Projected == nil {
+			if v.Projected == nil {
 				t.Fatal("evalhub-sa-token volume must be a projected volume")
 			}
 			hasSAToken := false
-			for _, src := range v.VolumeSource.Projected.Sources {
+			for _, src := range v.Projected.Sources {
 				if src.ServiceAccountToken != nil {
 					hasSAToken = true
 				}
@@ -1017,11 +1017,11 @@ func TestBuildJobSATokenSidecarOnly(t *testing.T) {
 	for _, v := range job.Spec.Template.Spec.Volumes {
 		if v.Name == adapterNamespaceVolumeName {
 			foundNamespaceVolume = true
-			if v.VolumeSource.Projected == nil {
+			if v.Projected == nil {
 				t.Fatal("pod-namespace volume must be a projected volume")
 			}
 			hasDownwardAPI := false
-			for _, src := range v.VolumeSource.Projected.Sources {
+			for _, src := range v.Projected.Sources {
 				if src.DownwardAPI != nil {
 					hasDownwardAPI = true
 				}

--- a/internal/eval_hub/runtimes/k8s/k8s_helper.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper.go
@@ -117,10 +117,10 @@ func (h *KubernetesHelper) CreateConfigMap(
 	}
 	if opts != nil {
 		if len(opts.Labels) > 0 {
-			cm.ObjectMeta.Labels = opts.Labels
+			cm.Labels = opts.Labels
 		}
 		if len(opts.Annotations) > 0 {
-			cm.ObjectMeta.Annotations = opts.Annotations
+			cm.Annotations = opts.Annotations
 		}
 	}
 	return h.clientset.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
@@ -264,7 +264,7 @@ func (h *KubernetesHelper) GetPodLogs(ctx context.Context, namespace, podName st
 	if err != nil {
 		return "", err
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 	data, err := io.ReadAll(stream)
 	if err != nil {
 		return "", err

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_test.go
@@ -435,7 +435,7 @@ func TestCreateBenchmarkResourcesAddsModelAuthVolumeAndEnvIntegration(t *testing
 	for _, volume := range job.Spec.Template.Spec.Volumes {
 		if volume.Name == modelAuthVolumeName {
 			foundVolume = true
-			if volume.VolumeSource.Secret == nil || volume.VolumeSource.Secret.SecretName != "model-auth-secret" {
+			if volume.Secret == nil || volume.Secret.SecretName != "model-auth-secret" {
 				t.Fatalf("expected model auth secret volume to reference %q", "model-auth-secret")
 			}
 		}
@@ -557,7 +557,7 @@ func TestCreateBenchmarkResourcesAddsInitContainerForS3TestDataIntegration(t *te
 		}
 		if volume.Name == testDataSecretVolumeName {
 			foundSecretVolume = true
-			if volume.VolumeSource.Secret == nil || volume.VolumeSource.Secret.SecretName != "s3-secret" {
+			if volume.Secret == nil || volume.Secret.SecretName != "s3-secret" {
 				t.Fatalf("expected secret volume %q with secret %q", testDataSecretVolumeName, "s3-secret")
 			}
 		}

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -458,7 +458,7 @@ func TestCreateBenchmarkResourcesAddsInitContainerForS3TestData(t *testing.T) {
 		}
 		if volume.Name == testDataSecretVolumeName {
 			foundSecretVolume = true
-			if volume.VolumeSource.Secret == nil || volume.VolumeSource.Secret.SecretName != "s3-secret" {
+			if volume.Secret == nil || volume.Secret.SecretName != "s3-secret" {
 				t.Fatalf("expected secret volume %q with secret %q", testDataSecretVolumeName, "s3-secret")
 			}
 		}
@@ -528,13 +528,13 @@ func TestCreateBenchmarkResourcesMountsPVCTestData(t *testing.T) {
 	var foundPVCVolume bool
 	for _, volume := range job.Spec.Template.Spec.Volumes {
 		if volume.Name == testDataVolumeName {
-			if volume.VolumeSource.PersistentVolumeClaim == nil {
+			if volume.PersistentVolumeClaim == nil {
 				t.Fatalf("expected PVC volume source for %q", testDataVolumeName)
 			}
-			if volume.VolumeSource.PersistentVolumeClaim.ClaimName != "eval-datasets-pvc" {
-				t.Fatalf("expected claimName %q, got %q", "eval-datasets-pvc", volume.VolumeSource.PersistentVolumeClaim.ClaimName)
+			if volume.PersistentVolumeClaim.ClaimName != "eval-datasets-pvc" {
+				t.Fatalf("expected claimName %q, got %q", "eval-datasets-pvc", volume.PersistentVolumeClaim.ClaimName)
 			}
-			if !volume.VolumeSource.PersistentVolumeClaim.ReadOnly {
+			if !volume.PersistentVolumeClaim.ReadOnly {
 				t.Fatal("expected PVC volume to be read-only")
 			}
 			foundPVCVolume = true
@@ -1178,8 +1178,8 @@ func sampleProviders(providerID string) map[string]api.ProviderResource {
 func findConfigMapVolumeName(t *testing.T, volumes []corev1.Volume) string {
 	t.Helper()
 	for _, v := range volumes {
-		if v.VolumeSource.ConfigMap != nil {
-			return v.VolumeSource.ConfigMap.Name
+		if v.ConfigMap != nil {
+			return v.ConfigMap.Name
 		}
 	}
 	t.Fatal("expected a ConfigMap-backed volume on the pod")

--- a/internal/eval_hub/runtimes/local/local_runtime_test.go
+++ b/internal/eval_hub/runtimes/local/local_runtime_test.go
@@ -191,7 +191,7 @@ func localJobDir(jobID string, benchmarkIndex int, providerID, benchmarkID strin
 func cleanupDir(t *testing.T, jobID string) {
 	t.Helper()
 	t.Cleanup(func() {
-		os.RemoveAll(filepath.Join(localJobsBaseDir, jobID))
+		_ = os.RemoveAll(filepath.Join(localJobsBaseDir, jobID))
 	})
 }
 
@@ -936,7 +936,7 @@ func TestDeleteEvaluationJobResources(t *testing.T) {
 
 	// Verify the benchmark directory was removed
 	if _, err := os.Stat(dirName); !os.IsNotExist(err) {
-		os.RemoveAll(dirName) // Clean up before failing
+		_ = os.RemoveAll(dirName) // Clean up before failing
 		t.Fatalf("expected directory %s to be removed", dirName)
 	}
 }

--- a/internal/eval_hub/runtimes/shared/logs.go
+++ b/internal/eval_hub/runtimes/shared/logs.go
@@ -24,7 +24,7 @@ func TailFileLines(path string, n int) (string, error) {
 		}
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
 	if err != nil {

--- a/internal/eval_hub/server/cors_middleware_test.go
+++ b/internal/eval_hub/server/cors_middleware_test.go
@@ -65,7 +65,7 @@ func TestCorsMiddleware_HeadersSet(t *testing.T) {
 			// Create a mock handler that returns 200 OK
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("OK"))
+				_, _ = w.Write([]byte("OK"))
 			})
 
 			// Wrap with CORS middleware
@@ -174,7 +174,7 @@ func TestCorsMiddleware_PassThrough(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			called = true
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("test response"))
+			_, _ = w.Write([]byte("test response"))
 		})
 
 		wrapped := CorsMiddleware(handler, &config.Config{})
@@ -202,7 +202,7 @@ func TestCorsMiddleware_PassThrough(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			called = true
 			w.WriteHeader(http.StatusCreated)
-			w.Write([]byte("created"))
+			_, _ = w.Write([]byte("created"))
 		})
 
 		wrapped := CorsMiddleware(handler, &config.Config{})

--- a/internal/eval_hub/server/server_test.go
+++ b/internal/eval_hub/server/server_test.go
@@ -99,7 +99,7 @@ func (r *stubRuntime) GetEvaluationLogs(
 
 func TestNewServer(t *testing.T) {
 	t.Run("creates server with default port", func(t *testing.T) {
-		os.Unsetenv("PORT")
+		_ = os.Unsetenv("PORT")
 		srv, err := createServer(t, 8080)
 		if err != nil {
 			t.Fatalf("NewServer() returned error: %v", err)

--- a/internal/eval_hub/storage/sql/collections.go
+++ b/internal/eval_hub/storage/sql/collections.go
@@ -8,7 +8,6 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
-	se "github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/storage/sql/shared"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
@@ -56,16 +55,16 @@ func (s *sqlStorage) getCollectionTransactional(txn *sql.Tx, id string) (*api.Co
 	err := s.queryRow(txn, selectQuery, selectArgs...).Scan(queryArgs...)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, se.NewServiceError(messages.ResourceNotFound, "Type", "collection", "ResourceId", id)
+			return nil, serviceerrors.NewServiceError(messages.ResourceNotFound, "Type", "collection", "ResourceId", id)
 		}
 		// For now we differentiate between no rows found and other errors but this might be confusing
 		s.logger.Error("Failed to get collection", "error", err, "id", id)
-		return nil, se.NewServiceError(messages.DatabaseOperationFailed, "Type", "collection", "ResourceId", id, "Error", err.Error())
+		return nil, serviceerrors.NewServiceError(messages.DatabaseOperationFailed, "Type", "collection", "ResourceId", id, "Error", err.Error())
 	}
 
 	// now check that the tenant_id is allowed to see this resource
 	if !s.isVisibleResource(&query.Resource) {
-		return nil, se.NewServiceError(messages.ResourceNotFound, "Type", "collection", "ResourceId", id)
+		return nil, serviceerrors.NewServiceError(messages.ResourceNotFound, "Type", "collection", "ResourceId", id)
 	}
 
 	// Unmarshal the entity JSON into EvaluationJobConfig
@@ -73,7 +72,7 @@ func (s *sqlStorage) getCollectionTransactional(txn *sql.Tx, id string) (*api.Co
 	err = json.Unmarshal([]byte(query.EntityJSON), &collectionConfig)
 	if err != nil {
 		s.logger.Error("Failed to unmarshal collection config", "error", err, "id", id)
-		return nil, se.NewServiceError(messages.JSONUnmarshalFailed, "Type", "collection", "Error", err.Error())
+		return nil, serviceerrors.NewServiceError(messages.JSONUnmarshalFailed, "Type", "collection", "Error", err.Error())
 	}
 
 	collectionResource := api.CollectionResource{
@@ -101,7 +100,7 @@ func (s *sqlStorage) UpdateCollection(id string, collection *api.CollectionConfi
 			return err
 		}
 		if persistedCollection.Resource.IsSystemResource() {
-			return se.NewServiceError(
+			return serviceerrors.NewServiceError(
 				messages.ReadOnlyCollection,
 				"CollectionID", id,
 			)
@@ -138,7 +137,7 @@ func (s *sqlStorage) deleteCollectionTxn(txn *sql.Tx, id string) error {
 	_, err := s.exec(txn, deleteQuery, args...)
 	if err != nil {
 		s.logger.Error("Failed to delete collection", "error", err, "id", id)
-		return se.NewServiceError(messages.DatabaseOperationFailed, "Type", "collection", "ResourceId", id, "Error", err.Error())
+		return serviceerrors.NewServiceError(messages.DatabaseOperationFailed, "Type", "collection", "ResourceId", id, "Error", err.Error())
 	}
 
 	s.logger.Debug("Deleted collection", "id", id)
@@ -153,7 +152,7 @@ func (s *sqlStorage) DeleteCollection(id string) error {
 			return err
 		}
 		if persistedCollection.Resource.IsSystemResource() {
-			return se.NewServiceError(
+			return serviceerrors.NewServiceError(
 				messages.ReadOnlyCollection,
 				"CollectionID", persistedCollection.Resource.ID,
 			)
@@ -171,7 +170,7 @@ func (s *sqlStorage) PatchCollection(id string, patches *api.Patch) (*api.Collec
 			return err
 		}
 		if persistedCollection.Resource.Owner == "system" {
-			return se.NewServiceError(
+			return serviceerrors.NewServiceError(
 				messages.ReadOnlyCollection,
 				"CollectionID", id,
 			)

--- a/internal/eval_hub/storage/sql/collections_test.go
+++ b/internal/eval_hub/storage/sql/collections_test.go
@@ -48,17 +48,17 @@ func TestCollections_PassCriteria(t *testing.T) {
 			t.Errorf("expected 2 collections, got %d", len(res.Items))
 		}
 		for _, coll := range res.Items {
-			if coll.CollectionConfig.PassCriteria == nil || coll.CollectionConfig.PassCriteria.Threshold == nil {
+			if coll.PassCriteria == nil || coll.PassCriteria.Threshold == nil {
 				t.Fatalf("collection %s is missing pass criteria", coll.Resource.ID)
 			}
-			passCriteria := *coll.CollectionConfig.PassCriteria.Threshold
+			passCriteria := *coll.PassCriteria.Threshold
 			if passCriteria < 0.0 {
 				t.Errorf("expected pass criteria to be at least 0.0, got %f", passCriteria)
 			}
 			// calculate the weighted average score
 			weightedAverage := float32(0.0)
 			totalWeight := float32(0.0)
-			for _, benchmark := range coll.CollectionConfig.Benchmarks {
+			for _, benchmark := range coll.Benchmarks {
 				if benchmark.PassCriteria == nil || benchmark.PassCriteria.Threshold == nil {
 					t.Fatalf("collection %s benchmark %s is missing pass criteria", coll.Resource.ID, benchmark.ID)
 				}
@@ -129,7 +129,7 @@ func TestCollections_BenchmarksExist(t *testing.T) {
 			t.Errorf("expected 2 collections, got %d", len(res.Items))
 		}
 		for _, coll := range res.Items {
-			for _, benchmark := range coll.CollectionConfig.Benchmarks {
+			for _, benchmark := range coll.Benchmarks {
 				if benchmark.ProviderID == "" {
 					t.Fatalf("expected provider ID for benchmark %s", benchmark.ID)
 				}

--- a/internal/eval_hub/storage/sql/evaluations.go
+++ b/internal/eval_hub/storage/sql/evaluations.go
@@ -534,8 +534,8 @@ func (s *sqlStorage) computeJobTestResult(job *api.EvaluationJobResource, collec
 }
 
 func getPassCriteriaThreshold(job *api.EvaluationJobResource, collection *api.CollectionResource) float32 {
-	if job.EvaluationJobConfig.PassCriteria != nil && job.EvaluationJobConfig.PassCriteria.Threshold != nil {
-		return *job.EvaluationJobConfig.PassCriteria.Threshold
+	if job.PassCriteria != nil && job.PassCriteria.Threshold != nil {
+		return *job.PassCriteria.Threshold
 	}
 	if collection != nil && collection.PassCriteria != nil && collection.PassCriteria.Threshold != nil {
 		return *collection.PassCriteria.Threshold

--- a/internal/eval_hub/storage/sql/evaluations_test.go
+++ b/internal/eval_hub/storage/sql/evaluations_test.go
@@ -740,7 +740,7 @@ func testEvaluationsStorage(t *testing.T, driver string, databaseName string) {
 		if evaluationId == "" {
 			t.Fatalf("Evaluation ID is empty")
 		}
-		if job.EvaluationJobConfig.Collection != nil {
+		if job.Collection != nil {
 			t.Fatalf("Collection is not nil")
 		}
 	})

--- a/internal/eval_hub/storage/sql/list.go
+++ b/internal/eval_hub/storage/sql/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
-	se "github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/storage/sql/shared"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
@@ -70,7 +69,7 @@ func listEntities[T api.EvaluationJobResource | api.ProviderResource | api.Colle
 		s.logger.Error(fmt.Sprintf("Failed to list %s", typeName), "error", err)
 		return nil, serviceerrors.NewServiceError(messages.QueryFailed, "Type", typeName, "Error", err.Error())
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	// Process rows (use make so empty result serializes to [] not null)
 	items := make([]T, 0)
@@ -112,7 +111,7 @@ func scanResource[T api.EvaluationJobResource | api.ProviderResource | api.Colle
 		err = json.Unmarshal([]byte(query.EntityJSON), &storedEntity)
 		if err == nil {
 			resource, err := constructEvaluationResource(s.logger, &query, query.Status, &storedEntity)
-			var t T = any(*resource).(T)
+			t := any(*resource).(T)
 			return &t, err
 		}
 	case shared.TABLE_PROVIDERS:
@@ -123,7 +122,7 @@ func scanResource[T api.EvaluationJobResource | api.ProviderResource | api.Colle
 				Resource:       query.Resource,
 				ProviderConfig: storedEntity,
 			}
-			var t T = any(*resource).(T)
+			t := any(*resource).(T)
 			return &t, nil
 		}
 	case shared.TABLE_COLLECTIONS:
@@ -134,11 +133,11 @@ func scanResource[T api.EvaluationJobResource | api.ProviderResource | api.Colle
 				Resource:         query.Resource,
 				CollectionConfig: storedEntity,
 			}
-			var t T = any(*resource).(T)
+			t := any(*resource).(T)
 			return &t, nil
 		}
 	default:
-		err = se.NewServiceError(messages.InternalServerError, "Error", fmt.Sprintf("Unknown table name: %s", tableName))
+		err = serviceerrors.NewServiceError(messages.InternalServerError, "Error", fmt.Sprintf("Unknown table name: %s", tableName))
 	}
 
 	return nil, err
@@ -148,17 +147,17 @@ func constructEvaluationResource(logger *slog.Logger, query *shared.EntityQuery,
 	if query == nil {
 		logger.Error("Failed to construct evaluation job resource", "error", "Missing evaluation query")
 		// Post-read validation: no writes done, so do not request rollback.
-		return nil, se.NewServiceError(messages.InternalServerError, "Error", "Evaluation resource query does not exist")
+		return nil, serviceerrors.NewServiceError(messages.InternalServerError, "Error", "Evaluation resource query does not exist")
 	}
 	if evaluationEntity == nil {
 		logger.Error("Failed to construct evaluation job resource", "error", "Evaluation entity does not exist", "id", query.Resource.ID)
 		// Post-read validation: no writes done, so do not request rollback.
-		return nil, se.NewServiceError(messages.InternalServerError, "Error", "Evaluation entity does not exist")
+		return nil, serviceerrors.NewServiceError(messages.InternalServerError, "Error", "Evaluation entity does not exist")
 	}
 	if evaluationEntity.Config == nil {
 		logger.Error("Failed to construct evaluation job resource", "error", "Evaluation config does not exist", "id", query.Resource.ID)
 		// Post-read validation: no writes done, so do not request rollback.
-		return nil, se.NewServiceError(messages.InternalServerError, "Error", "Evaluation config does not exist")
+		return nil, serviceerrors.NewServiceError(messages.InternalServerError, "Error", "Evaluation config does not exist")
 	}
 	if evaluationEntity.Status == nil {
 		evaluationEntity.Status = &api.EvaluationJobStatus{}

--- a/internal/eval_hub/storage/sql/postgres/statements.go
+++ b/internal/eval_hub/storage/sql/postgres/statements.go
@@ -204,7 +204,7 @@ func (s *postgresStatementsFactory) getWhereStatement(tenant api.Tenant, id stri
 	var sb strings.Builder
 	var args []any
 	if id != "" {
-		sb.WriteString(fmt.Sprintf(`id = $%d`, index))
+		fmt.Fprintf(&sb, `id = $%d`, index)
 		index++
 		args = append(args, id)
 	}
@@ -214,7 +214,7 @@ func (s *postgresStatementsFactory) getWhereStatement(tenant api.Tenant, id stri
 		if sb.Len() > 0 {
 			sb.WriteString(" AND ")
 		}
-		sb.WriteString(fmt.Sprintf("(tenant_id = $%d OR owner = '%s')", index, abstractions.OwnerSystem))
+		fmt.Fprintf(&sb, "(tenant_id = $%d OR owner = '%s')", index, abstractions.OwnerSystem)
 		args = append(args, tenant.String())
 	}
 	return sb.String(), args

--- a/internal/eval_hub/storage/sql/providers_gpu_test.go
+++ b/internal/eval_hub/storage/sql/providers_gpu_test.go
@@ -45,7 +45,11 @@ func TestProviderStorage_GPURuntimeRoundTrip(t *testing.T) {
 	if err := store.CreateProvider(provider); err != nil {
 		t.Fatalf("CreateProvider failed: %v", err)
 	}
-	defer func() { _ = store.DeleteProvider("gpu-provider-1") }()
+	t.Cleanup(func() {
+		if err := store.DeleteProvider("gpu-provider-1"); err != nil {
+			t.Errorf("DeleteProvider(gpu-provider-1) cleanup: %v", err)
+		}
+	})
 
 	got, err := store.GetProvider("gpu-provider-1")
 	if err != nil {

--- a/internal/eval_hub/storage/sql/providers_gpu_test.go
+++ b/internal/eval_hub/storage/sql/providers_gpu_test.go
@@ -45,7 +45,7 @@ func TestProviderStorage_GPURuntimeRoundTrip(t *testing.T) {
 	if err := store.CreateProvider(provider); err != nil {
 		t.Fatalf("CreateProvider failed: %v", err)
 	}
-	defer store.DeleteProvider("gpu-provider-1")
+	defer func() { _ = store.DeleteProvider("gpu-provider-1") }()
 
 	got, err := store.GetProvider("gpu-provider-1")
 	if err != nil {

--- a/internal/eval_hub/storage/sql/providers_test.go
+++ b/internal/eval_hub/storage/sql/providers_test.go
@@ -138,7 +138,11 @@ func TestProviderStorage(t *testing.T) {
 		if err := store.CreateProvider(providerWithTags); err != nil {
 			t.Fatalf("CreateProvider failed: %v", err)
 		}
-		defer func() { _ = store.DeleteProvider("provider-2") }()
+		t.Cleanup(func() {
+			if err := store.DeleteProvider("provider-2"); err != nil {
+				t.Errorf("DeleteProvider(provider-2) cleanup: %v", err)
+			}
+		})
 
 		filter := &abstractions.QueryFilter{
 			Limit:  10,

--- a/internal/eval_hub/storage/sql/providers_test.go
+++ b/internal/eval_hub/storage/sql/providers_test.go
@@ -138,7 +138,7 @@ func TestProviderStorage(t *testing.T) {
 		if err := store.CreateProvider(providerWithTags); err != nil {
 			t.Fatalf("CreateProvider failed: %v", err)
 		}
-		defer store.DeleteProvider("provider-2")
+		defer func() { _ = store.DeleteProvider("provider-2") }()
 
 		filter := &abstractions.QueryFilter{
 			Limit:  10,

--- a/internal/eval_hub/storage/sql/shared/helper.go
+++ b/internal/eval_hub/storage/sql/shared/helper.go
@@ -134,7 +134,6 @@ func CreateFilterStatement(s SQLStatementsFactory, where string, whereArgs []any
 	}
 	if offset > 0 {
 		cond, condArgs := s.CreateEntityFilterCondition("OFFSET", offset, index, tableName)
-		index += len(condArgs)
 		sb.WriteString(" ")
 		sb.WriteString(cond)
 		args = append(args, condArgs...)

--- a/internal/eval_hub/storage/sql/sql_test.go
+++ b/internal/eval_hub/storage/sql/sql_test.go
@@ -31,7 +31,7 @@ func TestNewStorageConnMaxLifetime(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewStorage failed with duration string: %v", err)
 		}
-		s.Close()
+		_ = s.Close()
 	})
 
 	t.Run("accepts config without conn_max_lifetime", func(t *testing.T) {
@@ -43,7 +43,7 @@ func TestNewStorageConnMaxLifetime(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewStorage failed without conn_max_lifetime: %v", err)
 		}
-		s.Close()
+		_ = s.Close()
 	})
 }
 
@@ -62,7 +62,7 @@ func TestNewStorageOTELMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStorage with OTEL metrics: %v", err)
 	}
-	s.Close()
+	_ = s.Close()
 }
 
 func TestSQLStorage(t *testing.T) {

--- a/internal/eval_hub/storage/sql/sqlite/statements.go
+++ b/internal/eval_hub/storage/sql/sqlite/statements.go
@@ -218,7 +218,7 @@ func (s *sqliteStatementsFactory) getWhereStatement(tenant api.Tenant, id string
 		if sb.Len() > 0 {
 			sb.WriteString(" AND ")
 		}
-		sb.WriteString(fmt.Sprintf("(tenant_id = ? OR owner = '%s')", abstractions.OwnerSystem))
+		fmt.Fprintf(&sb, "(tenant_id = ? OR owner = '%s')", abstractions.OwnerSystem)
 		args = append(args, tenant.String())
 	}
 	return sb.String(), args

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -31,7 +31,7 @@ const (
 	modelURLSuffix     = "_url"
 )
 
-// xModelCredError is an internal sentinel header set by the Director when ref resolution fails.
+// xModelCredError is an internal sentinel header set by Rewrite when ref resolution fails.
 // The modelRoundTripper checks for it and returns 400 to the eval container instead of
 // forwarding a request with a literal ref token.
 const xModelCredError = "X-Model-Cred-Error" // #nosec G101 -- internal HTTP header name, not a credential

--- a/internal/eval_runtime_sidecar/proxy/oci_auth.go
+++ b/internal/eval_runtime_sidecar/proxy/oci_auth.go
@@ -261,8 +261,7 @@ func (tp *OCITokenProducer) initiateChallenge() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
-
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusUnauthorized {
 		return "", nil
 	}
@@ -296,8 +295,7 @@ func (tp *OCITokenProducer) createNewToken(nextURL string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("auth request failed with status %d: %s", resp.StatusCode, string(body))

--- a/internal/eval_runtime_sidecar/proxy/proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/proxy.go
@@ -11,7 +11,7 @@ import (
 
 type contextKeyAuthInput struct{}
 
-// ContextWithAuthInput returns a context that carries authInput for the reverse proxy Director.
+// ContextWithAuthInput returns a context that carries authInput for the reverse proxy Rewrite hook.
 func ContextWithAuthInput(ctx context.Context, authInput AuthTokenInput) context.Context {
 	return context.WithValue(ctx, contextKeyAuthInput{}, authInput)
 }
@@ -107,24 +107,18 @@ func SetAuthHeader(req *http.Request, token string) {
 // The returned proxy is safe to reuse for many requests.
 func NewReverseProxy(target *url.URL, client *http.Client, logger *slog.Logger, modifyResponse func(*http.Response) error) *httputil.ReverseProxy {
 	transport := &roundTripperFromClient{client: client}
-	proxy := httputil.NewSingleHostReverseProxy(target)
-	proxy.Transport = transport
+	proxy := &httputil.ReverseProxy{Transport: transport}
 
-	proxy.Director = func(req *http.Request) {
-		req.URL.Scheme = target.Scheme
-		req.URL.Host = target.Host
-		req.Host = target.Host
-		if target.Path != "" && target.Path != "/" {
-			req.URL.Path = strings.TrimSuffix(target.Path, "/") + req.URL.Path
-		}
-		req.RequestURI = "" // required for client requests
-		// Content-Type and X-Tenant are already on req (copied from incoming by ReverseProxy)
-		authInput, ok := AuthInputFromContext(req.Context())
+	proxy.Rewrite = func(pr *httputil.ProxyRequest) {
+		pr.SetURL(target)
+		pr.Out.RequestURI = "" // required for client requests
+		// Content-Type and X-Tenant are already on Out (copied from inbound by ReverseProxy)
+		authInput, ok := AuthInputFromContext(pr.In.Context())
 		if ok {
 			authToken := ResolveAuthToken(logger, authInput)
-			SetAuthHeader(req, authToken)
+			SetAuthHeader(pr.Out, authToken)
 		}
-		logger.Info("Proxying request", "method", req.Method, "url", req.URL.String(), "headers", headersForLog(req.Header))
+		logger.Info("Proxying request", "method", pr.Out.Method, "url", pr.Out.URL.String(), "headers", headersForLog(pr.Out.Header))
 	}
 
 	proxy.ModifyResponse = func(resp *http.Response) error {

--- a/internal/eval_runtime_sidecar/proxy/proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/proxy_test.go
@@ -98,7 +98,7 @@ func TestNewReverseProxy(t *testing.T) {
 		}
 		w.Header().Set("X-Backend", "ok")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	}))
 	defer backend.Close()
 
@@ -134,7 +134,7 @@ func TestNewReverseProxyWithPathPrefix(t *testing.T) {
 			t.Errorf("backend path = %s, want /mlflow/api/2.0/mlflow/experiments/get-by-name", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	}))
 	defer backend.Close()
 

--- a/internal/evalhub_mcp/server/completions_test.go
+++ b/internal/evalhub_mcp/server/completions_test.go
@@ -29,14 +29,14 @@ func connectWithCompletions(t *testing.T, ds EvalHubDiscovery) (context.Context,
 	if err != nil {
 		t.Fatalf("server.Connect failed: %v", err)
 	}
-	t.Cleanup(func() { serverSession.Close() })
+	t.Cleanup(func() { _ = serverSession.Close() })
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
 	clientSession, err := client.Connect(ctx, clientTransport, nil)
 	if err != nil {
 		t.Fatalf("client.Connect failed: %v", err)
 	}
-	t.Cleanup(func() { clientSession.Close() })
+	t.Cleanup(func() { _ = clientSession.Close() })
 
 	return ctx, clientSession
 }

--- a/internal/evalhub_mcp/server/resources_test.go
+++ b/internal/evalhub_mcp/server/resources_test.go
@@ -243,14 +243,14 @@ func connectWithResources(t *testing.T, ds EvalHubDiscovery) (context.Context, *
 	if err != nil {
 		t.Fatalf("server.Connect failed: %v", err)
 	}
-	t.Cleanup(func() { serverSession.Close() })
+	t.Cleanup(func() { _ = serverSession.Close() })
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
 	clientSession, err := client.Connect(ctx, clientTransport, nil)
 	if err != nil {
 		t.Fatalf("client.Connect failed: %v", err)
 	}
-	t.Cleanup(func() { clientSession.Close() })
+	t.Cleanup(func() { _ = clientSession.Close() })
 
 	return ctx, clientSession
 }
@@ -707,14 +707,14 @@ func TestRegisterHandlersNilClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("server.Connect failed: %v", err)
 	}
-	defer serverSession.Close()
+	defer func() { _ = serverSession.Close() }()
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
 	clientSession, err := client.Connect(ctx, clientTransport, nil)
 	if err != nil {
 		t.Fatalf("client.Connect failed: %v", err)
 	}
-	defer clientSession.Close()
+	defer func() { _ = clientSession.Close() }()
 
 	result, err := clientSession.ListResources(ctx, nil)
 	if err != nil {

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -226,7 +226,7 @@ func serveHTTP(ctx context.Context, mcpHandler http.Handler, cfg *config.Config,
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"status":"ok"}`)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 	mux.Handle("/", mcpHandler)
 

--- a/internal/evalhub_mcp/server/server_test.go
+++ b/internal/evalhub_mcp/server/server_test.go
@@ -254,8 +254,7 @@ func TestHealthEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("health request failed: %v", err)
 	}
-	defer resp.Body.Close()
-
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("health status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
@@ -286,8 +285,7 @@ func TestHealthEndpointLegacyHTTPSSE(t *testing.T) {
 	if err != nil {
 		t.Fatalf("health request failed: %v", err)
 	}
-	defer resp.Body.Close()
-
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("health status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
@@ -299,7 +297,7 @@ func TestRunHTTPPortInUse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up listener: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 	port := l.Addr().(*net.TCPAddr).Port
 
 	cfg := &config.Config{
@@ -337,7 +335,7 @@ func freePort(t *testing.T) int {
 		t.Fatalf("finding free port: %v", err)
 	}
 	port := l.Addr().(*net.TCPAddr).Port
-	l.Close()
+	_ = l.Close()
 	return port
 }
 
@@ -348,7 +346,7 @@ func waitForPort(t *testing.T, host string, port int, timeout time.Duration) {
 	for time.Now().Before(deadline) {
 		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
 		if err == nil {
-			conn.Close()
+			_ = conn.Close()
 			return
 		}
 		time.Sleep(50 * time.Millisecond)

--- a/internal/evalhub_mcp/server/version_resource_test.go
+++ b/internal/evalhub_mcp/server/version_resource_test.go
@@ -22,14 +22,14 @@ func connectClient(t *testing.T, ctx context.Context, srv *mcp.Server) *mcp.Clie
 	if err != nil {
 		t.Fatalf("server.Connect failed: %v", err)
 	}
-	t.Cleanup(func() { serverSession.Close() })
+	t.Cleanup(func() { _ = serverSession.Close() })
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
 	clientSession, err := client.Connect(ctx, clientTransport, nil)
 	if err != nil {
 		t.Fatalf("client.Connect failed: %v", err)
 	}
-	t.Cleanup(func() { clientSession.Close() })
+	t.Cleanup(func() { _ = clientSession.Close() })
 
 	return clientSession
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -34,8 +34,7 @@ type ShutdownFunc func() error
 //   - *slog.Logger: A structured logger instance that can be used throughout the application
 //   - error: An error if the logger could not be initialized
 func NewLogger() (*slog.Logger, ShutdownFunc, error) {
-	var logConfig zap.Config
-	logConfig = zap.NewProductionConfig()
+	logConfig := zap.NewProductionConfig()
 	logConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	if level := parseLogLevel(os.Getenv(envLogLevel)); level != nil {
 		logConfig.Level = zap.NewAtomicLevelAt(*level)

--- a/internal/otel/otel_export_test.go
+++ b/internal/otel/otel_export_test.go
@@ -23,7 +23,7 @@ func TestSetupOTELExportsMetricsViaOTLPGRPC(t *testing.T) {
 	t.Run("exports otelhttp server duration", func(t *testing.T) {
 		collector, shutdownOTEL := setupOTELWithCollector(t)
 		defer collector.Shutdown()
-		defer shutdownOTEL(context.Background())
+		defer func() { _ = shutdownOTEL(context.Background()) }()
 
 		handler := otelhttp.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -48,7 +48,7 @@ func TestSetupOTELExportsMetricsViaOTLPGRPC(t *testing.T) {
 	t.Run("exports semconv HTTP request metrics via middleware", func(t *testing.T) {
 		collector, shutdownOTEL := setupOTELWithCollector(t)
 		defer collector.Shutdown()
-		defer shutdownOTEL(context.Background())
+		defer func() { _ = shutdownOTEL(context.Background()) }()
 
 		handler := server.HTTPMetricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/internal/otel/otel_sdk.go
+++ b/internal/otel/otel_sdk.go
@@ -243,7 +243,7 @@ func createResource(ctx context.Context, config *config.OTELConfig, logger *slog
 		attrs = append(attrs, attribute.String(key, value))
 	}
 
-	var res *resource.Resource = resource.Default()
+	res := resource.Default()
 
 	pr, createErr := createProcessResource(ctx, config)
 	if pr != nil {

--- a/pkg/mlflowclient/artifacts.go
+++ b/pkg/mlflowclient/artifacts.go
@@ -65,8 +65,7 @@ func (c *Client) UploadArtifact(artifactPath string, content io.Reader, contentT
 	if err != nil {
 		return "", fmt.Errorf("failed to upload artifact: %w", err)
 	}
-	defer resp.Body.Close()
-
+	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to read upload response body: %w", err)

--- a/pkg/mlflowclient/client.go
+++ b/pkg/mlflowclient/client.go
@@ -262,8 +262,7 @@ func (c *Client) doRequestInternal(method, endpoint string, body any, includeWor
 		c.logger.Info("MLFlow request errored", "method", method, "endpoint", endpoint, "stage", "failed to execute request", "error", err.Error())
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer resp.Body.Close()
-
+	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.logger.Info("MLFlow request errored", "method", method, "endpoint", endpoint, "stage", "failed to read response body", "error", err.Error())

--- a/pkg/mlflowclient/workspaces.go
+++ b/pkg/mlflowclient/workspaces.go
@@ -45,8 +45,7 @@ func (c *Client) ProbeWorkspacesEnabled() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to execute server-info request: %w", err)
 	}
-	defer resp.Body.Close()
-
+	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, fmt.Errorf("failed to read server-info response: %w", err)

--- a/pkg/ociclient/auth.go
+++ b/pkg/ociclient/auth.go
@@ -76,7 +76,7 @@ func (a *authenticator) initiateChallenge(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusUnauthorized {
 		return "", nil
@@ -119,7 +119,7 @@ func (a *authenticator) createNewToken(ctx context.Context, nextURL string) erro
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/pkg/ociclient/client.go
+++ b/pkg/ociclient/client.go
@@ -181,7 +181,7 @@ func (c *Client) blobExists(ctx context.Context, digest string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	switch resp.StatusCode {
 	case http.StatusOK:
 		return true, nil
@@ -216,7 +216,7 @@ func (c *Client) startBlobUpload(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusAccepted {
 		body, _ := io.ReadAll(resp.Body)
 		return "", fmt.Errorf("start blob upload failed with status %d: %s", resp.StatusCode, string(body))
@@ -251,7 +251,7 @@ func (c *Client) uploadBlobMonolithic(ctx context.Context, content []byte, diges
 	if err != nil {
 		return err
 	}
-	defer putResp.Body.Close()
+	defer func() { _ = putResp.Body.Close() }()
 	if putResp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(putResp.Body)
 		return fmt.Errorf("complete blob upload failed with status %d: %s", putResp.StatusCode, string(body))
@@ -315,7 +315,7 @@ func (c *Client) patchBlobChunk(ctx context.Context, uploadURL string, start, en
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusAccepted {
 		body, _ := io.ReadAll(resp.Body)
 		return "", fmt.Errorf("patch blob chunk failed with status %d: %s", resp.StatusCode, string(body))
@@ -339,7 +339,7 @@ func (c *Client) completeBlobUpload(ctx context.Context, uploadURL, digest strin
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("complete blob upload failed with status %d: %s", resp.StatusCode, string(body))
@@ -358,7 +358,7 @@ func (c *Client) putManifest(ctx context.Context, tag string, manifestJSON []byt
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("put manifest failed with status %d: %s", resp.StatusCode, string(body))

--- a/tests/features/gpu_step_definitions_test.go
+++ b/tests/features/gpu_step_definitions_test.go
@@ -505,7 +505,7 @@ func deleteGPUTestProvidersAPI(headers map[string]string) error {
 			logDebug("WARNING: Failed to delete GPU test provider %s: %v\n", id, err)
 			continue
 		}
-		delResp.Body.Close()
+		_ = delResp.Body.Close()
 		if delResp.StatusCode != http.StatusNoContent && delResp.StatusCode != http.StatusNotFound {
 			logDebug("WARNING: Delete provider %s returned %d\n", id, delResp.StatusCode)
 		} else {
@@ -533,7 +533,7 @@ func createGPUTestProviderViaAPI(headers map[string]string, bodyFile string) (st
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
@@ -1204,7 +1204,7 @@ func (tc *scenarioConfig) gpuTestProviderIsLoaded() error {
 	if err != nil {
 		return tc.logError(fmt.Errorf("failed to check GPU test provider: %w", err))
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return tc.logError(err)

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -406,6 +406,9 @@ func (a *apiFeature) startLocalServer(port int) error {
 
 	// Create a test server
 	handler, err := a.server.SetupRoutes()
+	if err != nil {
+		return err
+	}
 	a.httpServer = &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
 		Handler: handler,
@@ -418,7 +421,7 @@ func (a *apiFeature) startLocalServer(port int) error {
 	}
 
 	go func() {
-		a.httpServer.Serve(listener)
+		_ = a.httpServer.Serve(listener)
 	}()
 
 	if serviceConfig.IsPrometheusEnabled() {
@@ -522,7 +525,7 @@ func (a *apiFeature) cleanup(ctx context.Context, _ *godog.Scenario, _ error) (c
 	if a.httpServer != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
-		a.httpServer.Shutdown(ctx)
+		_ = a.httpServer.Shutdown(ctx)
 	}
 
 	return ctx, nil
@@ -540,7 +543,7 @@ func (tc *scenarioConfig) logError(err error, withStack ...bool) error {
 	var sb = strings.Builder{}
 	sb.WriteString("Error")
 	if reqId, exists := tc.reqHeaders[server.TRANSACTION_ID_HEADER]; exists && reqId != "" {
-		sb.WriteString(fmt.Sprintf(" (%s)", reqId))
+		fmt.Fprintf(&sb, " (%s)", reqId)
 	}
 	sb.WriteString(": ")
 	if len(withStack) > 0 && withStack[0] {
@@ -1072,14 +1075,14 @@ func (tc *scenarioConfig) iSendARequestImpl(method, path, body, caller string) e
 
 	defer func() {
 		// we do this for now as request ids are supposed to be unique per request
-		tc.iUnsetHeader(server.TRANSACTION_ID_HEADER)
+		_ = tc.iUnsetHeader(server.TRANSACTION_ID_HEADER)
 	}()
 
 	tc.body, err = io.ReadAll(tc.response.Body)
 	if err != nil {
 		return err
 	}
-	defer tc.response.Body.Close()
+	defer func() { _ = tc.response.Body.Close() }()
 
 	if len(tc.body) > 0 && len(tc.body) < 1024*5 {
 		tc.logDebug("Response status %d for %s %s with body %s\n", tc.response.StatusCode, method, endpoint, string(tc.body))
@@ -1641,7 +1644,7 @@ func (tc *scenarioConfig) assetCleanup(ctx context.Context, sc *godog.Scenario, 
 			}
 			err = tc.theResponseStatusShouldBe(204)
 			if err != nil {
-				err = tc.logError(fmt.Errorf("failed to delete asset %s expected status %d but got %d: %w", tc.lastURL, 204, tc.response.StatusCode, err))
+				_ = tc.logError(fmt.Errorf("failed to delete asset %s expected status %d but got %d: %w", tc.lastURL, 204, tc.response.StatusCode, err))
 				// return ctx, err
 			} else {
 				tc.logDebug("Deleted asset %s with status %d\n", path, tc.response.StatusCode)
@@ -1682,7 +1685,7 @@ func waitForService() {
 
 func tidyUpTests() {
 	if apiFeat != nil {
-		apiFeat.cleanup(context.Background(), nil, nil)
+		_, _ = apiFeat.cleanup(context.Background(), nil, nil)
 	}
 	if s, ok := logger.Writer().(*os.File); ok {
 		err := s.Close()

--- a/tests/kubernetes/features/step_definitions_test.go
+++ b/tests/kubernetes/features/step_definitions_test.go
@@ -227,7 +227,7 @@ func (tc *testContext) cleanup(ctx context.Context) error {
 			tc.applyAPIHeaders(req)
 			resp, reqErr := tc.client.Do(req)
 			if reqErr == nil && resp != nil {
-				resp.Body.Close()
+				_ = resp.Body.Close()
 			}
 		}
 	}
@@ -444,7 +444,7 @@ func (tc *testContext) iSendRequestWithBody(method, path, bodyFile string) error
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}
-	defer tc.response.Body.Close()
+	defer func() { _ = tc.response.Body.Close() }()
 
 	tc.body, err = io.ReadAll(tc.response.Body)
 	if err != nil {
@@ -2235,14 +2235,6 @@ func (tc *testContext) allConfigMapsShouldBeDeletedCount(expected int) error {
 	return tc.allConfigMapsShouldBeDeleted()
 }
 
-func (tc *testContext) responseBodyShouldContain(substr string) error {
-	body := strings.ToLower(string(tc.body))
-	if !strings.Contains(body, strings.ToLower(substr)) {
-		return fmt.Errorf("response does not contain %q: %s", substr, string(tc.body))
-	}
-	return nil
-}
-
 func (tc *testContext) listJobsByJobID() ([]batchv1.Job, error) {
 	return tc.listJobsByJobIDWithCache(false)
 }
@@ -2310,68 +2302,4 @@ func (tc *testContext) logK8sOp(resource, action, jobID string) {
 		return
 	}
 	fmt.Printf("[K8S] %s %s (job_id=%s, namespace=%s)\n", action, resource, jobID, tc.namespace)
-}
-
-func (tc *testContext) firstBenchmarkID() string {
-	if len(tc.lastBenchmarkIDs) > 0 {
-		return tc.lastBenchmarkIDs[0]
-	}
-	if tc.lastBenchmarkID != "" {
-		return tc.lastBenchmarkID
-	}
-	return ""
-}
-
-func (tc *testContext) fetchBenchmarkStatuses() ([]string, error) {
-	req, err := http.NewRequest("GET", tc.baseURL+"/api/v1/evaluations/jobs/"+tc.lastJobID, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	tc.applyAPIHeaders(req)
-	resp, err := tc.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
-	}
-	var data map[string]interface{}
-	if err := json.Unmarshal(body, &data); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-	status, ok := data["status"].(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("response missing status")
-	}
-	benchmarks, ok := status["benchmarks"].([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("response missing benchmark statuses")
-	}
-	var result []string
-	for _, item := range benchmarks {
-		if bm, ok := item.(map[string]interface{}); ok {
-			if st, ok := bm["status"].(string); ok && st != "" {
-				result = append(result, st)
-			}
-		}
-	}
-	return result, nil
-}
-
-// ============================================================================
-// Stub for Undefined Steps
-// ============================================================================
-
-func (tc *testContext) stubStepNoArgs() error {
-	return godog.ErrSkip
-}
-
-func (tc *testContext) stubStepInt(_ int) error {
-	return godog.ErrSkip
-}
-
-func (tc *testContext) stubStepString(_ string) error {
-	return godog.ErrSkip
 }

--- a/tests/mcp/features/step_definitions_test.go
+++ b/tests/mcp/features/step_definitions_test.go
@@ -52,7 +52,7 @@ func (tc *mcpTestContext) reset() {
 
 func (tc *mcpTestContext) cleanup() {
 	if tc.clientSession != nil {
-		tc.clientSession.Close()
+		_ = tc.clientSession.Close()
 	}
 	if tc.cancel != nil {
 		tc.cancel()

--- a/tests/mlflow/testutil/server.go
+++ b/tests/mlflow/testutil/server.go
@@ -170,7 +170,7 @@ func runMakeTarget(t *testing.T, dir string, timeout time.Duration, target strin
 	if err != nil {
 		return fmt.Errorf("open make output log %s: %w", logPath, err)
 	}
-	defer logFile.Close()
+	defer func() { _ = logFile.Close() }()
 
 	if _, err := fmt.Fprintf(logFile, "\n--- make %s (%s) at %s ---\n", target, opts.Version, time.Now().Format(time.RFC3339)); err != nil {
 		return fmt.Errorf("write make log header: %w", err)
@@ -223,7 +223,7 @@ func waitForHealth(trackingURI string, timeout time.Duration) error {
 	for time.Now().Before(deadline) {
 		resp, err := client.Get(healthURL)
 		if err == nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
 				return nil
 			}


### PR DESCRIPTION
## Summary
- Resolve golangci-lint `unused`, `staticcheck`, `ineffassign`, and `errcheck` findings across production and test code
- Migrate sidecar reverse proxy from deprecated `Director` to `Rewrite` (Go 1.26)
- Add `.golangci.yml` to disable staticcheck `ST1005` while keeping other default checks

## Test plan
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Pre-commit hooks passed (unit/integration tests + golangci-lint)
- [ ] CI green on the PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reverse-proxy request rewriting and authorization header handling.
  * Corrected SQL pagination/limit placeholder indexing to avoid incorrect filtering.
  * Fixed evaluation pass-criteria threshold resolution to use the job’s configured threshold.
* **Refactor**
  * Standardized safer shutdown/close handling across services, runtimes, storage, and HTTP clients.
* **Tests**
  * Improved reliability via safer environment handling, stricter filesystem setup, and deterministic reload/wait behavior.
  * Updated assertions for changed response shapes and Kubernetes volume field access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->