### PR TITLE
test(upgrade): add godog-based upgrade test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -769,25 +769,25 @@ run-pre-upgrade:
 	@echo "Running pre-upgrade tests for ${SOURCE_RELEASE} ..."
 	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	UPGRADE_STATE_JSON=$(UPGRADE_STATE_JSON) go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@pre-upgrade --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
+	UPGRADE_STATE_JSON=$(abspath $(UPGRADE_STATE_JSON)) go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@pre-upgrade --godog.format=junit:$(abspath $(JUNIT_XML)),pretty -v
 
 run-post-upgrade-verify:
 	@echo "Running post-upgrade verification tests for ${SOURCE_RELEASE} to ${TARGET_RELEASE} ..."
 	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	UPGRADE_STATE_JSON=$(UPGRADE_STATE_JSON) go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade-verify --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
+	UPGRADE_STATE_JSON=$(abspath $(UPGRADE_STATE_JSON)) go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade-verify --godog.format=junit:$(abspath $(JUNIT_XML)),pretty -v
 
 run-post-upgrade:
 	@echo "Running post-upgrade tests for ${TARGET_RELEASE} ..."
 	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
+	go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade --godog.format=junit:$(abspath $(JUNIT_XML)),pretty -v
 
 run-post-upgrade-cleanup:
 	@echo "Running post-upgrade cleanup for ${TARGET_RELEASE} ..."
 	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade-cleanup --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v || true
+	go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade-cleanup --godog.format=junit:$(abspath $(JUNIT_XML)),pretty -v || true
 	@echo "Post-upgrade cleanup complete"
 
 run-atris-upgrade: run-pre-upgrade run-post-upgrade-verify run-post-upgrade run-post-upgrade-cleanup

--- a/Makefile
+++ b/Makefile
@@ -760,59 +760,33 @@ test-mcp-vscode: start-service build-mcp ## Run VS Code/Cursor MCP test scripts 
 ## Atris Upgrade Tests
 ## ------------------------------------------------------------------------------------------------
 
+UPGRADE_STATE_JSON ?= test-reports/upgrade-state.json
+
 .PHONY: run-pre-upgrade run-post-upgrade-verify run-post-upgrade run-post-upgrade-cleanup run-atris-upgrade
 
 run-pre-upgrade:
 	@echo "Running pre-upgrade tests for ${SOURCE_RELEASE} ..."
-	@test -n "$(JUNIT_XML)" || { \
-		echo "ERROR: JUNIT_XML is not set or is empty."; \
-		exit 1; \
-	}
+	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	@echo "TODO"
-	@printf '%s\n' \
-		'<?xml version="1.0" encoding="UTF-8"?>' \
-		'<testsuites name="EvalHub Upgrade Tests" tests="0" skipped="0" failures="0" errors="0" time="0.0">' \
-		'</testsuites>' \
-		> "$(JUNIT_XML)"
-	@echo "Results saved to ${JUNIT_XML}"
-	@echo "Pre-upgrade tests complete"
+	UPGRADE_STATE_JSON=$(UPGRADE_STATE_JSON) go test ./tests/upgrade/... --godog.tags=@pre-upgrade --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
 
 run-post-upgrade-verify:
 	@echo "Running post-upgrade verification tests for ${SOURCE_RELEASE} to ${TARGET_RELEASE} ..."
-	@test -n "$(JUNIT_XML)" || { \
-		echo "ERROR: JUNIT_XML is not set or is empty."; \
-		exit 1; \
-	}
+	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	@echo "TODO"
-	@printf '%s\n' \
-		'<?xml version="1.0" encoding="UTF-8"?>' \
-		'<testsuites name="EvalHub Upgrade Tests" tests="0" skipped="0" failures="0" errors="0" time="0.0">' \
-		'</testsuites>' \
-		> "$(JUNIT_XML)"
-	@echo "Results saved to ${JUNIT_XML}"
-	@echo "Post-upgrade verification tests complete"
+	UPGRADE_STATE_JSON=$(UPGRADE_STATE_JSON) go test ./tests/upgrade/... --godog.tags=@post-upgrade-verify --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
 
 run-post-upgrade:
 	@echo "Running post-upgrade tests for ${TARGET_RELEASE} ..."
-	@test -n "$(JUNIT_XML)" || { \
-		echo "ERROR: JUNIT_XML is not set or is empty."; \
-		exit 1; \
-	}
+	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	@echo "TODO"
-	@printf '%s\n' \
-		'<?xml version="1.0" encoding="UTF-8"?>' \
-		'<testsuites name="EvalHub Upgrade Tests" tests="0" skipped="0" failures="0" errors="0" time="0.0">' \
-		'</testsuites>' \
-		> "$(JUNIT_XML)"
-	@echo "Results saved to ${JUNIT_XML}"
-	@echo "Post-upgrade tests complete"
+	go test ./tests/upgrade/... --godog.tags=@post-upgrade --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
 
 run-post-upgrade-cleanup:
 	@echo "Running post-upgrade cleanup for ${TARGET_RELEASE} ..."
-	@echo "TODO"
+	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
+	@mkdir -p $(dir $(JUNIT_XML))
+	go test ./tests/upgrade/... --godog.tags=@post-upgrade-cleanup --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v || true
 	@echo "Post-upgrade cleanup complete"
 
 run-atris-upgrade: run-pre-upgrade run-post-upgrade-verify run-post-upgrade run-post-upgrade-cleanup

--- a/Makefile
+++ b/Makefile
@@ -761,6 +761,7 @@ test-mcp-vscode: start-service build-mcp ## Run VS Code/Cursor MCP test scripts 
 ## ------------------------------------------------------------------------------------------------
 
 UPGRADE_STATE_JSON ?= test-reports/upgrade-state.json
+UPGRADE_TEST_TIMEOUT ?= 15m
 
 .PHONY: run-pre-upgrade run-post-upgrade-verify run-post-upgrade run-post-upgrade-cleanup run-atris-upgrade
 
@@ -768,25 +769,25 @@ run-pre-upgrade:
 	@echo "Running pre-upgrade tests for ${SOURCE_RELEASE} ..."
 	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	UPGRADE_STATE_JSON=$(UPGRADE_STATE_JSON) go test ./tests/upgrade/... --godog.tags=@pre-upgrade --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
+	UPGRADE_STATE_JSON=$(UPGRADE_STATE_JSON) go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@pre-upgrade --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
 
 run-post-upgrade-verify:
 	@echo "Running post-upgrade verification tests for ${SOURCE_RELEASE} to ${TARGET_RELEASE} ..."
 	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	UPGRADE_STATE_JSON=$(UPGRADE_STATE_JSON) go test ./tests/upgrade/... --godog.tags=@post-upgrade-verify --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
+	UPGRADE_STATE_JSON=$(UPGRADE_STATE_JSON) go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade-verify --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
 
 run-post-upgrade:
 	@echo "Running post-upgrade tests for ${TARGET_RELEASE} ..."
 	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	go test ./tests/upgrade/... --godog.tags=@post-upgrade --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
+	go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v
 
 run-post-upgrade-cleanup:
 	@echo "Running post-upgrade cleanup for ${TARGET_RELEASE} ..."
 	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	go test ./tests/upgrade/... --godog.tags=@post-upgrade-cleanup --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v || true
+	go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade-cleanup --godog.format=junit:${PWD}/$(JUNIT_XML),pretty -v || true
 	@echo "Post-upgrade cleanup complete"
 
 run-atris-upgrade: run-pre-upgrade run-post-upgrade-verify run-post-upgrade run-post-upgrade-cleanup

--- a/Makefile
+++ b/Makefile
@@ -787,7 +787,7 @@ run-post-upgrade-cleanup:
 	@echo "Running post-upgrade cleanup for ${TARGET_RELEASE} ..."
 	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade-cleanup --godog.format=junit:$(abspath $(JUNIT_XML)),pretty -v || true
+	UPGRADE_STATE_JSON=$(abspath $(UPGRADE_STATE_JSON)) go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade-cleanup --godog.format=junit:$(abspath $(JUNIT_XML)),pretty -v || true
 	@echo "Post-upgrade cleanup complete"
 
 run-atris-upgrade: run-pre-upgrade run-post-upgrade-verify run-post-upgrade run-post-upgrade-cleanup

--- a/Makefile
+++ b/Makefile
@@ -781,7 +781,7 @@ run-post-upgrade:
 	@echo "Running post-upgrade tests for ${TARGET_RELEASE} ..."
 	@test -n "$(JUNIT_XML)" || { echo "ERROR: JUNIT_XML is not set or is empty."; exit 1; }
 	@mkdir -p $(dir $(JUNIT_XML))
-	go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade --godog.format=junit:$(abspath $(JUNIT_XML)),pretty -v
+	UPGRADE_STATE_JSON=$(abspath $(UPGRADE_STATE_JSON)) go test -timeout=$(UPGRADE_TEST_TIMEOUT) -count=1 ./tests/upgrade/... --godog.tags=@post-upgrade --godog.format=junit:$(abspath $(JUNIT_XML)),pretty -v
 
 run-post-upgrade-cleanup:
 	@echo "Running post-upgrade cleanup for ${TARGET_RELEASE} ..."

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -100,33 +100,31 @@ for phase in "${phases[@]}"; do
     fi
 done
 
-cleanup_requested=false
+cleanup_pending=false
 for phase in "${phases[@]}"; do
     if [[ "$phase" == "post-upgrade-cleanup" ]]; then
-        cleanup_requested=true
+        cleanup_pending=true
         break
     fi
 done
 
-cleanup_done=false
-
 run_cleanup_on_exit() {
     local exit_status=$?
-    if [[ "$cleanup_requested" == true && "$cleanup_done" == false ]]; then
-        cleanup_done=true
+    if [[ "$cleanup_pending" == true ]]; then
+        cleanup_pending=false
         echo "==> Running post-upgrade-cleanup (exit trap)"
         run_phase "post-upgrade-cleanup" || true
     fi
     exit "$exit_status"
 }
 
-if [[ "$cleanup_requested" == true ]]; then
+if [[ "$cleanup_pending" == true ]]; then
     trap run_cleanup_on_exit EXIT
 fi
 
 for phase in "${phases[@]}"; do
     if [[ "$phase" == "post-upgrade-cleanup" ]]; then
