### PR TITLE
chore(lighteval): align provider metric names with adapter output

### DIFF
--- a/config/providers/lighteval.yaml
+++ b/config/providers/lighteval.yaml
@@ -286,8 +286,7 @@ benchmarks:
       Multi-step arithmetic word problems requiring 2-8 reasoning steps (8-shot, 1,319 examples).
     category: math
     metrics:
-      - exact_match
-      - acc
+      - extractive_match
     num_few_shot: 8
     dataset_size: 1319
     tags:
@@ -295,7 +294,7 @@ benchmarks:
       - reasoning
       - lighteval
     primary_score:
-      metric: acc
+      metric: extractive_match
       lower_is_better: false
     pass_criteria:
       threshold: 0.25
@@ -336,8 +335,7 @@ benchmarks:
     description: American Invitational Mathematics Examination 2024 - competition-level mathematical reasoning
     category: reasoning
     metrics:
-      - exact_match
-      - acc
+      - pass@1
     num_few_shot: 0
     dataset_size: 30
     tags:
@@ -346,7 +344,7 @@ benchmarks:
       - competition
       - lighteval
     primary_score:
-      metric: acc
+      metric: pass@1
       lower_is_better: false
     pass_criteria:
       threshold: 0.25
@@ -355,8 +353,7 @@ benchmarks:
     description: American Invitational Mathematics Examination 2025 - competition-level mathematical reasoning
     category: reasoning
     metrics:
-      - exact_match
-      - acc
+      - pass@1
     num_few_shot: 0
     dataset_size: 30
     tags:
@@ -365,7 +362,7 @@ benchmarks:
       - competition
       - lighteval
     primary_score:
-      metric: acc
+      metric: pass@1
       lower_is_better: false
     pass_criteria:
       threshold: 0.25
@@ -466,7 +463,6 @@ benchmarks:
     category: math
     metrics:
       - pass@1
-      - exact_match
     num_few_shot: 0
     dataset_size: 500
     tags:
@@ -489,7 +485,6 @@ benchmarks:
     category: reasoning
     metrics:
       - gpqa_pass@1
-      - acc
     num_few_shot: 0
     dataset_size: 198
     tags:


### PR DESCRIPTION
## What and why

Closes RHOAIENG-64173
Follow up to https://github.com/eval-hub/eval-hub-contrib/pull/57

After RHOAIENG-64169, the LightEval adapter reports clean metric names (e.g. `pass@1` instead of `pass@1:3`). Update the provider catalog so declared metrics and `primary_score.metric` match that output.

- **aime24 / aime25**: `acc` / `exact_match` → `pass@1`
- **gsm8k**: `acc` / `exact_match` → `extractive_match`
- **math_500**: drop unused `exact_match` (primary already `pass@1`)
- **gpqa:diamond**: drop unused `acc` (primary already `gpqa_pass@1`)

Collections already use the clean names and continue to resolve.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

`make validate-configs` passes; collection `primary_score.metric` values for LightEval benchmarks match the updated provider metrics lists.

## Breaking changes

Provider catalog metric names for aime24, aime25, and gsm8k change. Jobs/collections that still reference `acc` for those LightEval benchmarks will not resolve a test result until updated. OOTB collections already use `pass@1` for aime25.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated benchmark scoring to use more appropriate evaluation metrics for GSM8K, AIME24, AIME25, Math-500, and GPQA Diamond.
  * Corrected primary score reporting for supported benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->