### PR TITLE
docs: replace compatibility matrix with policy and sources of truth

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -27,8 +27,9 @@ to a given server release.
 
 ### Client guidance (pre-1.0)
 
-- Prefer an SDK release that targets the same EvalHub **minor** line as the server you call
-  (for example SDK `0.4.x` with server `0.4.x`).
+- Align the SDK with a given server only when that SDK release explicitly documents
+  support for it (see [eval-hub-sdk](https://github.com/eval-hub/eval-hub-sdk) releases).
+  Matching version numbers alone is not a guarantee.
 - Older clients may continue to work against newer servers when only additive API changes
   landed, but that is not a guarantee before `1.0.0`.
 - When in doubt, compare the server OpenAPI for your deployed version with the SDK’s
@@ -50,9 +51,14 @@ Behavioural contracts live in the OpenAPI specification for that release.
 ### What does not count as a breaking change
 
 - Adding new endpoints
-- Adding new optional fields to requests or responses
+- Adding new optional fields to requests
 - Adding new query parameters with defaults that preserve existing behaviour
 - Bug fixes that align behaviour with documented API contracts
+
+Adding new fields to responses is generally compatible for clients that ignore unknown
+properties. It may break strict clients that reject unknown fields or enforce a closed
+schema; treat that as a client-side constraint rather than a server API break unless
+release notes say otherwise.
 
 Release notes (or the PR description for a version bump) should call out intentional
 breaking changes when they occur.
@@ -71,14 +77,17 @@ following tags on pushes to observed branches (`main`, `develop`) and on version
 | `<version>` | Tag push (`v1.2.3`) | `1.2.3` |
 | `<major>.<minor>` | Tag push (`v1.2.3`) | `1.2` |
 
-Non-release branch images may carry a Quay expiry annotation; semver tags from `v*`
-releases are intended for durable pins.
+Non-release branch images may carry a Quay expiry annotation. Only full
+`major.minor.patch` tags from `v*` releases (for example `1.2.3`) are durable pins.
+`<major>.<minor>` tags (for example `1.2`) are mutable and move when later patch
+releases of that minor line are published.
 
 ### Production deployments
 
-Production environments should pin a specific semver tag (for example `0.4.4`) rather
-than `latest`. The `latest` tag is useful for development and testing but may point to an
-unreleased commit on `main` or `develop`.
+Production environments should pin a specific full `major.minor.patch` tag (for example
+`0.4.4`) rather than `latest` or a mutable `<major>.<minor>` tag. The `latest` tag is
+useful for development and testing but may point to an unreleased commit on `main` or
+`develop`.
 
 ## Keeping this document useful
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,28 +1,43 @@
-# EvalHub Compatibility Matrix
+# EvalHub Compatibility
 
-This document tracks version compatibility between EvalHub components and the RHOAI platform.
+This document describes compatibility for this repository: the EvalHub server, its REST
+API contract, published container images, and how clients (such as the Python SDK) relate
+to a given server release.
 
-## Version Matrix
+> **Note:** All components are currently pre-1.0. Breaking changes may occur between
+> minor releases. Prefer pinned image tags and release notes over `latest`.
 
-| EvalHub | SDK | RHOAI | Backwards Compatible | Notes |
-|---------|-----|-------|----------------------|-------|
-| 0.1.0 | 0.1.0a8 | 3.4-ea1 | N/A | Initial release |
+## Sources of truth
 
-> **Note:** All components are currently pre-1.0 and breaking changes may occur between releases. The version combinations listed above have been verified to work together.
+| Concern | Where to look |
+|---------|----------------|
+| Server version / release notes | [GitHub releases](https://github.com/eval-hub/eval-hub/releases) and the `VERSION` file |
+| REST API contract | OpenAPI under [`docs/openapi.yaml`](docs/openapi.yaml) (source: [`docs/src/`](docs/src/)); live docs at [eval-hub.github.io/eval-hub](https://eval-hub.github.io/eval-hub/) |
+| Python SDK versions | [eval-hub-sdk](https://github.com/eval-hub/eval-hub-sdk) releases / PyPI |
+| Image tags published by CI | [quay.io/evalhub/evalhub](https://quay.io/repository/evalhub/evalhub?tab=tags) (see [Container Image Tag Policy](#container-image-tag-policy)) |
 
-## Versioning Policy
+## Versioning policy
 
-- **EvalHub** (server) follows [SemVer](https://semver.org/). Major version bumps indicate breaking API changes.
-- **SDK** uses [PEP 440](https://peps.python.org/pep-0440/) pre-release versioning (e.g. `0.1.0a8`). Alpha releases (`aN`) may contain breaking changes between versions.
-- **RHOAI** versions follow Red Hat's release naming convention.
+- **EvalHub** (server) follows [SemVer](https://semver.org/). While the major version is
+  `0`, minor bumps may include breaking API changes; treat them as potentially incompatible
+  unless release notes say otherwise. After `1.0.0`, major bumps indicate breaking API changes.
+- **SDK** uses [PEP 440](https://peps.python.org/pep-0440/) versioning (including
+  pre-releases such as `0.1.0a8`). Alpha / pre-release SDK versions may break between
+  builds; prefer a stable SDK release when talking to a pinned server.
 
-## Backwards Compatibility
+### Client guidance (pre-1.0)
 
-The **Backwards Compatible** column indicates whether the EvalHub REST API is backwards compatible with the immediately preceding version:
+- Prefer an SDK release that targets the same EvalHub **minor** line as the server you call
+  (for example SDK `0.4.x` with server `0.4.x`).
+- Older clients may continue to work against newer servers when only additive API changes
+  landed, but that is not a guarantee before `1.0.0`.
+- When in doubt, compare the server OpenAPI for your deployed version with the SDK’s
+  expected API surface, or upgrade the client with the server.
 
-- **Yes** -- No breaking changes. Existing clients continue to work without modification.
-- **No** -- Breaking changes introduced. Clients may need updates (see notes for details).
-- **N/A** -- First release or no previous version to compare against.
+## API compatibility
+
+The compatibility boundary for HTTP clients is the versioned REST API under `/api/v1`.
+Behavioural contracts live in the OpenAPI specification for that release.
 
 ### What counts as a breaking change
 
@@ -32,27 +47,54 @@ The **Backwards Compatible** column indicates whether the EvalHub REST API is ba
 - Changing authentication or authorisation requirements
 - Removing support for a previously accepted query parameter
 
-## Container Image Tag Policy
-
-The EvalHub container image is published to `quay.io/evalhub/evalhub`. The following tags are produced by CI on every push:
-
-| Tag | When applied | Example |
-|-----|-------------|---------|
-| `latest` | Every push to GHA observed branches (`main`, `develop`, ...) or a version tag | Always points to the most recent image pushed |
-| `<branch>` | Branch push | `main`, `develop` |
-| `<branch>-<sha>` | Branch push | `main-a1b2c3d...` |
-| `<version>` | Tag push (`v1.2.3`) | `1.2.3` |
-| `<major>.<minor>` | Tag push (`v1.2.3`) | `1.2` |
-
-### Production deployments
-
-Production environments should pin to a specific semver tag (e.g. `0.1.0`) rather than `latest`.
-This is the case of `params.env` for ODH and RHOAI too.
-The `latest` tag is useful for development and testing but may point to an unreleased commit on `main`.
-
 ### What does not count as a breaking change
 
 - Adding new endpoints
 - Adding new optional fields to requests or responses
 - Adding new query parameters with defaults that preserve existing behaviour
 - Bug fixes that align behaviour with documented API contracts
+
+Release notes (or the PR description for a version bump) should call out intentional
+breaking changes when they occur.
+
+## Container Image Tag Policy
+
+The EvalHub container image is published to `quay.io/evalhub/evalhub`. CI produces the
+following tags on pushes to observed branches (`main`, `develop`) and on version tags
+(`v*`):
+
+| Tag | When applied | Example |
+|-----|-------------|---------|
+| `latest` | Every push to an observed branch or a version tag | Always points to the most recent image pushed |
+| `<branch>` | Branch push | `main`, `develop` |
+| `<branch>-<sha>` | Branch push | `main-a1b2c3d…` |
+| `<version>` | Tag push (`v1.2.3`) | `1.2.3` |
+| `<major>.<minor>` | Tag push (`v1.2.3`) | `1.2` |
+
+Non-release branch images may carry a Quay expiry annotation; semver tags from `v*`
+releases are intended for durable pins.
+
+### Production deployments
+
+Production environments should pin a specific semver tag (for example `0.4.4`) rather
+than `latest`. The `latest` tag is useful for development and testing but may point to an
+unreleased commit on `main` or `develop`.
+
+## Keeping this document useful
+
+Update this file when:
+
+- The API compatibility rules change
+- Image tagging behaviour in CI changes
+- The preferred discovery links (releases, Quay, SDK) change
+
+Do **not** add a multi-column version matrix here. Record server releases in GitHub
+Releases; keep client version history in the SDK repository.
+
+## Remark: ODH and RHOAI
+
+Which EvalHub image ships in a given Open Data Hub or Red Hat OpenShift AI release is
+decided outside this repository (typically via `evalHubImage` in TrustyAI Service Operator
+overlays such as `params.env`). Consult
+[trustyai-service-operator](https://github.com/trustyai-explainability/trustyai-service-operator)
+for product pins; this document does not track those combinations.


### PR DESCRIPTION
## Summary
- Replace the stale EvalHub × SDK × RHOAI version matrix in `COMPATIBILITY.md` with repository-focused compatibility policy (API contract, SemVer/pre-1.0 guidance, image tags).
- Point readers at living sources of truth (GitHub releases, OpenAPI, SDK, Quay) instead of duplicating version combinations that go out of date.
- Keep ODH/RHOAI product image pins as a short remark at the bottom; those belong in the TrustyAI operator overlays.

## Test plan
- [ ] Review `COMPATIBILITY.md` for accuracy of links and wording
- [ ] Confirm image tag policy still matches `.github/workflows/ci.yml`
- [ ] Confirm ODH/RHOAI guidance is appropriately demoted and points at the operator


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked compatibility guidance to define authoritative sources, versioning policies, pre-1.0 client expectations, and API compatibility boundaries.
  * Expanded container image tag guidance, including release pinning, branch annotations, and production deployment recommendations.
  * Added maintenance guidance for keeping compatibility documentation current.
  * Added references for ODH and RHOAI product version pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->