-        cleanup_done=true
+        cleanup_pending=false
     fi
     run_phase "${phase}"
 done

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -98,6 +98,36 @@ for phase in "${phases[@]}"; do
         usage >&2
         exit 1
     fi
+done
+
+cleanup_requested=false
+for phase in "${phases[@]}"; do
+    if [[ "$phase" == "post-upgrade-cleanup" ]]; then
+        cleanup_requested=true
+        break
+    fi
+done
+
+cleanup_done=false
+
+run_cleanup_on_exit() {
+    local exit_status=$?
+    if [[ "$cleanup_requested" == true && "$cleanup_done" == false ]]; then
+        cleanup_done=true
+        echo "==> Running post-upgrade-cleanup (exit trap)"
+        run_phase "post-upgrade-cleanup" || true
+    fi
+    exit "$exit_status"
+}
+
+if [[ "$cleanup_requested" == true ]]; then
+    trap run_cleanup_on_exit EXIT
+fi
+
+for phase in "${phases[@]}"; do
+    if [[ "$phase" == "post-upgrade-cleanup" ]]; then
+        cleanup_done=true
+    fi
     run_phase "${phase}"
 done
 

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -124,10 +124,15 @@ fi
 
 for phase in "${phases[@]}"; do
     if [[ "$phase" == "post-upgrade-cleanup" ]]; then
-        cleanup_pending=false
+        continue
     fi
     run_phase "${phase}"
 done
+
+if [[ "$cleanup_pending" == true ]]; then
+    cleanup_pending=false
+    run_phase "post-upgrade-cleanup"
+fi
 
 echo "==> All requested phases complete"
 echo "    Reports: ${REPORT_DIR}/"

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -80,7 +80,7 @@ fi
 check_required_vars
 
 phases=("$@")
