### PR TITLE
docs: document Go version bump skill invocation

### DIFF
--- a/.claude/skills/golang-version-update/SKILL.md
+++ b/.claude/skills/golang-version-update/SKILL.md
@@ -62,7 +62,14 @@ List available go-toolset tags from the registry tags API (paginated via `Link: 
 ```bash
 url='https://registry.access.redhat.com/v2/ubi9/go-toolset/tags/list?n=100'
 while [ -n "$url" ]; do
-  resp=$(curl -sS -D /tmp/go-toolset-headers.txt "$url")
+  resp=$(curl -fsS -D /tmp/go-toolset-headers.txt "$url") || {
+    echo "error: failed to fetch go-toolset tags from $url" >&2
+    exit 1
+  }
+  if ! echo "$resp" | jq -e 'has("tags") and (.tags | type == "array")' >/dev/null; then
+    echo "error: invalid go-toolset tags response (missing tags array) from $url" >&2
+    exit 1
+  fi
   echo "$resp" | jq -r '.tags[]'
   next=$(grep -i '^link:' /tmp/go-toolset-headers.txt | tr -d '\r' \
     | sed -n 's/.*<\([^>]*\)>; *rel="next".*/\1/p')

--- a/.claude/skills/golang-version-update/SKILL.md
+++ b/.claude/skills/golang-version-update/SKILL.md
@@ -9,9 +9,7 @@ description: >
 allowed-tools:
   - Read
   - Edit
-  - Write
   - Bash(grep *)
-  - Bash(find *)
   - Bash(git *)
   - Bash(gh *)
   - Bash(go *)
@@ -19,7 +17,6 @@ allowed-tools:
   - Bash(curl *)
   - Bash(jq *)
   - Bash(sort *)
-  - Bash(skopeo *)
   - Bash(sed *)
 ---
 
@@ -60,17 +57,7 @@ If an open PR already bumps the Go version, report its number and **stop**.
 
 ### Step 3 — Query the go-toolset registry for available tags
 
-List available go-toolset tags from `registry.access.redhat.com/ubi9/go-toolset`:
-
-```bash
-skopeo list-tags docker://registry.access.redhat.com/ubi9/go-toolset 2>/dev/null \
-  | jq -r '.Tags[]' \
-  | grep -E '^1\.[0-9]+(\.[0-9]+)?$' \
-  | sort -t. -k1,1n -k2,2n -k3,3n \
-  | tail -20
-```
-
-If `skopeo` is not available, fall back to the registry tags API (paginated via `Link: rel="next"`):
+List available go-toolset tags from the registry tags API (paginated via `Link: rel="next"`):
 
 ```bash
 url='https://registry.access.redhat.com/v2/ubi9/go-toolset/tags/list?n=100'

--- a/.claude/skills/golang-version-update/SKILL.md
+++ b/.claude/skills/golang-version-update/SKILL.md
@@ -10,7 +10,6 @@ allowed-tools:
   - Read
   - Edit
   - Write
-  - WebFetch
   - Bash(grep *)
   - Bash(find *)
   - Bash(git *)
@@ -61,23 +60,38 @@ If an open PR already bumps the Go version, report its number and **stop**.
 
 ### Step 3 — Query the go-toolset registry for available tags
 
-Use the Red Hat container catalog API to list available go-toolset tags:
+List available go-toolset tags from `registry.access.redhat.com/ubi9/go-toolset`:
 
 ```bash
 skopeo list-tags docker://registry.access.redhat.com/ubi9/go-toolset 2>/dev/null \
   | jq -r '.Tags[]' \
-  | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?(-[0-9]+)?$' \
+  | grep -E '^1\.[0-9]+(\.[0-9]+)?$' \
   | sort -t. -k1,1n -k2,2n -k3,3n \
   | tail -20
 ```
 
-If `skopeo` is not available, fall back to the Red Hat catalog API:
+If `skopeo` is not available, fall back to the registry tags API (paginated via `Link: rel="next"`):
 
 ```bash
-curl -s "https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/ubi9/go-toolset/tags?page_size=100&page=0" \
-  | jq -r '.data[].name' \
-  | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?(-[0-9]+)?$' \
+url='https://registry.access.redhat.com/v2/ubi9/go-toolset/tags/list?n=100'
+while [ -n "$url" ]; do
+  resp=$(curl -sS -D /tmp/go-toolset-headers.txt "$url")
+  echo "$resp" | jq -r '.tags[]'
+  next=$(grep -i '^link:' /tmp/go-toolset-headers.txt | tr -d '\r' \
+    | sed -n 's/.*<\([^>]*\)>; *rel="next".*/\1/p')
+  if [ -n "$next" ]; then
+    case "$next" in
+      http*) url="$next" ;;
+      /*) url="https://registry.access.redhat.com${next}" ;;
+      *) url="" ;;
+    esac
+  else
+    url=""
+  fi
+done \
+  | grep -E '^1\.[0-9]+(\.[0-9]+)?$' \
   | sort -t. -k1,1n -k2,2n -k3,3n \
+  | uniq \
   | tail -20
 ```
 

--- a/.claude/skills/golang-version-update/SKILL.md
+++ b/.claude/skills/golang-version-update/SKILL.md
@@ -29,6 +29,17 @@ allowed-tools:
 Update the Go toolchain version across the repository, gated on availability
 in the Red Hat UBI9 go-toolset container image.
 
+Policy (go-toolset gate, Containerfile, CI) lives in `CLAUDE.md`.
+
+## How to invoke
+
+**Cursor:** In Agent chat, ask e.g. “Bump the Go version using the golang-version-update skill”
+(or “Check whether we can update Go / go-toolset”). Optionally attach
+`@.claude/skills/golang-version-update/SKILL.md`.
+
+**Claude Code terminal:** From the repo root run `claude`, then `/golang-version-update`
+(or ask naturally; type `/` to list skills).
+
 ## Procedure
 
 Follow these steps **in order**. Do not skip steps.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,9 @@ If a `.pre-commit-config.yaml` file exists, run `pre-commit install && pre-commi
 
 ### Go Version
 
-The version in `go.mod` is the source of truth for local development. If your local Go toolchain is older, use `GOTOOLCHAIN=auto` to let Go automatically download the required version. Never downgrade `go.mod` to match a locally installed toolchain.
+The version in `go.mod` is the source of truth for local development. If your local Go toolchain is older than the version in `go.mod` but at least Go 1.21, use `GOTOOLCHAIN=auto` to let Go automatically download the required version. Never downgrade `go.mod` to match a locally installed toolchain.
+
+`GOTOOLCHAIN=auto` requires an installed Go 1.21+ binary. Contributors on older Go versions should upgrade to Go 1.21 or newer, or use the project container (`podman build` / `podman run` with the repo `Containerfile`; see README), before relying on automatic toolchain switching.
 
 For intentional Go upgrades, follow `CLAUDE.md` (CVE fixing → Updating the golang version) and the `golang-version-update` skill at `.claude/skills/golang-version-update/SKILL.md`. The target version must exist in `registry.access.redhat.com/ubi9/go-toolset` before updating `go.mod`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,9 @@ If a `.pre-commit-config.yaml` file exists, run `pre-commit install && pre-commi
 
 ### Go Version
 
-**Do not modify the Go version in `go.mod`.** The version specified there is the source of truth. If your local Go toolchain is older, use `GOTOOLCHAIN=auto` to let Go automatically download the required version. Never downgrade `go.mod` to match a locally installed toolchain.
+The version in `go.mod` is the source of truth for local development. If your local Go toolchain is older, use `GOTOOLCHAIN=auto` to let Go automatically download the required version. Never downgrade `go.mod` to match a locally installed toolchain.
+
+For intentional Go upgrades, follow `CLAUDE.md` (CVE fixing → Updating the golang version) and the `golang-version-update` skill at `.claude/skills/golang-version-update/SKILL.md`. The target version must exist in `registry.access.redhat.com/ubi9/go-toolset` before updating `go.mod`.
 
 ### Version Bumps
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,10 @@ Type `/` in Claude Code to list available skills if needed.
 
 ##### After the skill runs
 
-Expect a summary (previous/new Go version, files touched, test results). Create a PR only if
-requested, following the CVE-fix flow above (skip if an open Go bump PR already exists).
+Expect a summary (previous/new Go version, files touched, test results).
+
+- **CVE-driven Go upgrades:** Follow the CVE-fix flow above — check for an existing open PR that provides the fix; if one exists, report its number and skip the rest; otherwise create a PR with the fix.
+- **Non-CVE Go upgrades:** Create a PR only if requested; still skip if an open Go bump PR already exists.
 
 #### npm devDependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,38 @@ The go.mod must not be updated until the same version exists in go-toolset.
 If there are other files in the repository that require updating due to new golang version then mention them in the PR.
 Use `go-version-file: "go.mod"` in the github actions where possible.
 
+Use the project skill [`.claude/skills/golang-version-update/SKILL.md`](.claude/skills/golang-version-update/SKILL.md)
+for the full procedure (registry check, file updates, `go mod tidy`, tests, and PR).
+
+##### Run from Cursor
+
+In Agent chat, ask in natural language, for example:
+
+- “Bump the Go version using the golang-version-update skill”
+- “Check whether we can update Go / go-toolset”
+
+Cursor loads the skill from `.claude/skills/golang-version-update/` and follows it.
+Optionally attach `@.claude/skills/golang-version-update/SKILL.md` to force the procedure into context.
+
+##### Run from Claude Code terminal
+
+From the repo root, start Claude Code (`claude`), then invoke the skill by name:
+
+```text
+/golang-version-update
+```
+
+Or ask naturally (the skill auto-matches on its description), for example:
+
+- “Bump Go to the latest version supported by ubi9/go-toolset”
+
+Type `/` in Claude Code to list available skills if needed.
+
+##### After the skill runs
+
+Expect a summary (previous/new Go version, files touched, test results). Create a PR only if
+requested, following the CVE-fix flow above (skip if an open Go bump PR already exists).
+
 #### npm devDependencies
 
 Ensure that version pinning is correct and pins to a **single version**,


### PR DESCRIPTION
## Summary
- Document how to run the `golang-version-update` skill from Cursor Agent chat and from the Claude Code terminal (`/golang-version-update`).
- Point CVE golang bump policy in `CLAUDE.md` at the skill procedure and expected post-run summary/PR behavior.
- Clarify in `AGENTS.md` that `go.mod` must not be downgraded for a local toolchain, while intentional upgrades use the skill (gated on go-toolset).

## Test plan
- [x] Skim `CLAUDE.md` golang section for clear Cursor vs Claude Code steps
- [x] Confirm skill `How to invoke` matches `CLAUDE.md`
- [x] Confirm `AGENTS.md` Go Version section no longer forbids intentional upgrades


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added step-by-step instructions to invoke the Go version update workflow from supported development tools.
  * Clarified that `go.mod` is the source of truth for the Go version.
  * Documented how to handle older local toolchains (including `GOTOOLCHAIN=auto`) and requirements for intentional Go upgrades.
  * Added guidance on expected workflow outcomes (version/file/test summary) and when an optional pull request may be created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->