### PR TITLE
fix: preserve path in multi-model *_url ref secret values

### DIFF
--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_unit_test.go
@@ -281,12 +281,15 @@ func TestCreateBenchmarkResourcesSetsAnnotations(t *testing.T) {
 
 func TestBuildInternalModelRefSecretMultiModel(t *testing.T) {
 	// Multi-model credential secret: *_api-key keys become refs, *_url keys become the sidecar
-	// proxy URL, ca_cert is excluded (projected directly from the real secret into the adapter).
+	// proxy URL with the original path preserved, ca_cert is excluded (projected directly
+	// from the real secret into the adapter).
 	data := map[string][]byte{
 		"model-1_api-key": []byte("sk-model1"),
 		"model-1_url":     []byte("https://api.openai.com/v1"),
 		"model-2_api-key": []byte("sk-model2"),
 		"model-2_url":     []byte("https://azure.example.com/v1"),
+		"judge_url":       []byte("https://my-vllm.example.com/v1"),
+		"attacker_url":    []byte("https://attacker.example.com"),
 		"ca_cert":         []byte("-----BEGIN CERTIFICATE-----"),
 	}
 	clientset := fake.NewClientset()
@@ -301,8 +304,10 @@ func TestBuildInternalModelRefSecretMultiModel(t *testing.T) {
 	cases := map[string]string{
 		"model-1_api-key": "model-1_api-key:ref",
 		"model-2_api-key": "model-2_api-key:ref",
-		"model-1_url":     sidecarURL,
-		"model-2_url":     sidecarURL,
+		"model-1_url":     "http://localhost:8080/v1",
+		"model-2_url":     "http://localhost:8080/v1",
+		"judge_url":       "http://localhost:8080/v1",
+		"attacker_url":    "http://localhost:8080",
 	}
 	for k, want := range cases {
 		got := string(secret.Data[k])
@@ -312,6 +317,17 @@ func TestBuildInternalModelRefSecretMultiModel(t *testing.T) {
 	}
 	if _, ok := secret.Data["ca_cert"]; ok {
 		t.Error("ca_cert must not appear in the internalModelRef secret")
+	}
+}
+
+func TestBuildInternalModelRefSecretInvalidURL(t *testing.T) {
+	data := map[string][]byte{
+		"judge_url": []byte("://bad"),
+	}
+	helper := &KubernetesHelper{clientset: fake.NewClientset()}
+	_, err := buildInternalModelRefSecret(context.Background(), "default", "bad-url-ref", data, "http://localhost:8080", nil, helper)
+	if err == nil {
+		t.Fatal("expected error for invalid *_url value")
 	}
 }
 
@@ -1196,7 +1212,7 @@ func findConfigMapVolumeName(t *testing.T, volumes []corev1.Volume) string {
 //   - model-auth-internal volume (adapter) → present iff secret is configured
 //   - projected sources: 2 (ref+real) when api-key present; 1 (real only) when ca_cert-only
 //   - ephemeral internalModelRef secret → created iff api-key (or *_api-key) present
-//   - ref secret keys → api-key→"api-key:ref", *_api-key→"<k>:ref", *_url→sidecarURL
+//   - ref secret keys → api-key→"api-key:ref", *_api-key→"<k>:ref", *_url→sidecarURL+path
 //   - adapter projected passthrough keys → ca_cert / hf-token projected optional when present in real secret
 //
 // TestModelAuthCombinations is a table-driven end-to-end test covering every meaningful
@@ -1388,7 +1404,7 @@ func TestModelAuthCombinations(t *testing.T) {
 			wantInternalRefFirstSrc:   true,
 			wantRealSecretOptional:    true,
 			wantAuthMountInSidecarCfg: true,
-			refKeys:                   []refSecretExpect{{"model-1_url", "http://localhost:8080"}},
+			refKeys:                   []refSecretExpect{{"model-1_url", "http://localhost:8080/v1"}},
 		},
 		{
 			name: "multi-model api-keys + urls",
@@ -1407,9 +1423,9 @@ func TestModelAuthCombinations(t *testing.T) {
 			wantAuthMountInSidecarCfg: true,
 			refKeys: []refSecretExpect{
 				{"model-1_api-key", "model-1_api-key:ref"},
-				{"model-1_url", "http://localhost:8080"},
+				{"model-1_url", "http://localhost:8080/v1"},
 				{"model-2_api-key", "model-2_api-key:ref"},
-				{"model-2_url", "http://localhost:8080"},
+				{"model-2_url", "http://localhost:8080/v1"},
 			},
 		},
 		{
@@ -1428,7 +1444,7 @@ func TestModelAuthCombinations(t *testing.T) {
 			wantAuthMountInSidecarCfg: true,
 			refKeys: []refSecretExpect{
 				{"model-1_api-key", "model-1_api-key:ref"},
-				{"model-1_url", "http://localhost:8080"},
+				{"model-1_url", "http://localhost:8080/v1"},
 			},
 			passthroughItemKeys: []string{"ca_cert"},
 		},

--- a/internal/eval_hub/runtimes/k8s/secret_builder.go
+++ b/internal/eval_hub/runtimes/k8s/secret_builder.go
@@ -64,7 +64,8 @@ func inspectModelSecret(ctx context.Context, namespace, secretName string, helpe
 //   - "api-key"          → value becomes "api-key:ref" (sidecar injects real key)
 //   - "*_api-key" suffix → value becomes "<key>:ref"   (sidecar injects real key)
 //   - "*_sa_token" suffix → value becomes "<key>:ref"   (sidecar injects SA token when value empty)
-//   - "*_url" suffix     → value becomes sidecarProxyURL (adapter routes through sidecar)
+//   - "*_url" suffix     → value becomes sidecarProxyURL with the original URL path preserved
+//     (same rewrite as primary model.url via rewriteModelURLForSidecar)
 //   - "hf-token"         → omitted; projected directly from the model credential secret
 //   - "ca_cert"          → omitted; projected directly from the model credential secret
 //   - all other keys     → omitted (conservative; avoids leaking unknown fields)
@@ -84,11 +85,15 @@ func buildInternalModelRefSecret(
 	}
 
 	refData := make(map[string][]byte, len(data))
-	for k := range data {
+	for k, v := range data {
 		switch {
 		case isModelCredentialKey(k):
 			if strings.HasSuffix(k, modelURLSuffix) {
-				refData[k] = []byte(sidecarProxyURL)
+				rewritten, err := rewriteModelURLForSidecar(sidecarProxyURL, string(v))
+				if err != nil {
+					return nil, fmt.Errorf("model credential secret key %q: %w", k, err)
+				}
+				refData[k] = []byte(rewritten)
 			} else {
 				refData[k] = []byte(k + modelRefValueSuffix)
 			}


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->
Preserve the path from multi-model *_url secret values when building the ephemeral internal ref secret (reuse rewriteModelURLForSidecar).
Example: judge_url: https://model.example.com/v1 → adapter sees http://localhost:8080/v1 instead of bare http://localhost:8080.

Closes # https://redhat.atlassian.net/browse/RHOAIENG-78640

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model credential URLs routed through the sidecar now preserve their original paths, improving compatibility with path-based endpoints.
  * Invalid credential URLs now produce a clear error instead of generating an incorrect secret.
  * Certificate credentials remain excluded from internal reference secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->