-if [[ ${#phases[@]} -eq 0 || "${phases[0]}" == "all" ]]; then
+if [[ ${#phases[@]} -eq 0 || ( ${#phases[@]} -eq 1 && "${phases[0]}" == "all" ) ]]; then
     phases=("${ALL_PHASES[@]}")
 fi
 

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -f .env ]]; then
+    set -a
+    source .env
+    set +a
+fi
+
+REPORT_DIR="${REPORT_DIR:-test-reports}"
+UPGRADE_STATE_JSON="${UPGRADE_STATE_JSON:-${REPORT_DIR}/upgrade-state.json}"
+
+REQUIRED_VARS=(SERVER_URL AUTH_TOKEN X_TENANT MODEL_URL MODEL_NAME)
+
+check_required_vars() {
+    local missing=()
+    for var in "${REQUIRED_VARS[@]}"; do
+        if [[ -z "${!var:-}" ]]; then
+            missing+=("$var")
+        fi
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "ERROR: required environment variables are not set: ${missing[*]}" >&2
+        exit 1
+    fi
+}
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [PHASE...]
+
+Run upgrade test phases via make targets. When called with no arguments,
+runs all four phases in order (equivalent to 'make run-atris-upgrade').
+
+Phases:
+  pre-upgrade             Create evaluation jobs on the source version
+  post-upgrade-verify     Verify resources survived the upgrade
+  post-upgrade            Run new evaluations on the target version
+  post-upgrade-cleanup    Clean up all test resources
+  all                     Run all phases in order (default)
+
+Environment variables (required):
+  SERVER_URL              EvalHub API base URL
+  AUTH_TOKEN              Bearer token for authentication
+  X_TENANT                Tenant namespace
+  MODEL_URL               Model inference endpoint URL
+  MODEL_NAME              Model name
+
+Environment variables (optional):
+  MODEL_AUTH_SECRET_REF   Secret reference for model auth (omits model.auth if unset)
+  REPORT_DIR              Report output directory (default: test-reports)
+  UPGRADE_STATE_JSON      State file path (default: \$REPORT_DIR/upgrade-state.json)
+  X_USER                  User identity header (default: upgrade-test-user)
+
+Examples:
+  $(basename "$0")                          # run all phases
+  $(basename "$0") pre-upgrade              # run only pre-upgrade
+  $(basename "$0") post-upgrade-verify post-upgrade  # run two phases
+EOF
+}
+
+run_phase() {
+    local phase="$1"
+    local junit_xml="${REPORT_DIR}/${phase}.xml"
+
+    echo "==> Running phase: ${phase}"
+    JUNIT_XML="${junit_xml}" \
+    UPGRADE_STATE_JSON="${UPGRADE_STATE_JSON}" \
+        make "run-${phase}"
+    echo ""
+}
+
+ALL_PHASES=(pre-upgrade post-upgrade-verify post-upgrade post-upgrade-cleanup)
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+check_required_vars
+
+phases=("$@")
+if [[ ${#phases[@]} -eq 0 || "${phases[0]}" == "all" ]]; then
+    phases=("${ALL_PHASES[@]}")
+fi
+
+is_valid_phase() {
+    local needle="$1"
+    for p in "${ALL_PHASES[@]}"; do
+        [[ "$p" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+for phase in "${phases[@]}"; do
+    if ! is_valid_phase "${phase}"; then
+        echo "ERROR: unknown phase '${phase}'" >&2
+        usage >&2
+        exit 1
+    fi
+    run_phase "${phase}"
+done
+
+echo "==> All requested phases complete"
+echo "    Reports: ${REPORT_DIR}/"
+echo "    State:   ${UPGRADE_STATE_JSON}"

--- a/tests/upgrade/README.md
+++ b/tests/upgrade/README.md
@@ -106,6 +106,22 @@ JUNIT_XML=test-reports/post-upgrade-cleanup.xml \
 make run-post-upgrade-cleanup
 ```
 
+### make run-atris-upgrade
+
+Quick dev target that chains all four phases in order. Each phase overwrites the same `JUNIT_XML` file, so only the last phase's report is kept. CI pipelines and `scripts/upgrade-test.sh` use per-phase `JUNIT_XML` paths instead.
+
+```bash
+SERVER_URL=$SERVER_URL \
+AUTH_TOKEN=$AUTH_TOKEN \
+X_TENANT=$X_TENANT \
+MODEL_URL=$MODEL_URL \
+MODEL_NAME=$MODEL_NAME \
+MODEL_AUTH_SECRET_REF=$MODEL_AUTH_SECRET_REF \
+UPGRADE_STATE_JSON=test-reports/upgrade-state.json \
+JUNIT_XML=test-reports/upgrade.xml \
+make run-atris-upgrade
+```
+
 ### Generated files
 
 - `test-reports/upgrade-state.json` from `UPGRADE_STATE_JSON` -- all evaluation jobs on the cluster (id, name, state), used by post-upgrade phases

--- a/tests/upgrade/README.md
+++ b/tests/upgrade/README.md
@@ -1,0 +1,122 @@
+# Upgrade Tests
+
+BDD-style upgrade tests using [godog](https://github.com/cucumber/godog). These tests verify that evaluation resources survive an RHOAI upgrade.
+
+## Phases
+
+| Makefile target            | Tag                  | Description                                        |
+|----------------------------|----------------------|----------------------------------------------------|
+| `run-pre-upgrade`          | `@pre-upgrade`       | Create evaluation jobs on the source version       |
+| `run-post-upgrade-verify`  | `@post-upgrade-verify` | Verify resources survived the upgrade            |
+| `run-post-upgrade`         | `@post-upgrade`      | Run new evaluations on the target version          |
+| `run-post-upgrade-cleanup` | `@post-upgrade-cleanup` | Clean up all test resources                     |
+
+## Pre-upgrade
+
+Creates an evaluation job, waits for completion, then collects all jobs on the cluster into a state file (`test-reports/upgrade-state.json`) for use by post-upgrade phases.
+
+## Required environment variables
+
+| Variable                | Description                          |
+|-------------------------|--------------------------------------|
+| `SERVER_URL`            | EvalHub API base URL                 |
+| `AUTH_TOKEN`            | Bearer token for authentication      |
+| `X_TENANT`              | Tenant namespace                     |
+| `MODEL_URL`             | Model inference endpoint URL         |
+| `MODEL_NAME`            | Model name                           |
+
+## Optional environment variables
+
+| Variable                | Description                          |
+|-------------------------|--------------------------------------|
+| `MODEL_AUTH_SECRET_REF` | Secret reference for model auth (omits `model.auth` from the job payload if unset) |
+| `X_USER`                | User identity header (default: `upgrade-test-user`) |
+| `UPGRADE_STATE_JSON`    | State file path (default: `test-reports/upgrade-state.json`) |
+| `JUNIT_XML`             | Output path for JUnit XML report     |
+
+### Running
+
+Fill up the env var in .env file under project directory
+```bash
+source .env
+```
+and then execute the follow make target for each step
+
+Or, export the env variables
+
+### make run-pre-upgrade
+```bash
+SERVER_URL=$SERVER_URL \
+AUTH_TOKEN=$AUTH_TOKEN \
+X_TENANT=$X_TENANT \
+MODEL_URL=$MODEL_URL \
+MODEL_NAME=$MODEL_NAME \
+MODEL_AUTH_SECRET_REF=$MODEL_AUTH_SECRET_REF \
+UPGRADE_STATE_JSON=test-reports/upgrade-state.json \
+JUNIT_XML=test-reports/pre-upgrade.xml \
+make run-pre-upgrade
+```
+
+### make run-post-upgrade-verify
+This step is dependent on UPGRADE_STATE_JSON generated from the prior step of run-pre-upgrade
+```bash
+SERVER_URL=$SERVER_URL \
+AUTH_TOKEN=$AUTH_TOKEN \
+X_TENANT=$X_TENANT \
+UPGRADE_STATE_JSON=test-reports/upgrade-state.json \
+JUNIT_XML=test-reports/post-upgrade-verify.xml \
+make run-post-upgrade-verify
+```
+
+### make run-post-upgrade
+This can run independent of other targets.
+```bash
+SERVER_URL=$SERVER_URL \
+AUTH_TOKEN=$AUTH_TOKEN \
+X_TENANT=$X_TENANT \
+MODEL_URL=$MODEL_URL \
+MODEL_NAME=$MODEL_NAME \
+MODEL_AUTH_SECRET_REF=$MODEL_AUTH_SECRET_REF \
+JUNIT_XML=test-reports/post-upgrade.xml \
+make run-post-upgrade
+```
+
+
+### make run-post-upgrade-cleanup
+Clean up al evaluation jobs which has "*-upgrade-*" in it's job name. This can run independent of other targets.
+
+```bash
+SERVER_URL=$SERVER_URL \
+AUTH_TOKEN=$AUTH_TOKEN \
+X_TENANT=$X_TENANT \
+JUNIT_XML=test-reports/post-upgrade-cleanup.xml \
+make run-post-upgrade-cleanup
+```
+
+
+### Generated files
+
+- `test-reports/upgrade-state.json` from `UPGRADE_STATE_JSON` -- all evaluation jobs on the cluster (id, name, state), used by post-upgrade phases
+- `$JUNIT_XML` -- JUnit XML test report for each make target.
+
+## Running all phases with the upgrade script
+
+The `scripts/upgrade-test.sh` script automates the steps listed above. It
+validates that the required environment variables are set, passes `JUNIT_XML`
+and `UPGRADE_STATE_JSON` automatically, and reports results under `test-reports/`.
+
+Run all four phases in order:
+
+```bash
+source .env
+./scripts/upgrade-test.sh
+```
+
+Run only specific phases:
+
+```bash
+./scripts/upgrade-test.sh pre-upgrade                       # single phase
+./scripts/upgrade-test.sh post-upgrade-verify post-upgrade   # multiple phases
+```
+
+Run `./scripts/upgrade-test.sh --help` for the full list of options.

--- a/tests/upgrade/README.md
+++ b/tests/upgrade/README.md
@@ -32,19 +32,27 @@ Creates an evaluation job, waits for completion, then collects all jobs on the c
 | `MODEL_AUTH_SECRET_REF` | Secret reference for model auth (omits `model.auth` from the job payload if unset) |
 | `X_USER`                | User identity header (default: `upgrade-test-user`) |
 | `UPGRADE_STATE_JSON`    | State file path (default: `test-reports/upgrade-state.json`) |
-| `JUNIT_XML`             | Output path for JUnit XML report     |
+
+## Required Makefile variables
+
+| Variable                | Description                          |
+|-------------------------|--------------------------------------|
+| `JUNIT_XML`             | Output path for JUnit XML report (required by all make targets) |
 
 ### Running
 
 Fill up the env var in .env file under project directory
+
 ```bash
 source .env
 ```
+
 and then execute the follow make target for each step
 
 Or, export the env variables
 
 ### make run-pre-upgrade
+
 ```bash
 SERVER_URL=$SERVER_URL \
 AUTH_TOKEN=$AUTH_TOKEN \
@@ -58,7 +66,9 @@ make run-pre-upgrade
 ```
 
 ### make run-post-upgrade-verify
+
 This step is dependent on UPGRADE_STATE_JSON generated from the prior step of run-pre-upgrade
+
 ```bash
 SERVER_URL=$SERVER_URL \
 AUTH_TOKEN=$AUTH_TOKEN \
@@ -69,7 +79,9 @@ make run-post-upgrade-verify
 ```
 
 ### make run-post-upgrade
+
 This can run independent of other targets.
+
 ```bash
 SERVER_URL=$SERVER_URL \
 AUTH_TOKEN=$AUTH_TOKEN \
@@ -83,7 +95,8 @@ make run-post-upgrade
 
 
 ### make run-post-upgrade-cleanup
-Clean up al evaluation jobs which has "*-upgrade-*" in it's job name. This can run independent of other targets.
+
+Clean up all evaluation jobs which have "*-upgrade-*" in their job name. This can run independent of other targets.
 
 ```bash
 SERVER_URL=$SERVER_URL \
@@ -92,7 +105,6 @@ X_TENANT=$X_TENANT \
 JUNIT_XML=test-reports/post-upgrade-cleanup.xml \
 make run-post-upgrade-cleanup
 ```
-
 
 ### Generated files
 

--- a/tests/upgrade/README.md
+++ b/tests/upgrade/README.md
@@ -41,15 +41,16 @@ Creates an evaluation job, waits for completion, then collects all jobs on the c
 
 ### Running
 
-Fill up the env var in .env file under project directory
+Export the required environment variables, then execute the make target for each step.
 
 ```bash
-source .env
+export SERVER_URL=https://....openshiftapps.com
+export X_TENANT=dataplane
+export MODEL_URL=https://vllm-sim2-evalhub-test.....openshiftapps.com/v1
+export MODEL_NAME=ibm-granite/granite-3.3-2b-instruct
+export MODEL_AUTH_SECRET_REF=vllm-sim2-secret
+export AUTH_TOKEN="..."
 ```
-
-and then execute the follow make target for each step
-
-Or, export the env variables
 
 ### make run-pre-upgrade
 

--- a/tests/upgrade/post_upgrade.feature
+++ b/tests/upgrade/post_upgrade.feature
@@ -1,0 +1,23 @@
+@post-upgrade
+Feature: Post-Upgrade — Create New Resources (Regression)
+  Verify that the upgraded cluster accepts new evaluation jobs.
+
+  Background:
+    Given I set the header "Authorization" to "Bearer {{env:AUTH_TOKEN}}"
+    And I set the header "X-Tenant" to "{{env:X_TENANT}}"
+    And I set the header "X-User" to "{{env:X_USER|upgrade-test-user}}"
+    And I set the wait deadline to "10m"
+    And I set the wait interval to "10s"
+
+  Scenario: Create evaluation job on upgraded cluster and wait for completion
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/post_upgrade_job.jsonnet"
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the response should contain the value "completed" at path "$.status.state"
+    And the response should contain the value "arc_easy" at path "$.results.benchmarks[0].id"
+    And the response should contain the value "{{value:job_id}}" at path "$.resource.id"
+    And the response should contain the value "post-upgrade-job1" at path "$.name"

--- a/tests/upgrade/post_upgrade_cleanup.feature
+++ b/tests/upgrade/post_upgrade_cleanup.feature
@@ -1,0 +1,12 @@
+@post-upgrade-cleanup
+Feature: Post-Upgrade Cleanup
+  Delete all evaluation jobs on the upgraded cluster.
+
+  Background:
+    Given I set the header "Authorization" to "Bearer {{env:AUTH_TOKEN}}"
+    And I set the header "X-Tenant" to "{{env:X_TENANT}}"
+    And I set the header "X-User" to "{{env:X_USER|upgrade-test-user}}"
+
+  Scenario: Hard-delete all evaluation jobs
+    Given the service is running
+    Then I hard-delete all evaluation jobs

--- a/tests/upgrade/post_upgrade_cleanup.feature
+++ b/tests/upgrade/post_upgrade_cleanup.feature
@@ -1,12 +1,12 @@
 @post-upgrade-cleanup
 Feature: Post-Upgrade Cleanup
-  Delete all evaluation jobs on the upgraded cluster.
+  Delete evaluation jobs whose names contain "-upgrade-" on the upgraded cluster.
 
   Background:
     Given I set the header "Authorization" to "Bearer {{env:AUTH_TOKEN}}"
     And I set the header "X-Tenant" to "{{env:X_TENANT}}"
     And I set the header "X-User" to "{{env:X_USER|upgrade-test-user}}"
 
-  Scenario: Hard-delete all evaluation jobs
+  Scenario: Hard-delete all upgrade evaluation jobs
     Given the service is running
-    Then I hard-delete all evaluation jobs
+    Then I hard-delete all evaluation jobs containing "-upgrade-" in its job name

--- a/tests/upgrade/post_upgrade_verify.feature
+++ b/tests/upgrade/post_upgrade_verify.feature
@@ -7,7 +7,7 @@ Feature: Post-Upgrade Verify — Fixtures Survived
     Given I set the header "Authorization" to "Bearer {{env:AUTH_TOKEN}}"
     And I set the header "X-Tenant" to "{{env:X_TENANT}}"
     And I set the header "X-User" to "{{env:X_USER|upgrade-test-user}}"
-    And I load the upgrade state from "{{env:UPGRADE_STATE_JSON|test-reports/upgrade-state.json}}"
+    And I load the upgrade state from "{{env:UPGRADE_STATE_JSON}}"
 
   Scenario: All pre-upgrade jobs still exist
     Given the service is running

--- a/tests/upgrade/post_upgrade_verify.feature
+++ b/tests/upgrade/post_upgrade_verify.feature
@@ -1,0 +1,14 @@
+@post-upgrade-verify
+Feature: Post-Upgrade Verify — Fixtures Survived
+  Verify that resources created before the upgrade still exist and
+  are retrievable on the upgraded cluster.
+
+  Background:
+    Given I set the header "Authorization" to "Bearer {{env:AUTH_TOKEN}}"
+    And I set the header "X-Tenant" to "{{env:X_TENANT}}"
+    And I set the header "X-User" to "{{env:X_USER|upgrade-test-user}}"
+    And I load the upgrade state from "{{env:UPGRADE_STATE_JSON|test-reports/upgrade-state.json}}"
+
+  Scenario: All pre-upgrade jobs still exist
+    Given the service is running
+    Then I verify all jobs from upgrade state exist

--- a/tests/upgrade/pre_upgrade.feature
+++ b/tests/upgrade/pre_upgrade.feature
@@ -22,4 +22,4 @@ Feature: Pre-Upgrade — Create Test Fixtures
     And the response should contain the value "arc_easy" at path "$.results.benchmarks[0].id"
     And the response should contain the value "{{value:job_id}}" at path "$.resource.id"
     And the response should contain the value "pre-upgrade-job1" at path "$.name"
-    And I collect all jobs and save upgrade state to "test-reports/upgrade-state.json" expecting current job "pre-upgrade-job1" in "completed" state
+    And I collect all jobs and save upgrade state to "{{env:UPGRADE_STATE_JSON}}" expecting current job "pre-upgrade-job1" in "completed" state

--- a/tests/upgrade/pre_upgrade.feature
+++ b/tests/upgrade/pre_upgrade.feature
@@ -1,0 +1,25 @@
+@pre-upgrade
+Feature: Pre-Upgrade — Create Test Fixtures
+  Create evaluation resources on the source RHOAI version that
+  must survive the upgrade.
+
+  Background:
+    Given I set the header "Authorization" to "Bearer {{env:AUTH_TOKEN}}"
+    And I set the header "X-Tenant" to "{{env:X_TENANT}}"
+    And I set the header "X-User" to "{{env:X_USER|upgrade-test-user}}"
+    And I set the wait deadline to "10m"
+    And I set the wait interval to "10s"
+
+  Scenario: Create evaluation job and wait for completion
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/pre_upgrade_job.jsonnet"
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the response should contain the value "completed" at path "$.status.state"
+    And the response should contain the value "arc_easy" at path "$.results.benchmarks[0].id"
+    And the response should contain the value "{{value:job_id}}" at path "$.resource.id"
+    And the response should contain the value "pre-upgrade-job1" at path "$.name"
+    And I collect all jobs and save upgrade state to "test-reports/upgrade-state.json" expecting current job "pre-upgrade-job1" in "completed" state

--- a/tests/upgrade/suite_test.go
+++ b/tests/upgrade/suite_test.go
@@ -206,17 +206,11 @@ func (s *scenarioState) getValue(id string) (string, error) {
 // ---------------------------------------------------------------------------
 
 func (s *scenarioState) getEndpoint(path string) (string, error) {
-	for strings.Contains(path, fmt.Sprintf("{{%s", valuePrefix)) {
-		match := templateTokenRe.FindStringSubmatch(path)
-		if len(match) <= 1 {
-			break
-		}
-		v, err := s.getValue(match[1])
-		if err != nil {
-			return "", err
-		}
-		path = strings.ReplaceAll(path, fmt.Sprintf("{{%s}}", match[1]), v)
+	expanded, err := s.substituteValues(path)
+	if err != nil {
+		return "", err
 	}
+	path = expanded
 
 	if strings.Contains(path, "{id}") {
 		if s.lastId == "" {
@@ -780,9 +774,14 @@ func resolveRepoPath(path string) string {
 	return filepath.Join(repoRoot(), path)
 }
 
+const maxPaginationPages = 200
+
 func (s *scenarioState) paginateJobs(visit func(*gabs.Container) error) error {
 	endpoint := "/api/v1/evaluations/jobs"
-	for endpoint != "" {
+	for page := 0; endpoint != ""; page++ {
+		if page >= maxPaginationPages {
+			return fmt.Errorf("pagination exceeded %d pages", maxPaginationPages)
+		}
 		ref, err := url.Parse(endpoint)
 		if err != nil {
 			return fmt.Errorf("parse endpoint %q: %w", endpoint, err)
@@ -818,7 +817,11 @@ func (s *scenarioState) paginateJobs(visit func(*gabs.Container) error) error {
 		}
 
 		if next := parsed.Path("next.href"); next != nil && next.Data() != nil {
-			endpoint = next.Data().(string)
+			href, ok := next.Data().(string)
+			if !ok {
+				return fmt.Errorf("next.href is not a string: %T", next.Data())
+			}
+			endpoint = href
 		} else {
 			endpoint = ""
 		}

--- a/tests/upgrade/suite_test.go
+++ b/tests/upgrade/suite_test.go
@@ -1,0 +1,990 @@
+package upgrade
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Jeffail/gabs/v2"
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/cucumber/godog"
+	"github.com/cucumber/godog/colors"
+	pkgapi "github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/google/go-jsonnet"
+	"github.com/spf13/pflag"
+)
+
+var opts = godog.Options{
+	Output: colors.Colored(os.Stdout),
+	Format: "pretty",
+	Strict: true,
+	Paths:  []string{"."},
+}
+
+var apiConfig *apiFeature
+
+type apiFeature struct {
+	baseURL *url.URL
+	client  *http.Client
+}
+
+type scenarioState struct {
+	api        *apiFeature
+	reqHeaders map[string]string
+	response   *http.Response
+	body       []byte
+
+	values map[string]string
+	lastId string
+
+	waitDeadline time.Duration
+	waitInterval time.Duration
+
+	loadedState *upgradeState
+}
+
+type upgradeState struct {
+	Jobs []upgradeJob `json:"jobs"`
+}
+
+type upgradeJob struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+type jsonnetHarness struct {
+	Env    map[string]string `json:"env"`
+	Values map[string]string `json:"values"`
+}
+
+var (
+	templateTokenRe = regexp.MustCompile(`\{\{([^}]*)\}\}`)
+	arrayIndexRe    = regexp.MustCompile(`\[(\d+)\]`)
+)
+
+func TestMain(m *testing.M) {
+	godog.BindCommandLineFlags("godog.", &opts)
+	pflag.Parse()
+	if args := pflag.Args(); len(args) > 0 {
+		opts.Paths = args
+	}
+
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true, //nolint:gosec
+	}
+
+	serverURL := os.Getenv("SERVER_URL")
+	if serverURL == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: SERVER_URL is not set")
+		os.Exit(1)
+	}
+	uri, err := url.Parse(serverURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: invalid SERVER_URL: %v\n", err)
+		os.Exit(1)
+	}
+
+	apiConfig = &apiFeature{
+		baseURL: uri,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+
+	suite := godog.TestSuite{
+		Name:                "EvalHub Upgrade Tests",
+		ScenarioInitializer: initializeScenario,
+		Options:             &opts,
+	}
+	os.Exit(suite.Run())
+}
+
+func initializeScenario(ctx *godog.ScenarioContext) {
+	s := &scenarioState{
+		api:          apiConfig,
+		reqHeaders:   make(map[string]string),
+		values:       make(map[string]string),
+		waitDeadline: 5 * time.Minute,
+		waitInterval: 10 * time.Second,
+	}
+
+	ctx.Step(`^the service is running$`, s.theServiceIsRunning)
+	ctx.Step(`^I set the header "([^"]*)" to "([^"]*)"$`, s.iSetHeaderTo)
+	ctx.Step(`^I set the wait deadline to "([^"]*)"$`, s.iSetWaitDeadlineTo)
+	ctx.Step(`^I set the wait interval to "([^"]*)"$`, s.iSetWaitIntervalTo)
+
+	ctx.Step(`^I send a (GET|DELETE|POST|PUT) request to "([^"]*)"$`, s.iSendRequestTo)
+	ctx.Step(`^I send a (POST|PUT|PATCH) request to "([^"]*)" with body "([^"]*)"$`, s.iSendRequestToWithBody)
+	ctx.Step(`^I send a (POST|PUT|PATCH) request to "([^"]*)" with body:$`, s.iSendRequestToWithInlineBody)
+
+	ctx.Step(`^the response code should be (\d+)$`, s.theResponseCodeShouldBe)
+	ctx.Step(`^the response code should be (\d+) or (\d+)$`, s.theResponseCodeShouldBeOr)
+	ctx.Step(`^the response should be JSON$`, s.theResponseShouldBeJSON)
+	ctx.Step(`^the response should contain "([^"]*)" with value "([^"]*)"$`, s.theResponseShouldContainWithValue)
+	ctx.Step(`^the response should contain "([^"]*)"$`, s.theResponseShouldContain)
+	ctx.Step(`^the response should contain the value "([^"]*)" at path "([^"]*)"$`, s.theResponseShouldContainAtJSONPath)
+	ctx.Step(`^the response should contain at least the value "([^"]*)" at path "([^"]*)"$`, s.theResponseShouldContainAtJSONPathAtLeast)
+	ctx.Step(`^the array at path "([^"]*)" in the response should have length at least (\d+)$`, s.theArrayAtPathShouldHaveLengthAtLeast)
+
+	ctx.Step(`^the "([^"]*)" field in the response should be saved as "([^"]*)"$`, s.theFieldShouldBeSaved)
+	ctx.Step(`^I wait for the evaluation job status to be "([^"]*)"$`, s.iWaitForEvaluationJobStatus)
+	ctx.Step(`^I collect all jobs and save upgrade state to "([^"]*)" expecting current job "([^"]*)" in "([^"]*)" state$`, s.iCollectAndSaveUpgradeState)
+	ctx.Step(`^I load the upgrade state from "([^"]*)"$`, s.iLoadUpgradeState)
+	ctx.Step(`^I hard-delete all evaluation jobs$`, s.iHardDeleteAllEvaluationJobs)
+	ctx.Step(`^I verify all jobs from upgrade state exist$`, s.iVerifyAllJobsFromUpgradeStateExist)
+}
+
+// ---------------------------------------------------------------------------
+// Value resolution
+// ---------------------------------------------------------------------------
+
+const valuePrefix = "value:"
+
+func (s *scenarioState) substituteValues(body string) (string, error) {
+	for strings.Contains(body, "{{") {
+		match := templateTokenRe.FindStringSubmatch(body)
+		if len(match) <= 1 {
+			break
+		}
+		token := match[1]
+		if raw, ok := strings.CutPrefix(token, "env:"); ok {
+			envName, fallback, hasFallback := strings.Cut(raw, "|")
+			var value string
+			if envValue, envOk := os.LookupEnv(envName); envOk {
+				value = envValue
+			} else if hasFallback {
+				value = fallback
+			}
+			body = strings.ReplaceAll(body, fmt.Sprintf("{{%s}}", token), value)
+		} else if name, ok := strings.CutPrefix(token, valuePrefix); ok {
+			body = strings.ReplaceAll(body, fmt.Sprintf("{{%s}}", token), s.values[name])
+		} else {
+			return "", fmt.Errorf("unknown substitution: %s", token)
+		}
+	}
+	return body, nil
+}
+
+func (s *scenarioState) getValue(id string) (string, error) {
+	if value, err := s.substituteValues(id); err == nil {
+		id = value
+	}
+	if strings.HasPrefix(id, "{") && strings.HasSuffix(id, "}") {
+		n := strings.TrimSuffix(strings.TrimPrefix(id, "{"), "}")
+		v := s.values[n]
+		if v == "" {
+			return "", fmt.Errorf("value {%s} not found", n)
+		}
+		return v, nil
+	}
+	if strings.HasPrefix(id, valuePrefix) {
+		n := strings.TrimPrefix(id, valuePrefix)
+		v := s.values[n]
+		if v == "" {
+			return "", fmt.Errorf("value %s not found", n)
+		}
+		return v, nil
+	}
+	return id, nil
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint resolution
+// ---------------------------------------------------------------------------
+
+func (s *scenarioState) getEndpoint(path string) (string, error) {
+	for strings.Contains(path, fmt.Sprintf("{{%s", valuePrefix)) {
+		match := templateTokenRe.FindStringSubmatch(path)
+		if len(match) <= 1 {
+			break
+		}
+		v, err := s.getValue(match[1])
+		if err != nil {
+			return "", err
+		}
+		path = strings.ReplaceAll(path, fmt.Sprintf("{{%s}}", match[1]), v)
+	}
+
+	if strings.Contains(path, "{id}") {
+		if s.lastId == "" {
+			return "", fmt.Errorf("last ID is not set")
+		}
+		path = strings.Replace(path, "{id}", s.lastId, 1)
+	}
+
+	if !strings.HasPrefix(path, s.api.baseURL.String()) {
+		baseStr := strings.TrimRight(s.api.baseURL.String(), "/")
+		path = baseStr + path
+	}
+	return path, nil
+}
+
+// ---------------------------------------------------------------------------
+// Request body handling (file + jsonnet)
+// ---------------------------------------------------------------------------
+
+var (
+	testDataRoot     string
+	testDataRootOnce sync.Once
+	jsonnetLibDir    string
+	jsonnetLibOnce   sync.Once
+	envMap           map[string]string
+	envMapOnce       sync.Once
+	repoRootDir      string
+	repoRootOnce     sync.Once
+)
+
+func upgradeTestDataRoot() string {
+	testDataRootOnce.Do(func() {
+		for _, dir := range []string{
+			filepath.Join("tests", "upgrade", "test_data"),
+			filepath.Join("test_data"),
+		} {
+			if _, err := os.Stat(dir); err == nil {
+				testDataRoot = dir
+				return
+			}
+		}
+		testDataRoot = filepath.Join("tests", "upgrade", "test_data")
+	})
+	return testDataRoot
+}
+
+func fvtJsonnetLibDir() string {
+	jsonnetLibOnce.Do(func() {
+		for _, dir := range []string{
+			filepath.Join("tests", "features", "test_data", "jsonnet"),
+			filepath.Join("..", "features", "test_data", "jsonnet"),
+		} {
+			if _, err := os.Stat(dir); err == nil {
+				jsonnetLibDir = dir
+				return
+			}
+		}
+		jsonnetLibDir = filepath.Join("tests", "features", "test_data", "jsonnet")
+	})
+	return jsonnetLibDir
+}
+
+func cachedEnvMap() map[string]string {
+	envMapOnce.Do(func() {
+		envMap = make(map[string]string)
+		for _, kv := range os.Environ() {
+			key, val, _ := strings.Cut(kv, "=")
+			envMap[key] = val
+		}
+	})
+	return envMap
+}
+
+func (s *scenarioState) jsonnetHarnessJSON() (string, error) {
+	values := s.values
+	if values == nil {
+		values = map[string]string{}
+	}
+	harness := jsonnetHarness{
+		Env:    cachedEnvMap(),
+		Values: values,
+	}
+	encoded, err := json.Marshal(harness)
+	if err != nil {
+		return "", fmt.Errorf("encode jsonnet harness: %w", err)
+	}
+	return string(encoded), nil
+}
+
+func (s *scenarioState) evaluateJsonnetFile(path string) (string, error) {
+	harnessJSON, err := s.jsonnetHarnessJSON()
+	if err != nil {
+		return "", err
+	}
+	vm := jsonnet.MakeVM()
+	vm.Importer(&jsonnet.FileImporter{
+		JPaths: []string{
+			filepath.Dir(path),
+			fvtJsonnetLibDir(),
+		},
+	})
+	vm.ExtVar("harness", harnessJSON)
+	output, err := vm.EvaluateFile(path)
+	if err != nil {
+		return "", fmt.Errorf("evaluate jsonnet file %s: %w", path, err)
+	}
+	return output, nil
+}
+
+func jsonnetSiblingName(fileName string) string {
+	ext := filepath.Ext(fileName)
+	if ext == "" {
+		return fileName + ".jsonnet"
+	}
+	return strings.TrimSuffix(fileName, ext) + ".jsonnet"
+}
+
+func (s *scenarioState) getFile(fileName string) (string, error) {
+	root := upgradeTestDataRoot()
+
+	jsonnetName := jsonnetSiblingName(fileName)
+	jsonnetPath := filepath.Join(root, jsonnetName)
+	if _, err := os.Stat(jsonnetPath); err == nil {
+		return s.evaluateJsonnetFile(jsonnetPath)
+	}
+
+	filePath := filepath.Join(root, fileName)
+	contents, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("test file %s not found in %s: %w", fileName, root, err)
+	}
+	return string(contents), nil
+}
+
+func (s *scenarioState) getRequestBody(body string) (io.Reader, error) {
+	if body == "" {
+		return nil, nil
+	}
+	var err error
+	if strings.HasPrefix(body, "file:/") {
+		body, err = s.getFile(strings.TrimPrefix(body, "file:/"))
+		if err != nil {
+			return nil, err
+		}
+	}
+	body, err = s.substituteValues(body)
+	if err != nil {
+		return nil, err
+	}
+	return strings.NewReader(body), nil
+}
+
+// ---------------------------------------------------------------------------
+// ID extraction
+// ---------------------------------------------------------------------------
+
+var pathDetails = regexp.MustCompile(`^.*/api/v1/([^/?]+)(?:/([^/?]+))?(?:/([^/?]+))?.*$`)
+
+func (s *scenarioState) extractId(body []byte) (string, error) {
+	if len(body) == 0 {
+		return "", nil
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return "", fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+	resource, ok := obj["resource"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("response does not contain resource object: %s", string(body))
+	}
+	id, ok := resource["id"].(string)
+	if !ok || id == "" {
+		return "", fmt.Errorf("response does not contain resource.id: %s", string(body))
+	}
+	return id, nil
+}
+
+// ---------------------------------------------------------------------------
+// HTTP step definitions
+// ---------------------------------------------------------------------------
+
+func (s *scenarioState) theServiceIsRunning() error {
+	endpoint := s.api.baseURL.String() + "/api/v1/health"
+	for range 20 {
+		req, _ := http.NewRequest("GET", endpoint, nil)
+		for k, v := range s.reqHeaders {
+			req.Header.Set(k, v)
+		}
+		resp, err := s.api.client.Do(req)
+		if err == nil && resp.StatusCode == 200 {
+			_ = resp.Body.Close()
+			return nil
+		}
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return fmt.Errorf("service is not running at %s", s.api.baseURL)
+}
+
+func (s *scenarioState) iSetHeaderTo(name, value string) error {
+	resolved, err := s.getValue(value)
+	if err != nil {
+		return err
+	}
+	s.reqHeaders[name] = resolved
+	return nil
+}
+
+func (s *scenarioState) iSendRequestTo(method, path string) error {
+	return s.iSendRequestImpl(method, path, "")
+}
+
+func (s *scenarioState) iSendRequestToWithBody(method, path, body string) error {
+	return s.iSendRequestImpl(method, path, body)
+}
+
+func (s *scenarioState) iSendRequestToWithInlineBody(method, path string, body *godog.DocString) error {
+	if body == nil {
+		return fmt.Errorf("inline body is missing")
+	}
+	return s.iSendRequestImpl(method, path, body.Content)
+}
+
+func (s *scenarioState) iSendRequestImpl(method, path, body string) error {
+	endpoint, err := s.getEndpoint(path)
+	if err != nil {
+		return err
+	}
+	entity, err := s.getRequestBody(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(method, endpoint, entity)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range s.reqHeaders {
+		req.Header.Set(k, v)
+	}
+
+	s.response, err = s.api.client.Do(req)
+	if err != nil {
+		return err
+	}
+	s.body, err = io.ReadAll(s.response.Body)
+	_ = s.response.Body.Close()
+	if err != nil {
+		return err
+	}
+
+	if method == http.MethodPost && (s.response.StatusCode == http.StatusAccepted || s.response.StatusCode == http.StatusCreated) {
+		if matches := pathDetails.FindStringSubmatch(endpoint); len(matches) >= 3 && matches[2] != "" {
+			s.lastId, err = s.extractId(s.body)
+			if err != nil {
+				return err
+			}
+			if s.lastId != "" {
+				s.values["id"] = s.lastId
+			}
+		}
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Response assertions
+// ---------------------------------------------------------------------------
+
+func (s *scenarioState) theResponseCodeShouldBe(code int) error {
+	if s.response.StatusCode != code {
+		return fmt.Errorf("expected status %d, got %d: %s", code, s.response.StatusCode, string(s.body))
+	}
+	return nil
+}
+
+func (s *scenarioState) theResponseCodeShouldBeOr(code1, code2 int) error {
+	if s.response.StatusCode != code1 && s.response.StatusCode != code2 {
+		return fmt.Errorf("expected status %d or %d, got %d: %s", code1, code2, s.response.StatusCode, string(s.body))
+	}
+	return nil
+}
+
+func (s *scenarioState) theResponseShouldBeJSON() error {
+	var data interface{}
+	if err := json.Unmarshal(s.body, &data); err != nil {
+		return fmt.Errorf("response is not valid JSON: %w", err)
+	}
+	return nil
+}
+
+func (s *scenarioState) theResponseShouldContainWithValue(key, expected string) error {
+	var data map[string]interface{}
+	if err := json.Unmarshal(s.body, &data); err != nil {
+		return err
+	}
+	if expanded, err := s.substituteValues(expected); err == nil {
+		expected = expanded
+	}
+	actual, ok := data[key]
+	if !ok {
+		return fmt.Errorf("response does not contain key %q", key)
+	}
+	if fmt.Sprintf("%v", actual) != expected {
+		return fmt.Errorf("expected %s=%q, got %q", key, expected, actual)
+	}
+	return nil
+}
+
+func (s *scenarioState) theResponseShouldContain(key string) error {
+	var data map[string]interface{}
+	if err := json.Unmarshal(s.body, &data); err != nil {
+		return err
+	}
+	if expanded, err := s.substituteValues(key); err == nil {
+		key = expanded
+	}
+	if _, ok := data[key]; !ok {
+		return fmt.Errorf("response does not contain key %q in %s", key, strings.TrimSpace(string(s.body)))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// JSONPath assertions
+// ---------------------------------------------------------------------------
+
+func (s *scenarioState) getJsonPathValue(jsonPath string) (interface{}, error) {
+	var respMap map[string]interface{}
+	if err := json.Unmarshal(s.body, &respMap); err != nil {
+		return nil, err
+	}
+	path := jsonPath
+	if !strings.HasPrefix(path, "$") {
+		path = "$." + path
+	}
+	foundValue, err := jsonpath.Get(path, respMap)
+	if err != nil {
+		return nil, fmt.Errorf("JSONPath %s not found in %s: %w", jsonPath, asPrettyJson(string(s.body)), err)
+	}
+	return foundValue, nil
+}
+
+func (s *scenarioState) getJsonPath(jp string) (string, error) {
+	jp = strings.ReplaceAll(jp, "&quot;", "\"")
+	raw, err := s.getJsonPathValue(jp)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%v", raw), nil
+}
+
+func (s *scenarioState) theResponseShouldContainAtJSONPath(expectedValue, jsonPath string) error {
+	expanded, err := s.substituteValues(expectedValue)
+	if err != nil {
+		return err
+	}
+	expectedValue = expanded
+
+	foundValue, err := s.getJsonPath(jsonPath)
+	if err != nil {
+		return err
+	}
+
+	// Support OR matching with pipe separator
+	for _, expected := range strings.Split(expectedValue, "|") {
+		if strings.Contains(foundValue, expected) {
+			return nil
+		}
+	}
+	return fmt.Errorf("expected %q to contain %q at path %s", foundValue, expectedValue, jsonPath)
+}
+
+func (s *scenarioState) theResponseShouldContainAtJSONPathAtLeast(expectedValue, jsonPath string) error {
+	expanded, err := s.substituteValues(expectedValue)
+	if err != nil {
+		return err
+	}
+
+	foundValue, err := s.getJsonPath(jsonPath)
+	if err != nil {
+		return err
+	}
+
+	expectedFloat, err := strconv.ParseFloat(expanded, 64)
+	if err != nil {
+		return fmt.Errorf("expected value %q is not a number: %w", expanded, err)
+	}
+	foundFloat, err := strconv.ParseFloat(foundValue, 64)
+	if err != nil {
+		return fmt.Errorf("found value %q is not a number: %w", foundValue, err)
+	}
+	if foundFloat < expectedFloat {
+		return fmt.Errorf("expected value at %s >= %v, got %v", jsonPath, expectedFloat, foundFloat)
+	}
+	return nil
+}
+
+func (s *scenarioState) theArrayAtPathShouldHaveLengthAtLeast(jsonPath string, minLength int) error {
+	raw, err := s.getJsonPathValue(jsonPath)
+	if err != nil {
+		return err
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return fmt.Errorf("value at path %s is not an array, got %T", jsonPath, raw)
+	}
+	if len(arr) < minLength {
+		return fmt.Errorf("expected array at %s to have length >= %d, got %d", jsonPath, minLength, len(arr))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Field saving
+// ---------------------------------------------------------------------------
+
+func getJsonPointer(path string) string {
+	path = strings.TrimPrefix(path, "$.")
+	path = strings.TrimPrefix(path, "$")
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	path = strings.ReplaceAll(path, ".", "/")
+	path = arrayIndexRe.ReplaceAllString(path, "/$1")
+	return path
+}
+
+func (s *scenarioState) theFieldShouldBeSaved(path, name string) error {
+	jsonParsed, err := gabs.ParseJSON(s.body)
+	if err != nil {
+		return fmt.Errorf("failed to parse JSON response: %w", err)
+	}
+	pathObj, err := jsonParsed.JSONPointer(getJsonPointer(path))
+	if err != nil {
+		return fmt.Errorf("path %v does not exist in %s", path, string(s.body))
+	}
+	finalResult, ok := pathObj.Data().(string)
+	if !ok {
+		if floatResult, ok := pathObj.Data().(float64); ok {
+			finalResult = strconv.FormatFloat(floatResult, 'f', -1, 64)
+		} else {
+			return fmt.Errorf("expected %s to be a string or float64 but got %T", path, pathObj.Data())
+		}
+	}
+	if !strings.HasPrefix(name, valuePrefix) {
+		return fmt.Errorf("save target %q must start with %q", name, valuePrefix)
+	}
+	realName := strings.TrimPrefix(name, valuePrefix)
+	s.values[realName] = finalResult
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Wait for evaluation job status
+// ---------------------------------------------------------------------------
+
+func (s *scenarioState) parseDuration(raw string) (time.Duration, error) {
+	v, err := s.getValue(raw)
+	if err != nil {
+		return 0, err
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", v, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("duration must be positive, got %v", d)
+	}
+	return d, nil
+}
+
+func (s *scenarioState) iSetWaitDeadlineTo(paramValue string) error {
+	d, err := s.parseDuration(paramValue)
+	if err != nil {
+		return err
+	}
+	s.waitDeadline = d
+	return nil
+}
+
+func (s *scenarioState) iSetWaitIntervalTo(paramValue string) error {
+	d, err := s.parseDuration(paramValue)
+	if err != nil {
+		return err
+	}
+	s.waitInterval = d
+	return nil
+}
+
+func (s *scenarioState) iWaitForEvaluationJobStatus(expectedStatus string) error {
+	deadline := time.Now().Add(s.waitDeadline)
+	var lastErr error
+	var lastStatus string
+
+	for time.Now().Before(deadline) {
+		if err := s.iSendRequestImpl(http.MethodGet, "/api/v1/evaluations/jobs/{id}", ""); err != nil {
+			lastErr = err
+			time.Sleep(s.waitInterval)
+			continue
+		}
+		if s.response != nil && s.response.StatusCode == http.StatusOK {
+			status, err := s.getJsonPath("$.status.state")
+			if status != "" {
+				lastStatus = status
+			}
+			if err != nil {
+				lastErr = err
+			} else if status == expectedStatus {
+				return nil
+			} else if pkgapi.OverallState(status).IsTerminalState() {
+				message, _ := s.getJsonPath("$.status.message.message")
+				if message != "" {
+					return fmt.Errorf("evaluation job reached terminal state %q (expected %q): %s", status, expectedStatus, message)
+				}
+				return fmt.Errorf("evaluation job reached terminal state %q (expected %q)", status, expectedStatus)
+			}
+		} else if s.response != nil {
+			lastErr = fmt.Errorf("unexpected response status %d", s.response.StatusCode)
+		}
+		time.Sleep(s.waitInterval)
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("timed out after %v waiting for status %q, last status: %q", s.waitDeadline, expectedStatus, lastStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Upgrade state file
+// ---------------------------------------------------------------------------
+
+func repoRoot() string {
+	repoRootOnce.Do(func() {
+		wd, _ := os.Getwd()
+		dir := wd
+		for {
+			if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+				repoRootDir = dir
+				return
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+		repoRootDir = wd
+	})
+	return repoRootDir
+}
+
+func resolveRepoPath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(repoRoot(), path)
+}
+
+func (s *scenarioState) paginateJobs(visit func(*gabs.Container) error) error {
+	endpoint := "/api/v1/evaluations/jobs"
+	for endpoint != "" {
+		req, err := http.NewRequest(http.MethodGet, s.api.baseURL.JoinPath(endpoint).String(), nil)
+		if err != nil {
+			return fmt.Errorf("build list request: %w", err)
+		}
+		for k, v := range s.reqHeaders {
+			req.Header.Set(k, v)
+		}
+
+		resp, err := s.api.client.Do(req)
+		if err != nil {
+			return fmt.Errorf("list jobs: %w", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("list jobs returned %d: %s", resp.StatusCode, string(body))
+		}
+
+		parsed, err := gabs.ParseJSON(body)
+		if err != nil {
+			return fmt.Errorf("parse list response: %w", err)
+		}
+
+		for _, item := range parsed.Path("items").Children() {
+			if err := visit(item); err != nil {
+				return err
+			}
+		}
+
+		if next := parsed.Path("next.href"); next != nil && next.Data() != nil {
+			endpoint = next.Data().(string)
+		} else {
+			endpoint = ""
+		}
+	}
+	return nil
+}
+
+func (s *scenarioState) iCollectAndSaveUpgradeState(path, expectedName, expectedState string) error {
+	if expanded, err := s.substituteValues(path); err == nil {
+		path = expanded
+	}
+	path = resolveRepoPath(path)
+
+	var allJobs []upgradeJob
+	var currentJob *upgradeJob
+	if err := s.paginateJobs(func(item *gabs.Container) error {
+		job := upgradeJob{
+			ID:    item.Path("resource.id").Data().(string),
+			Name:  item.Path("name").Data().(string),
+			State: item.Path("status.state").Data().(string),
+		}
+		if v := item.Path("resource.created_at").Data(); v != nil {
+			job.CreatedAt, _ = v.(string)
+		}
+		if v := item.Path("resource.updated_at").Data(); v != nil {
+			job.UpdatedAt, _ = v.(string)
+		}
+		allJobs = append(allJobs, job)
+		if job.ID == s.lastId {
+			currentJob = &allJobs[len(allJobs)-1]
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if currentJob == nil {
+		return fmt.Errorf("current job %s not found in jobs list", s.lastId)
+	}
+	if currentJob.Name != expectedName {
+		return fmt.Errorf("current job %s has name %q, expected %q", s.lastId, currentJob.Name, expectedName)
+	}
+	if currentJob.State != expectedState {
+		return fmt.Errorf("current job %s has state %q, expected %q", s.lastId, currentJob.State, expectedState)
+	}
+
+	state := upgradeState{Jobs: allJobs}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal upgrade state: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write upgrade state: %w", err)
+	}
+	return nil
+}
+
+func (s *scenarioState) iLoadUpgradeState(path string) error {
+	if expanded, err := s.substituteValues(path); err == nil {
+		path = expanded
+	}
+	path = resolveRepoPath(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read upgrade state %s: %w", path, err)
+	}
+	var state upgradeState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("parse upgrade state: %w", err)
+	}
+	s.loadedState = &state
+	for i, job := range state.Jobs {
+		s.values[fmt.Sprintf("job_id_%d", i)] = job.ID
+		s.values[fmt.Sprintf("job_name_%d", i)] = job.Name
+		s.values[fmt.Sprintf("job_state_%d", i)] = job.State
+	}
+	if len(state.Jobs) > 0 {
+		s.values["job_id"] = state.Jobs[0].ID
+		s.lastId = state.Jobs[0].ID
+	}
+	return nil
+}
+
+func (s *scenarioState) iVerifyAllJobsFromUpgradeStateExist() error {
+	if s.loadedState == nil {
+		return fmt.Errorf("no upgrade state loaded")
+	}
+
+	collected := make(map[string]bool)
+	if err := s.paginateJobs(func(item *gabs.Container) error {
+		if id, ok := item.Path("resource.id").Data().(string); ok {
+			collected[id] = true
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	var missing []string
+	for _, job := range s.loadedState.Jobs {
+		if !collected[job.ID] {
+			missing = append(missing, fmt.Sprintf("%s (%s)", job.ID, job.Name))
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("jobs from upgrade state not found: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+func (s *scenarioState) iHardDeleteAllEvaluationJobs() error {
+	var jobIDs []string
+	if err := s.paginateJobs(func(item *gabs.Container) error {
+		name, _ := item.Path("name").Data().(string)
+		if strings.Contains(name, "-upgrade-") {
+			if id, ok := item.Path("resource.id").Data().(string); ok {
+				jobIDs = append(jobIDs, id)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	var errors []string
+	for _, id := range jobIDs {
+		delURL := s.api.baseURL.JoinPath("/api/v1/evaluations/jobs", id).String() + "?hard_delete=true"
+		req, err := http.NewRequest(http.MethodDelete, delURL, nil)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("build delete request for %s: %v", id, err))
+			continue
+		}
+		for k, v := range s.reqHeaders {
+			req.Header.Set(k, v)
+		}
+
+		resp, err := s.api.client.Do(req)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("delete %s: %v", id, err))
+			continue
+		}
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+			errors = append(errors, fmt.Sprintf("delete %s returned %d", id, resp.StatusCode))
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("cleanup errors: %s", strings.Join(errors, "; "))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func asPrettyJson(s string) string {
+	var js map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &js); err != nil {
+		return s
+	}
+	ns, err := json.MarshalIndent(js, "", "  ")
+	if err != nil {
+		return s
+	}
+	return string(ns)
+}

--- a/tests/upgrade/suite_test.go
+++ b/tests/upgrade/suite_test.go
@@ -55,7 +55,8 @@ type scenarioState struct {
 }
 
 type upgradeState struct {
-	Jobs []upgradeJob `json:"jobs"`
+	CurrentJobID string       `json:"current_job_id,omitempty"`
+	Jobs         []upgradeJob `json:"jobs"`
 }
 
 type upgradeJob struct {
@@ -96,6 +97,10 @@ func TestMain(m *testing.M) {
 	uri, err := url.Parse(serverURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: invalid SERVER_URL: %v\n", err)
+		os.Exit(1)
+	}
+	if uri.Scheme == "" || uri.Host == "" {
+		fmt.Fprintf(os.Stderr, "ERROR: invalid SERVER_URL %q: must include scheme and host (e.g. https://host:port)\n", serverURL)
 		os.Exit(1)
 	}
 
@@ -471,6 +476,9 @@ func (s *scenarioState) iSendRequestImpl(method, path, body string) error {
 // ---------------------------------------------------------------------------
 
 func (s *scenarioState) theResponseCodeShouldBe(code int) error {
+	if s.response == nil {
+		return fmt.Errorf("expected status %d but no response was received", code)
+	}
 	if s.response.StatusCode != code {
 		return fmt.Errorf("expected status %d, got %d: %s", code, s.response.StatusCode, string(s.body))
 	}
@@ -729,10 +737,11 @@ func (s *scenarioState) paginateJobs(visit func(*gabs.Container) error) error {
 }
 
 func (s *scenarioState) iCollectAndSaveUpgradeState(path, expectedName, expectedState string) error {
-	if expanded, err := s.substituteValues(path); err == nil {
-		path = expanded
+	expanded, err := s.substituteValues(path)
+	if err != nil {
+		return fmt.Errorf("substitute state path: %w", err)
 	}
-	path = resolveRepoPath(path)
+	path = resolveRepoPath(expanded)
 
 	var allJobs []upgradeJob
 	var currentJob *upgradeJob
@@ -779,7 +788,7 @@ func (s *scenarioState) iCollectAndSaveUpgradeState(path, expectedName, expected
 		return fmt.Errorf("current job %s has state %q, expected %q", s.lastId, currentJob.State, expectedState)
 	}
 
-	state := upgradeState{Jobs: allJobs}
+	state := upgradeState{CurrentJobID: currentJob.ID, Jobs: allJobs}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create state dir: %w", err)
 	}
@@ -794,10 +803,11 @@ func (s *scenarioState) iCollectAndSaveUpgradeState(path, expectedName, expected
 }
 
 func (s *scenarioState) iLoadUpgradeState(path string) error {
-	if expanded, err := s.substituteValues(path); err == nil {
-		path = expanded
+	expanded, err := s.substituteValues(path)
+	if err != nil {
+		return fmt.Errorf("substitute state path: %w", err)
 	}
-	path = resolveRepoPath(path)
+	path = resolveRepoPath(expanded)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("read upgrade state %s: %w", path, err)
@@ -807,7 +817,10 @@ func (s *scenarioState) iLoadUpgradeState(path string) error {
 		return fmt.Errorf("parse upgrade state: %w", err)
 	}
 	s.loadedState = &state
-	if len(state.Jobs) > 0 {
+	if state.CurrentJobID != "" {
+		s.values["job_id"] = state.CurrentJobID
+		s.lastId = state.CurrentJobID
+	} else if len(state.Jobs) > 0 {
 		s.values["job_id"] = state.Jobs[0].ID
 		s.lastId = state.Jobs[0].ID
 	}

--- a/tests/upgrade/suite_test.go
+++ b/tests/upgrade/suite_test.go
@@ -128,16 +128,9 @@ func initializeScenario(ctx *godog.ScenarioContext) {
 
 	ctx.Step(`^I send a (GET|DELETE|POST|PUT) request to "([^"]*)"$`, s.iSendRequestTo)
 	ctx.Step(`^I send a (POST|PUT|PATCH) request to "([^"]*)" with body "([^"]*)"$`, s.iSendRequestToWithBody)
-	ctx.Step(`^I send a (POST|PUT|PATCH) request to "([^"]*)" with body:$`, s.iSendRequestToWithInlineBody)
 
 	ctx.Step(`^the response code should be (\d+)$`, s.theResponseCodeShouldBe)
-	ctx.Step(`^the response code should be (\d+) or (\d+)$`, s.theResponseCodeShouldBeOr)
-	ctx.Step(`^the response should be JSON$`, s.theResponseShouldBeJSON)
-	ctx.Step(`^the response should contain "([^"]*)" with value "([^"]*)"$`, s.theResponseShouldContainWithValue)
-	ctx.Step(`^the response should contain "([^"]*)"$`, s.theResponseShouldContain)
 	ctx.Step(`^the response should contain the value "([^"]*)" at path "([^"]*)"$`, s.theResponseShouldContainAtJSONPath)
-	ctx.Step(`^the response should contain at least the value "([^"]*)" at path "([^"]*)"$`, s.theResponseShouldContainAtJSONPathAtLeast)
-	ctx.Step(`^the array at path "([^"]*)" in the response should have length at least (\d+)$`, s.theArrayAtPathShouldHaveLengthAtLeast)
 
 	ctx.Step(`^the "([^"]*)" field in the response should be saved as "([^"]*)"$`, s.theFieldShouldBeSaved)
 	ctx.Step(`^I wait for the evaluation job status to be "([^"]*)"$`, s.iWaitForEvaluationJobStatus)
@@ -429,13 +422,6 @@ func (s *scenarioState) iSendRequestToWithBody(method, path, body string) error 
 	return s.iSendRequestImpl(method, path, body)
 }
 
-func (s *scenarioState) iSendRequestToWithInlineBody(method, path string, body *godog.DocString) error {
-	if body == nil {
-		return fmt.Errorf("inline body is missing")
-	}
-	return s.iSendRequestImpl(method, path, body.Content)
-}
-
 func (s *scenarioState) iSendRequestImpl(method, path, body string) error {
 	endpoint, err := s.getEndpoint(path)
 	if err != nil {
@@ -491,53 +477,6 @@ func (s *scenarioState) theResponseCodeShouldBe(code int) error {
 	return nil
 }
 
-func (s *scenarioState) theResponseCodeShouldBeOr(code1, code2 int) error {
-	if s.response.StatusCode != code1 && s.response.StatusCode != code2 {
-		return fmt.Errorf("expected status %d or %d, got %d: %s", code1, code2, s.response.StatusCode, string(s.body))
-	}
-	return nil
-}
-
-func (s *scenarioState) theResponseShouldBeJSON() error {
-	var data interface{}
-	if err := json.Unmarshal(s.body, &data); err != nil {
-		return fmt.Errorf("response is not valid JSON: %w", err)
-	}
-	return nil
-}
-
-func (s *scenarioState) theResponseShouldContainWithValue(key, expected string) error {
-	var data map[string]interface{}
-	if err := json.Unmarshal(s.body, &data); err != nil {
-		return err
-	}
-	if expanded, err := s.substituteValues(expected); err == nil {
-		expected = expanded
-	}
-	actual, ok := data[key]
-	if !ok {
-		return fmt.Errorf("response does not contain key %q", key)
-	}
-	if fmt.Sprintf("%v", actual) != expected {
-		return fmt.Errorf("expected %s=%q, got %q", key, expected, actual)
-	}
-	return nil
-}
-
-func (s *scenarioState) theResponseShouldContain(key string) error {
-	var data map[string]interface{}
-	if err := json.Unmarshal(s.body, &data); err != nil {
-		return err
-	}
-	if expanded, err := s.substituteValues(key); err == nil {
-		key = expanded
-	}
-	if _, ok := data[key]; !ok {
-		return fmt.Errorf("response does not contain key %q in %s", key, strings.TrimSpace(string(s.body)))
-	}
-	return nil
-}
-
 // ---------------------------------------------------------------------------
 // JSONPath assertions
 // ---------------------------------------------------------------------------
@@ -586,46 +525,6 @@ func (s *scenarioState) theResponseShouldContainAtJSONPath(expectedValue, jsonPa
 		}
 	}
 	return fmt.Errorf("expected %q to contain %q at path %s", foundValue, expectedValue, jsonPath)
-}
-
-func (s *scenarioState) theResponseShouldContainAtJSONPathAtLeast(expectedValue, jsonPath string) error {
-	expanded, err := s.substituteValues(expectedValue)
-	if err != nil {
-		return err
-	}
-
-	foundValue, err := s.getJsonPath(jsonPath)
-	if err != nil {
-		return err
-	}
-
-	expectedFloat, err := strconv.ParseFloat(expanded, 64)
-	if err != nil {
-		return fmt.Errorf("expected value %q is not a number: %w", expanded, err)
-	}
-	foundFloat, err := strconv.ParseFloat(foundValue, 64)
-	if err != nil {
-		return fmt.Errorf("found value %q is not a number: %w", foundValue, err)
-	}
-	if foundFloat < expectedFloat {
-		return fmt.Errorf("expected value at %s >= %v, got %v", jsonPath, expectedFloat, foundFloat)
-	}
-	return nil
-}
-
-func (s *scenarioState) theArrayAtPathShouldHaveLengthAtLeast(jsonPath string, minLength int) error {
-	raw, err := s.getJsonPathValue(jsonPath)
-	if err != nil {
-		return err
-	}
-	arr, ok := raw.([]interface{})
-	if !ok {
-		return fmt.Errorf("value at path %s is not an array, got %T", jsonPath, raw)
-	}
-	if len(arr) < minLength {
-		return fmt.Errorf("expected array at %s to have length >= %d, got %d", jsonPath, minLength, len(arr))
-	}
-	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -908,11 +807,6 @@ func (s *scenarioState) iLoadUpgradeState(path string) error {
 		return fmt.Errorf("parse upgrade state: %w", err)
 	}
 	s.loadedState = &state
-	for i, job := range state.Jobs {
-		s.values[fmt.Sprintf("job_id_%d", i)] = job.ID
-		s.values[fmt.Sprintf("job_name_%d", i)] = job.Name
-		s.values[fmt.Sprintf("job_state_%d", i)] = job.State
-	}
 	if len(state.Jobs) > 0 {
 		s.values["job_id"] = state.Jobs[0].ID
 		s.lastId = state.Jobs[0].ID

--- a/tests/upgrade/suite_test.go
+++ b/tests/upgrade/suite_test.go
@@ -143,7 +143,7 @@ func initializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I wait for the evaluation job status to be "([^"]*)"$`, s.iWaitForEvaluationJobStatus)
 	ctx.Step(`^I collect all jobs and save upgrade state to "([^"]*)" expecting current job "([^"]*)" in "([^"]*)" state$`, s.iCollectAndSaveUpgradeState)
 	ctx.Step(`^I load the upgrade state from "([^"]*)"$`, s.iLoadUpgradeState)
-	ctx.Step(`^I hard-delete all evaluation jobs$`, s.iHardDeleteAllEvaluationJobs)
+	ctx.Step(`^I hard-delete all evaluation jobs containing "([^"]*)" in its job name$`, s.iHardDeleteAllEvaluationJobsContaining)
 	ctx.Step(`^I verify all jobs from upgrade state exist$`, s.iVerifyAllJobsFromUpgradeStateExist)
 }
 
@@ -783,7 +783,11 @@ func resolveRepoPath(path string) string {
 func (s *scenarioState) paginateJobs(visit func(*gabs.Container) error) error {
 	endpoint := "/api/v1/evaluations/jobs"
 	for endpoint != "" {
-		req, err := http.NewRequest(http.MethodGet, s.api.baseURL.JoinPath(endpoint).String(), nil)
+		ref, err := url.Parse(endpoint)
+		if err != nil {
+			return fmt.Errorf("parse endpoint %q: %w", endpoint, err)
+		}
+		req, err := http.NewRequest(http.MethodGet, s.api.baseURL.ResolveReference(ref).String(), nil)
 		if err != nil {
 			return fmt.Errorf("build list request: %w", err)
 		}
@@ -831,10 +835,22 @@ func (s *scenarioState) iCollectAndSaveUpgradeState(path, expectedName, expected
 	var allJobs []upgradeJob
 	var currentJob *upgradeJob
 	if err := s.paginateJobs(func(item *gabs.Container) error {
+		id, ok := item.Path("resource.id").Data().(string)
+		if !ok {
+			return fmt.Errorf("job missing resource.id or not a string")
+		}
+		name, ok := item.Path("name").Data().(string)
+		if !ok {
+			return fmt.Errorf("job missing name or not a string")
+		}
+		state, ok := item.Path("status.state").Data().(string)
+		if !ok {
+			return fmt.Errorf("job missing status.state or not a string")
+		}
 		job := upgradeJob{
-			ID:    item.Path("resource.id").Data().(string),
-			Name:  item.Path("name").Data().(string),
-			State: item.Path("status.state").Data().(string),
+			ID:    id,
+			Name:  name,
+			State: state,
 		}
 		if v := item.Path("resource.created_at").Data(); v != nil {
 			job.CreatedAt, _ = v.(string)
@@ -929,11 +945,11 @@ func (s *scenarioState) iVerifyAllJobsFromUpgradeStateExist() error {
 	return nil
 }
 
-func (s *scenarioState) iHardDeleteAllEvaluationJobs() error {
+func (s *scenarioState) iHardDeleteAllEvaluationJobsContaining(substring string) error {
 	var jobIDs []string
 	if err := s.paginateJobs(func(item *gabs.Container) error {
 		name, _ := item.Path("name").Data().(string)
-		if strings.Contains(name, "-upgrade-") {
+		if strings.Contains(name, substring) {
 			if id, ok := item.Path("resource.id").Data().(string); ok {
 				jobIDs = append(jobIDs, id)
 			}

--- a/tests/upgrade/test_data/post_upgrade_job.jsonnet
+++ b/tests/upgrade/test_data/post_upgrade_job.jsonnet
@@ -1,0 +1,17 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'post-upgrade-job1',
+  model: test.model(),
+  benchmarks: [
+    {
+      id: 'arc_easy',
+      provider_id: 'lm_evaluation_harness',
+      parameters: {
+        num_examples: 5,
+        num_fewshot: 0,
+        tokenizer: 'ibm-granite/granite-3.3-2b-instruct',
+      },
+    },
+  ],
+}

--- a/tests/upgrade/test_data/post_upgrade_job.jsonnet
+++ b/tests/upgrade/test_data/post_upgrade_job.jsonnet
@@ -9,7 +9,7 @@ local test = import 'test.libsonnet';
       provider_id: 'lm_evaluation_harness',
       parameters: {
         num_examples: 5,
-        num_fewshot: 0,
+        num_few_shot: 0,
         tokenizer: 'ibm-granite/granite-3.3-2b-instruct',
       },
     },

--- a/tests/upgrade/test_data/pre_upgrade_job.jsonnet
+++ b/tests/upgrade/test_data/pre_upgrade_job.jsonnet
@@ -1,0 +1,17 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'pre-upgrade-job1',
+  model: test.model(),
+  benchmarks: [
+    {
+      id: 'arc_easy',
+      provider_id: 'lm_evaluation_harness',
+      parameters: {
+        num_examples: 5,
+        num_fewshot: 0,
+        tokenizer: 'ibm-granite/granite-3.3-2b-instruct',
+      },
+    },
+  ],
+}

--- a/tests/upgrade/test_data/pre_upgrade_job.jsonnet
+++ b/tests/upgrade/test_data/pre_upgrade_job.jsonnet
@@ -9,7 +9,7 @@ local test = import 'test.libsonnet';
       provider_id: 'lm_evaluation_harness',
       parameters: {
         num_examples: 5,
-        num_fewshot: 0,
+        num_few_shot: 0,
         tokenizer: 'ibm-granite/granite-3.3-2b-instruct',
       },
     },


### PR DESCRIPTION
## What and why

Add BDD upgrade tests using godog to verify eval-hub behavior across version upgrades. The suite covers four phases: pre-upgrade fixture creation, post-upgrade verification, post-upgrade evaluation runs, and cleanup. Includes a shared state file for cross-phase coordination, jsonnet test data templates, a wrapper script for running phases individually or together, and updated Makefile targets wired to the go test runner.

**Updated Makefile targets:**

- **`run-pre-upgrade`** — creates an evaluation job, waits for completion, collects all jobs on the cluster and writes them to `UPGRADE_STATE_JSON`
- **`run-post-upgrade-verify`** — loads `UPGRADE_STATE_JSON` and verifies all previously recorded jobs still exist after the upgrade
- **`run-post-upgrade`** — runs post-upgrade evaluation tests independently (no state file dependency)
- **`run-post-upgrade-cleanup`** — paginates all jobs and hard-deletes those with `-upgrade-` in the name; runs independently, failures are ignored (`|| true`)

All four now include `-timeout=$(UPGRADE_TEST_TIMEOUT)` (default 15m) and `-count=1` to prevent caching.

**`UPGRADE_STATE_JSON` flow:**

The state file (default `test-reports/upgrade-state.json`) is the handoff artifact between the pre- and post-upgrade-verify phases:

1. `run-pre-upgrade` writes it — a snapshot of every job on the cluster (id, name, state, timestamps) plus a pointer to the job it just created
2. `run-post-upgrade-verify` reads it — confirms every job from the snapshot survived the upgrade intact

`run-post-upgrade` and `run-post-upgrade-cleanup` don't use the state file. The orchestrating target `run-atris-upgrade` chains all four in order.

- Use GNU Make's `$(abspath ...)` for `JUNIT_XML` and `UPGRADE_STATE_JSON` so both relative paths (local dev) and absolute paths (Jenkinsfile's `${WORKSPACE}/...`) resolve correctly

Closes # https://redhat.atlassian.net/browse/RHOAIENG-78317

Assisted-by: Claude
## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

Runs in under `1 min` the current set of test , on a `Warm` cluster.
<img width="1181" height="695" alt="Screenshot 2026-07-27 at 4 13 55 PM" src="https://github.com/user-attachments/assets/10066296-23a1-428d-8c10-d38f83bde6ef" />


## Breaking changes
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added end-to-end upgrade verification tests covering pre-upgrade job creation, post-upgrade verification (fixture persistence), post-upgrade regression (accepts new jobs), and post-upgrade cleanup (removes upgrade jobs).
  - Enhanced the upgrade test runner to support phase selection, state-based verification, per-phase JUnit output, and configurable timeouts.

- **Documentation**
  - Added documentation for running each upgrade phase, required environment variables, and expected test artifacts (upgrade state and JUnit XML).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->