### PR TITLE
fix: address code scanning issues

### DIFF
--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -127,7 +127,9 @@ func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *s
 		pr.Out.URL.Host = target.Host
 		pr.Out.Host = target.Host
 		pr.Out.RequestURI = ""
-		reqLog.Info("Proxying model request", "method", pr.Out.Method, "url", pr.Out.URL.String(), "headers", headersForLog(pr.Out.Header))
+		// Do not log request headers: CodeQL treats http.Header as sensitive even when
+		// Authorization is masked (go/clear-text-logging).
+		reqLog.Info("Proxying model request", "method", pr.Out.Method, "url", pr.Out.URL.String())
 	}
 
 	rp.ModifyResponse = func(resp *http.Response) error {

--- a/internal/eval_runtime_sidecar/proxy/proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/proxy.go
@@ -63,23 +63,6 @@ func clientScheme(r *http.Request) string {
 	return "http"
 }
 
-// headersForLog returns a copy of h suitable for logging, with Authorization values obfuscated.
-func headersForLog(h http.Header) http.Header {
-	out := h.Clone()
-	if v := out.Get("Authorization"); v != "" {
-		if strings.HasPrefix(v, "Bearer ") {
-			out.Set("Authorization", "Bearer ***")
-		} else if strings.HasPrefix(v, "Basic ") {
-			out.Set("Authorization", "Basic ***")
-		} else {
-			out.Set("Authorization", "***")
-		}
-	} else {
-		out.Set("Authorization", "Empty")
-	}
-	return out
-}
-
 // roundTripperFromClient adapts *http.Client to http.RoundTripper so ReverseProxy can use client's Transport, timeout, etc.
 type roundTripperFromClient struct {
 	client *http.Client
@@ -113,12 +96,17 @@ func NewReverseProxy(target *url.URL, client *http.Client, logger *slog.Logger, 
 		pr.SetURL(target)
 		pr.Out.RequestURI = "" // required for client requests
 		// Content-Type and X-Tenant are already on Out (copied from inbound by ReverseProxy)
+		reqID := getOrCreateRequestID(pr.In)
+		pr.Out.Header.Set(globalTransactionIDHeader, reqID)
+		reqLog := logger.With("request_id", reqID)
 		authInput, ok := AuthInputFromContext(pr.In.Context())
 		if ok {
-			authToken := ResolveAuthToken(logger, authInput)
+			authToken := ResolveAuthToken(reqLog, authInput)
 			SetAuthHeader(pr.Out, authToken)
 		}
-		logger.Info("Proxying request", "method", pr.Out.Method, "url", pr.Out.URL.String(), "headers", headersForLog(pr.Out.Header))
+		// Do not log request headers: CodeQL treats http.Header as sensitive even when
+		// Authorization is masked (go/clear-text-logging).
+		reqLog.Info("Proxying request", "method", pr.Out.Method, "url", pr.Out.URL.String())
 	}
 
 	proxy.ModifyResponse = func(resp *http.Response) error {
@@ -128,13 +116,13 @@ func NewReverseProxy(target *url.URL, client *http.Client, logger *slog.Logger, 
 			}
 		}
 		if resp.Request != nil {
-			logger.Info("Response from proxy", "method", resp.Request.Method, "url", resp.Request.URL.String(), "status", resp.StatusCode)
+			loggerForRequest(logger, resp.Request).Info("Response from proxy", "method", resp.Request.Method, "url", resp.Request.URL.String(), "status", resp.StatusCode)
 		}
 		return nil
 	}
 
 	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
-		logger.Error("Error proxying request", "method", req.Method, "url", req.URL.String(), "error", err)
+		loggerForRequest(logger, req).Error("Error proxying request", "method", req.Method, "url", req.URL.String(), "error", err)
 		http.Error(w, err.Error(), http.StatusBadGateway)
 	}
 

--- a/internal/eval_runtime_sidecar/proxy/proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/proxy_test.go
@@ -10,32 +10,6 @@ import (
 	"testing"
 )
 
-func TestHeadersForLog(t *testing.T) {
-	tests := []struct {
-		name   string
-		header string
-		want   string
-	}{
-		{"Bearer obfuscated", "Bearer secret-token", "Bearer ***"},
-		{"Basic obfuscated", "Basic dXNlcjpwYXNz", "Basic ***"},
-		{"Other auth obfuscated", "Digest xxx", "***"},
-		{"Empty auth", "", "Empty"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			h := http.Header{}
-			if tt.header != "" {
-				h.Set("Authorization", tt.header)
-			}
-			out := headersForLog(h)
-			got := out.Get("Authorization")
-			if got != tt.want {
-				t.Errorf("headersForLog() Authorization = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestSetAuthHeader(t *testing.T) {
 	t.Run("no op when token empty", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -124,6 +98,40 @@ func TestNewReverseProxy(t *testing.T) {
 	}
 	if body := rw.Body.String(); body != "ok" {
 		t.Errorf("body = %q, want ok", body)
+	}
+}
+
+func TestNewReverseProxyRequestIDInLogs(t *testing.T) {
+	var logBuf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	var sawTxnHeader string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawTxnHeader = r.Header.Get(globalTransactionIDHeader)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	target, err := url.Parse(strings.TrimSuffix(backend.URL, "/"))
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	proxy := NewReverseProxy(target, backend.Client(), logger, nil)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set(globalTransactionIDHeader, "proxy-req-id")
+	rw := httptest.NewRecorder()
+	proxy.ServeHTTP(rw, req)
+
+	if sawTxnHeader != "proxy-req-id" {
+		t.Fatalf("backend %s = %q, want proxy-req-id", globalTransactionIDHeader, sawTxnHeader)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "request_id=proxy-req-id") {
+		t.Fatalf("logs = %q, want request_id field", logs)
+	}
+	if !strings.Contains(logs, "Proxying request") || !strings.Contains(logs, "Response from proxy") {
+		t.Fatalf("logs = %q, want proxy request and response lines", logs)
 	}
 }
 


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

- Stop logging HTTP request headers in the sidecar reverse proxies (NewReverseProxy and model proxy). CodeQL go/clear-text-logging still flags http.Header even when Authorization is masked, so header dumps are removed entirely.
- Keep request correlation via request_id: read/generate from X-Global-Transaction-Id, set it on the outbound request, and include it on proxy request/response/error logs (and auth resolver logs).
- Drop headersForLog and add coverage for request_id propagation in proxy tests.

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy logging privacy by excluding HTTP headers from request, response, and error logs.
  * Added request IDs to proxy logs and forwarded requests, making request activity easier to trace consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->