### PR TITLE
test(fvt): add comprehensive EvalCard test scenarios

### DIFF
--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1328,3 +1328,1011 @@ Feature: Evaluation Jobs
     And the response should contain the value "{{env:TEST_DATA_PVC_MISSING_CLAIM_NAME|evalhub-offline-test-data-does-not-exist}}" at path "$.status.benchmarks[0].error_message.message"
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
+  
+  @mlflow 
+  Scenario: Card generated for completed job with benchmarks
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_benchmark_test",
+        "description": "Job for card testing with benchmarks",
+        "tags": ["evalcard", "test"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "weight": 0.6,
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            },
+            "primary_score": {
+              "metric": "accuracy",
+              "aggregation": "mean"
+            },
+            "pass_criteria": {
+              "threshold": 0.3
+            }
+          }
+        ],
+        "pass_criteria": {
+          "threshold": 0.3
+        },
+        "experiment": {
+          "name": "evalcard_test_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "card_version"
+    And the MLflow artifact should contain "schema_version"
+    And the MLflow artifact should contain the value "{{value:job_id}}" at path "$.metadata.evaluation_job_id"
+    And the MLflow artifact should contain the value "{{env:MODEL_NAME|test}}" at path "$.context.model.name"
+    And the MLflow artifact should contain "arc_easy"
+  
+  @mlflow 
+  Scenario: Card generated for completed job with collection
+    Given the service is running
+    And there is a system collection with id "toxicity-and-ethical-principles"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_collection_test",
+        "description": "Job for card testing with collection",
+        "tags": ["evalcard", "collection"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "collection": {
+          "id": "toxicity-and-ethical-principles",
+          "benchmarks": [
+            {
+              "id": "toxigen",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            },
+            {
+              "id": "truthfulqa_mc1",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            },
+            {
+              "id": "bigbench_hhh_alignment_multiple_choice",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            }
+          ]
+        },
+        "pass_criteria": {
+          "threshold": 0.5
+        },
+        "experiment": {
+          "name": "evalcard_collection_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the "results.benchmarks[0].mlflow_run_id" field in the response should be saved as "value:run_id_0"
+
+  @mlflow 
+  Scenario: Card generated for job with multiple benchmarks
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_multibenchmark_test",
+        "description": "Job for card testing with multiple benchmarks",
+        "tags": ["evalcard", "multi"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          },
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 3,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "pass_criteria": {
+          "threshold": 0.5
+        },
+        "experiment": {
+          "name": "evalcard_multi_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the "results.benchmarks[0].mlflow_run_id" field in the response should be saved as "value:run_id_0"
+    And the "results.benchmarks[1].mlflow_run_id" field in the response should be saved as "value:run_id_1"
+
+  Scenario: Card generated for partially failed job
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_partial_fail_test",
+        "description": "Job that may have partial failures",
+        "tags": ["evalcard", "failure"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_fail_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+
+  Scenario: No card for pending job
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_pending_test",
+        "description": "Job to verify no card for pending",
+        "tags": ["evalcard", "pending"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_pending_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the response should contain the value "pending" at path "$.status.state"
+
+  @mlflow
+  Scenario: Multiple jobs in same experiment have different cards
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_shared_exp_job1",
+        "description": "First job in shared experiment",
+        "tags": ["evalcard", "shared"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_shared_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job1_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{{value:job1_id}}"
+    Then the response code should be 200
+    And the "results.benchmarks[0].mlflow_run_id" field in the response should be saved as "value:run_id_job1"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_shared_exp_job2",
+        "description": "Second job in shared experiment",
+        "tags": ["evalcard", "shared"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_shared_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job2_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{{value:job2_id}}"
+    Then the response code should be 200
+    And the "results.benchmarks[0].mlflow_run_id" field in the response should be saved as "value:run_id_job2"
+
+  @mlflow
+  Scenario: Card has correct card_version and schema_version
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_version_test",
+        "description": "Test card version fields",
+        "tags": ["evalcard", "version"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_version_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain the value "1.0" at path "$.card_version"
+    And the MLflow artifact should contain the value "1.0" at path "$.schema_version"
+
+  @mlflow
+  Scenario: Card metadata contains all required timestamps in ISO 8601 format
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_timestamps_test",
+        "description": "Test card metadata timestamps",
+        "tags": ["evalcard", "metadata"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_timestamps_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "metadata.created_at"
+    And the MLflow artifact should contain "metadata.updated_at"
+    And the MLflow artifact field "metadata.created_at" should match ISO 8601 format
+    And the MLflow artifact field "metadata.updated_at" should match ISO 8601 format
+
+  @mlflow
+  Scenario: Card structure has all top-level fields
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_structure_test",
+        "description": "Test card top-level structure",
+        "tags": ["evalcard", "structure"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_structure_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "card_version"
+    And the MLflow artifact should contain "schema_version"
+    And the MLflow artifact should contain "metadata"
+    And the MLflow artifact should contain "context"
+    And the MLflow artifact should contain "results"
+
+  @mlflow
+  Scenario: Card context.model contains url and name
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_model_fields_test",
+        "description": "Test card context model fields",
+        "tags": ["evalcard", "model"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_model_fields_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "context.model.url"
+    And the MLflow artifact should contain "context.model.name"
+
+  @mlflow
+  Scenario: Card context.benchmarks exists for benchmark job
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_benchmarks_array_test",
+        "description": "Test card context benchmarks array",
+        "tags": ["evalcard", "benchmarks"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_benchmarks_array_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "context.benchmarks"
+    And the MLflow artifact should contain "context.benchmarks[0].id"
+    And the MLflow artifact should contain "context.benchmarks[0].provider_id"
+
+  @mlflow
+  Scenario: Card results.benchmarks contains metrics
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_metrics_test",
+        "description": "Test card results benchmark metrics",
+        "tags": ["evalcard", "metrics"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_metrics_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "results.benchmarks"
+    And the MLflow artifact should contain "results.benchmarks[0].metrics"
+
+  @mlflow
+  Scenario: Card results.benchmarks contains mlflow_run_id
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_mlflow_runid_test",
+        "description": "Test card results contains mlflow_run_id",
+        "tags": ["evalcard", "mlflow"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_mlflow_runid_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "results.benchmarks[0].mlflow_run_id"
+
+  @mlflow
+  Scenario: Card results.status.state matches job status
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_status_state_test",
+        "description": "Test card results status state",
+        "tags": ["evalcard", "status"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_status_state_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain the value "completed" at path "$.results.status.state"
+
+  @mlflow
+  Scenario: Card context.collection_id exists for collection job
+    Given the service is running
+    And there is a system collection with id "toxicity-and-ethical-principles"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_collection_id_test",
+        "description": "Test card context has collection_id",
+        "tags": ["evalcard", "collection"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "collection": {
+          "id": "toxicity-and-ethical-principles",
+          "benchmarks": [
+            {
+              "id": "toxigen",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            },
+            {
+              "id": "truthfulqa_mc1",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            },
+            {
+              "id": "bigbench_hhh_alignment_multiple_choice",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            }
+          ]
+        },
+        "experiment": {
+          "name": "evalcard_collection_id_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "context.collection_id"
+    And the MLflow artifact should contain the value "toxicity-and-ethical-principles" at path "$.context.collection_id"
+
+  @mlflow
+  Scenario: Card context.benchmarks is omitted for collection job
+    Given the service is running
+    And there is a system collection with id "toxicity-and-ethical-principles"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_collection_no_benchmarks_test",
+        "description": "Test collection jobs don't expand benchmarks in context",
+        "tags": ["evalcard", "collection"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "collection": {
+          "id": "toxicity-and-ethical-principles",
+          "benchmarks": [
+            {
+              "id": "toxigen",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            },
+            {
+              "id": "truthfulqa_mc1",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            },
+            {
+              "id": "bigbench_hhh_alignment_multiple_choice",
+              "provider_id": "lm_evaluation_harness",
+              "parameters": {
+                "num_examples": 5
+              }
+            }
+          ]
+        },
+        "experiment": {
+          "name": "evalcard_collection_no_benchmarks_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "context.collection_id"
+
+  @mlflow
+  Scenario: Card context.benchmarks contains correct benchmark IDs
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_benchmark_ids_test",
+        "description": "Test card context benchmarks have correct IDs",
+        "tags": ["evalcard", "benchmarks"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_benchmark_ids_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain the value "arc_easy" at path "$.context.benchmarks[0].id"
+    And the MLflow artifact should contain the value "lm_evaluation_harness" at path "$.context.benchmarks[0].provider_id"
+
+  @mlflow
+  Scenario: Card results.benchmarks array has expected structure
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_results_array_test",
+        "description": "Test card results.benchmarks array structure",
+        "tags": ["evalcard", "results"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_results_array_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "results.benchmarks[0].id"
+    And the MLflow artifact should contain "results.benchmarks[0].provider_id"
+    And the MLflow artifact should contain "results.benchmarks[0].status"
+    And the MLflow artifact should contain "results.benchmarks[0].metrics"
+
+  @mlflow
+  Scenario: Card results.benchmarks.status matches benchmark state for completed job
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_benchmark_status_test",
+        "description": "Test card benchmark status matches state",
+        "tags": ["evalcard", "status"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_benchmark_status_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain the value "completed" at path "$.results.benchmarks[0].status"
+
+  @mlflow
+  Scenario: Card error_message structure is valid for failed benchmark
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_error_structure_test",
+        "description": "Test error_message structure in EvalCard for failed job",
+        "tags": ["evalcard", "error"],
+        "model": {
+          "url": "http://invalid-model.test/v1",
+          "name": "invalid-model"
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 2,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_error_test"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "failed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:experiment_id"
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "results.benchmarks[0].error_message"
+    And the MLflow artifact should contain "results.benchmarks[0].error_message.message"
+    And the MLflow artifact should contain "results.benchmarks[0].error_message.message_code"
+    And the MLflow artifact should contain "results.benchmarks[0].error_message.message_origin"
+  
+  @mlflow
+  Scenario: EvalCard artifact is valid parseable JSON for failed job
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_json_validation_test",
+        "description": "Test that EvalCard artifact is valid JSON even for failed jobs",
+        "tags": ["evalcard", "validation"],
+        "model": {
+          "url": "http://invalid.test/v1",
+          "name": "invalid-model"
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 2,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_json_test"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to match "completed|failed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:experiment_id"
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should be valid JSON
+ 
+  @mlflow
+  Scenario: Card generated for job with no pass_criteria
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_no_pass_criteria_test",
+        "description": "Test EvalCard generation for job without pass_criteria",
+        "tags": ["evalcard", "edge-case"],
+        "model": {
+          "url": "http://test.model/v1",
+          "name": "test-model"
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 2,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_no_criteria_test"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to match "completed|failed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:experiment_id"
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "card_version"
+    And the MLflow artifact should contain "results.benchmarks"
+    And the MLflow artifact should contain the value "{{value:job_id}}" at path "$.metadata.evaluation_job_id"

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1437,10 +1437,15 @@ Feature: Evaluation Jobs
       }
       """
     Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
     And I wait for the evaluation job status to be "completed"
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
     Then the response code should be 200
-    And the "results.benchmarks[0].mlflow_run_id" field in the response should be saved as "value:run_id_0"
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "context.collection_id"
+    And the MLflow artifact should contain the value "toxicity-and-ethical-principles" at path "$.context.collection_id"
 
   @mlflow 
   Scenario: Card generated for job with multiple benchmarks
@@ -1485,20 +1490,25 @@ Feature: Evaluation Jobs
       }
       """
     Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
     And I wait for the evaluation job status to be "completed"
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
     Then the response code should be 200
-    And the "results.benchmarks[0].mlflow_run_id" field in the response should be saved as "value:run_id_0"
-    And the "results.benchmarks[1].mlflow_run_id" field in the response should be saved as "value:run_id_1"
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "results.benchmarks[0]"
+    And the MLflow artifact should contain "results.benchmarks[1]"
 
-  Scenario: Card generated for partially failed job
+  @mlflow 
+  Scenario: Card generated for completed benchmark job
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
       """
       {
-        "name": "evalcard_partial_fail_test",
-        "description": "Job that may have partial failures",
-        "tags": ["evalcard", "failure"],
+        "name": "evalcard_completed_benchmark_test",
+        "description": "Job for card testing on completed benchmark",
+        "tags": ["evalcard", "benchmark"],
         "model": {
           "url": "{{env:MODEL_URL|http://test.com}}",
           "name": "{{env:MODEL_NAME|test}}",
@@ -1517,15 +1527,20 @@ Feature: Evaluation Jobs
           }
         ],
         "experiment": {
-          "name": "evalcard_fail_experiment"
+          "name": "evalcard_completed_experiment"
         }
       }
       """
     Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
     And I wait for the evaluation job status to be "completed"
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
     Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
 
+  @mlflow 
   Scenario: No card for pending job
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
@@ -1558,8 +1573,9 @@ Feature: Evaluation Jobs
       """
     Then the response code should be 202
     And the response should contain the value "pending" at path "$.status.state"
+    # EvalCards are only exported on completion, so pending jobs have no card
 
-  @mlflow
+  @mlflow 
   Scenario: Multiple jobs in same experiment have different cards
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
@@ -1592,6 +1608,7 @@ Feature: Evaluation Jobs
       """
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job1_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
     And I wait for the evaluation job status to be "completed"
     When I send a GET request to "/api/v1/evaluations/jobs/{{value:job1_id}}"
     Then the response code should be 200
@@ -1629,7 +1646,13 @@ Feature: Evaluation Jobs
     And I wait for the evaluation job status to be "completed"
     When I send a GET request to "/api/v1/evaluations/jobs/{{value:job2_id}}"
     Then the response code should be 200
-    And the "results.benchmarks[0].mlflow_run_id" field in the response should be saved as "value:run_id_job2"
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job1_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain the value "{{value:job1_id}}" at path "$.metadata.evaluation_job_id"
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job2_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain the value "{{value:job2_id}}" at path "$.metadata.evaluation_job_id"
+    # Each job gets its own distinct EvalCard even in the same experiment
 
   @mlflow
   Scenario: Card has correct card_version and schema_version
@@ -2031,64 +2054,6 @@ Feature: Evaluation Jobs
     And the MLflow artifact should contain the value "toxicity-and-ethical-principles" at path "$.context.collection_id"
 
   @mlflow
-  Scenario: Card context.benchmarks is omitted for collection job
-    Given the service is running
-    And there is a system collection with id "toxicity-and-ethical-principles"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_collection_no_benchmarks_test",
-        "description": "Test collection jobs don't expand benchmarks in context",
-        "tags": ["evalcard", "collection"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "collection": {
-          "id": "toxicity-and-ethical-principles",
-          "benchmarks": [
-            {
-              "id": "toxigen",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            },
-            {
-              "id": "truthfulqa_mc1",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            },
-            {
-              "id": "bigbench_hhh_alignment_multiple_choice",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            }
-          ]
-        },
-        "experiment": {
-          "name": "evalcard_collection_no_benchmarks_experiment"
-        }
-      }
-      """
-    Then the response code should be 202
-    And the "resource.id" field in the response should be saved as "value:job_id"
-    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
-    And I wait for the evaluation job status to be "completed"
-    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
-    Then the response code should be 200
-    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
-    Then the MLflow artifact should exist
-    And the MLflow artifact should contain "context.collection_id"
-
-  @mlflow
   Scenario: Card context.benchmarks contains correct benchmark IDs
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
@@ -2215,7 +2180,7 @@ Feature: Evaluation Jobs
     Then the MLflow artifact should exist
     And the MLflow artifact should contain the value "completed" at path "$.results.benchmarks[0].status"
 
-  @mlflow
+  @mlflow 
   Scenario: Card error_message structure is valid for failed benchmark
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
@@ -2246,7 +2211,7 @@ Feature: Evaluation Jobs
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
-    And I wait for the evaluation job status to be "failed"
+    And I wait for the evaluation job status to match "completed|failed"
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
     Then the response code should be 200
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:experiment_id"
@@ -2257,7 +2222,7 @@ Feature: Evaluation Jobs
     And the MLflow artifact should contain "results.benchmarks[0].error_message.message_code"
     And the MLflow artifact should contain "results.benchmarks[0].error_message.message_origin"
   
-  @mlflow
+  @mlflow 
   Scenario: EvalCard artifact is valid parseable JSON for failed job
     Given the service is running
     When I send a POST request to "/api/v1/evaluations/jobs" with body:
@@ -2306,8 +2271,11 @@ Feature: Evaluation Jobs
         "description": "Test EvalCard generation for job without pass_criteria",
         "tags": ["evalcard", "edge-case"],
         "model": {
-          "url": "http://test.model/v1",
-          "name": "test-model"
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
         },
         "benchmarks": [
           {

--- a/tests/features/mcp.feature
+++ b/tests/features/mcp.feature
@@ -835,7 +835,7 @@ Feature: MCP Tools
     Then the MCP tool call should fail
     And the MCP error should contain "resource_not_found"
 
-  @mlflow @cluster
+  @mlflow @cluster 
   Scenario: MCP can retrieve completed job that has evalcard exported
     Given the service is running
     And the model endpoint is reachable
@@ -869,6 +869,7 @@ Feature: MCP Tools
       """
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:mcp_job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
     And I wait for the evaluation job status to be "completed"
     When I call MCP tool "get_job_status" with arguments:
       """
@@ -878,6 +879,8 @@ Feature: MCP Tools
       """
     Then the MCP tool call should succeed
     And the MCP response should contain the value "completed" at path "$.state"
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:mcp_job_id}}"
+    Then the MLflow artifact should exist
  
   @mlflow @cluster
   Scenario: MCP resource returns job with mlflow_run_id for completed job with evalcard
@@ -916,4 +919,5 @@ Feature: MCP Tools
     And I wait for the evaluation job status to be "completed"
     When I read MCP resource "evalhub://jobs/{{value:mcp_resource_job_id}}"
     Then the MCP resource read should succeed
+    And the MCP resource should contain "benchmarks"
     And the MCP resource should contain "mlflow_run_id"

--- a/tests/features/mcp.feature
+++ b/tests/features/mcp.feature
@@ -834,3 +834,86 @@ Feature: MCP Tools
       """
     Then the MCP tool call should fail
     And the MCP error should contain "resource_not_found"
+
+  @mlflow @cluster
+  Scenario: MCP can retrieve completed job that has evalcard exported
+    Given the service is running
+    And the model endpoint is reachable
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_mcp_test",
+        "description": "Job for MCP card testing",
+        "tags": ["evalcard", "mcp"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_mcp_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:mcp_job_id"
+    And I wait for the evaluation job status to be "completed"
+    When I call MCP tool "get_job_status" with arguments:
+      """
+      {
+        "job_id": "{{value:mcp_job_id}}"
+      }
+      """
+    Then the MCP tool call should succeed
+    And the MCP response should contain the value "completed" at path "$.state"
+ 
+  @mlflow @cluster
+  Scenario: MCP resource returns job with mlflow_run_id for completed job with evalcard
+    Given the service is running
+    And the model endpoint is reachable
+    When I send a POST request to "/api/v1/evaluations/jobs" with body:
+      """
+      {
+        "name": "evalcard_mcp_resource_test",
+        "description": "Test MCP resource includes mlflow_run_id",
+        "tags": ["evalcard", "mcp", "resource"],
+        "model": {
+          "url": "{{env:MODEL_URL|http://test.com}}",
+          "name": "{{env:MODEL_NAME|test}}",
+          "auth": {
+            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
+          }
+        },
+        "benchmarks": [
+          {
+            "id": "arc_easy",
+            "provider_id": "lm_evaluation_harness",
+            "parameters": {
+              "num_examples": 5,
+              "tokenizer": "google/flan-t5-small"
+            }
+          }
+        ],
+        "experiment": {
+          "name": "evalcard_mcp_resource_experiment"
+        }
+      }
+      """
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:mcp_resource_job_id"
+    And I wait for the evaluation job status to be "completed"
+    When I read MCP resource "evalhub://jobs/{{value:mcp_resource_job_id}}"
+    Then the MCP resource read should succeed
+    And the MCP resource should contain "mlflow_run_id"

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -2047,7 +2047,7 @@ func (tc *scenarioConfig) fetchMLflowArtifactWithExperimentID(artifactPath, expe
 		tc.mlflowArtifactError = err
 		return tc.logError(fmt.Errorf("failed to fetch MLflow artifact: %w", err))
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -2193,7 +2193,7 @@ func (tc *scenarioConfig) iFetchMLflowArtifactByExperimentAndJob(artifactName, e
 	if err != nil {
 		return tc.logError(fmt.Errorf("failed to search MLflow runs: %w", err))
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -195,6 +195,28 @@ func getMLflowHTTPClient() *http.Client {
 	}
 }
 
+// mlflowBaseURL returns the MLflow base URL from MLFLOW_URL env or default cluster internal URL
+func mlflowBaseURL() string {
+	baseURL := os.Getenv("MLFLOW_URL")
+	if baseURL == "" {
+		baseURL = "https://mlflow.redhat-ods-applications.svc.cluster.local:8443"
+	}
+	return strings.TrimRight(baseURL, "/")
+}
+
+// mlflowWorkspace resolves the MLflow workspace using X_TENANT env → X-Tenant header → "tenant" fallback
+func (tc *scenarioConfig) mlflowWorkspace() string {
+	workspace := os.Getenv("X_TENANT")
+	if workspace == "" {
+		if tenant, ok := tc.reqHeaders["X-Tenant"]; ok && tenant != "" {
+			workspace = tenant
+		} else {
+			workspace = "tenant" // fallback
+		}
+	}
+	return workspace
+}
+
 func isMetricsScrapePath(path string) bool {
 	path = strings.TrimSpace(path)
 	if path == "/metrics" {
@@ -1995,24 +2017,11 @@ func (tc *scenarioConfig) iFetchMLflowArtifact(artifactPath, runIDPattern string
 }
 
 func (tc *scenarioConfig) fetchMLflowArtifactWithExperimentID(artifactPath, experimentID, runID string) error {
-	// Get MLflow base URL from environment or use default cluster internal URL
-	mlflowBaseURL := os.Getenv("MLFLOW_URL")
-	if mlflowBaseURL == "" {
-		mlflowBaseURL = "https://mlflow.redhat-ods-applications.svc.cluster.local:8443"
-	}
-
-	// Get MLflow workspace (tenant namespace)
-	workspace := os.Getenv("X_TENANT")
-	if workspace == "" {
-		if tenant, ok := tc.reqHeaders["X-Tenant"]; ok && tenant != "" {
-			workspace = tenant
-		} else {
-			workspace = "tenant" // fallback
-		}
-	}
+	baseURL := mlflowBaseURL()
+	workspace := tc.mlflowWorkspace()
 
 	artifactURL := fmt.Sprintf("%s/mlflow/api/2.0/mlflow-artifacts/artifacts/%s/%s/artifacts/%s",
-		strings.TrimRight(mlflowBaseURL, "/"), experimentID, runID, artifactPath)
+		baseURL, experimentID, runID, artifactPath)
 
 	tc.logDebug("Fetching MLflow artifact from: %s\n", artifactURL)
 	tc.logDebug("Using workspace: %s\n", workspace)
@@ -2151,13 +2160,10 @@ func (tc *scenarioConfig) iFetchMLflowArtifactByExperimentAndJob(artifactName, e
 	}
 
 	// Search for the MLflow run with the matching evaluation_job_id tag
-	// First, get all runs for the experiment
-	mlflowBaseURL := os.Getenv("MLFLOW_URL")
-	if mlflowBaseURL == "" {
-		mlflowBaseURL = "https://mlflow.redhat-ods-applications.svc.cluster.local:8443"
-	}
+	baseURL := mlflowBaseURL()
+	workspace := tc.mlflowWorkspace()
 
-	searchURL := fmt.Sprintf("%s/mlflow/api/2.0/mlflow/runs/search", strings.TrimRight(mlflowBaseURL, "/"))
+	searchURL := fmt.Sprintf("%s/mlflow/api/2.0/mlflow/runs/search", baseURL)
 	searchBody := map[string]interface{}{
 		"experiment_ids": []string{experimentIDResolved},
 		"filter":         fmt.Sprintf("tags.evaluation_job_id = '%s'", jobIDResolved),
@@ -2174,7 +2180,7 @@ func (tc *scenarioConfig) iFetchMLflowArtifactByExperimentAndJob(artifactName, e
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-MLFLOW-WORKSPACE", tc.reqHeaders["X-Tenant"])
+	req.Header.Set("X-MLFLOW-WORKSPACE", workspace)
 
 	// Add Authorization header (required for external MLflow access)
 	authToken := os.Getenv("AUTH_TOKEN")
@@ -2278,6 +2284,12 @@ func (tc *scenarioConfig) theMLflowArtifactFieldShouldMatchISO8601(fieldPath str
 }
 
 func (tc *scenarioConfig) iWaitForEvaluationJobStatusToMatch(statusPattern string) error {
+	// Compile regex once before polling loop for fail-fast validation and performance
+	re, err := regexp.Compile(statusPattern)
+	if err != nil {
+		return tc.logError(fmt.Errorf("invalid status pattern %q: %w", statusPattern, err))
+	}
+
 	deadline := time.Now().Add(tc.waitDeadline)
 	var lastErr error
 	var lastStatus string
@@ -2302,12 +2314,7 @@ func (tc *scenarioConfig) iWaitForEvaluationJobStatusToMatch(statusPattern strin
 			}
 
 			// Check if state matches the pattern (supports regex like "completed|failed")
-			matched, err := regexp.MatchString(statusPattern, status)
-			if err != nil {
-				return tc.logError(fmt.Errorf("invalid status pattern %q: %w", statusPattern, err))
-			}
-
-			if matched {
+			if re.MatchString(status) {
 				tc.logDebug("Job reached status matching %q: %s\n", statusPattern, status)
 				return nil
 			}

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -1,6 +1,7 @@
 package features
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -126,6 +127,10 @@ type scenarioConfig struct {
 
 	waitDeadline time.Duration
 	waitInterval time.Duration
+
+	// MLflow artifact fetching
+	mlflowArtifactBody  []byte
+	mlflowArtifactError error
 }
 
 func getLogger() *log.Logger {
@@ -166,6 +171,27 @@ func checkBaseURL(uri *url.URL, from string) {
 	}
 	if uri.String() == "" {
 		panic("Empty baseURL from  " + from)
+	}
+}
+
+// getMLflowTLSConfig returns TLS config for MLflow clients, respecting MLFLOW_INSECURE env var
+func getMLflowTLSConfig() *tls.Config {
+	insecure := true // default to true for backward compatibility with cluster internal certs
+	if insecureStr := os.Getenv("MLFLOW_INSECURE"); insecureStr != "" {
+		if parsed, err := strconv.ParseBool(insecureStr); err == nil {
+			insecure = parsed
+		}
+	}
+	return &tls.Config{InsecureSkipVerify: insecure} //nolint:gosec
+}
+
+// getMLflowHTTPClient returns an HTTP client configured for MLflow API calls
+func getMLflowHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 60 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: getMLflowTLSConfig(),
+		},
 	}
 }
 
@@ -1920,9 +1946,380 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	// MCP-specific steps
 	InitializeMCPSteps(ctx, tc)
 
+	// MLflow artifact steps
+	ctx.Step(`^I fetch the MLflow artifact "([^"]*)" for run "([^"]*)"$`, tc.iFetchMLflowArtifact)
+	ctx.Step(`^I fetch the MLflow artifact "([^"]*)" for experiment "([^"]*)" and job "([^"]*)"$`, tc.iFetchMLflowArtifactByExperimentAndJob)
+	ctx.Step(`^the MLflow artifact should exist$`, tc.theMLflowArtifactShouldExist)
+	ctx.Step(`^the MLflow artifact should contain "([^"]*)"$`, tc.theMLflowArtifactShouldContain)
+	ctx.Step(`^the MLflow artifact should contain the value "([^"]*)" at path "([^"]*)"$`, tc.theMLflowArtifactShouldContainValueAtPath)
+	ctx.Step(`^the MLflow artifact should be valid JSON$`, tc.theMLflowArtifactShouldBeValidJSON)
+	ctx.Step(`^the MLflow artifact field "([^"]*)" should match ISO 8601 format$`, tc.theMLflowArtifactFieldShouldMatchISO8601)
+	ctx.Step(`^I wait for the evaluation job status to match "([^"]*)"$`, tc.iWaitForEvaluationJobStatusToMatch)
+
 	// GPU-specific steps
 	InitializeGPUSteps(ctx, tc)
 
 	// Hardware profile steps (Kubernetes client-go via KUBECONFIG-first FVT helper)
 	InitializeHardwareProfileSteps(ctx, tc)
+}
+
+// --- MLflow Artifact Step Definitions ---
+
+func (tc *scenarioConfig) iFetchMLflowArtifact(artifactPath, runIDPattern string) error {
+	// Resolve run ID from saved values or use literal
+	runID, err := tc.getValue(runIDPattern)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to get run ID from pattern %q: %w", runIDPattern, err))
+	}
+	if runID == "" {
+		return tc.logError(fmt.Errorf("run ID pattern %q resolved to empty string", runIDPattern))
+	}
+
+	// Extract experiment ID from the current response body
+	var experimentID string
+	var respData map[string]interface{}
+	if err := json.Unmarshal(tc.body, &respData); err == nil {
+		if resource, ok := respData["resource"].(map[string]interface{}); ok {
+			if expIDFloat, ok := resource["mlflow_experiment_id"].(float64); ok {
+				experimentID = fmt.Sprintf("%.0f", expIDFloat)
+			} else if expIDStr, ok := resource["mlflow_experiment_id"].(string); ok {
+				experimentID = expIDStr
+			}
+		}
+	}
+	if experimentID == "" {
+		return tc.logError(fmt.Errorf("failed to extract mlflow_experiment_id from response"))
+	}
+
+	return tc.fetchMLflowArtifactWithExperimentID(artifactPath, experimentID, runID)
+}
+
+func (tc *scenarioConfig) fetchMLflowArtifactWithExperimentID(artifactPath, experimentID, runID string) error {
+	// Get MLflow base URL from environment or use default cluster internal URL
+	mlflowBaseURL := os.Getenv("MLFLOW_URL")
+	if mlflowBaseURL == "" {
+		mlflowBaseURL = "https://mlflow.redhat-ods-applications.svc.cluster.local:8443"
+	}
+
+	// Get MLflow workspace (tenant namespace)
+	workspace := os.Getenv("X_TENANT")
+	if workspace == "" {
+		if tenant, ok := tc.reqHeaders["X-Tenant"]; ok && tenant != "" {
+			workspace = tenant
+		} else {
+			workspace = "tenant" // fallback
+		}
+	}
+
+	artifactURL := fmt.Sprintf("%s/mlflow/api/2.0/mlflow-artifacts/artifacts/%s/%s/artifacts/%s",
+		strings.TrimRight(mlflowBaseURL, "/"), experimentID, runID, artifactPath)
+
+	tc.logDebug("Fetching MLflow artifact from: %s\n", artifactURL)
+	tc.logDebug("Using workspace: %s\n", workspace)
+
+	client := getMLflowHTTPClient()
+
+	req, err := http.NewRequest("GET", artifactURL, nil)
+	if err != nil {
+		tc.mlflowArtifactError = err
+		return tc.logError(fmt.Errorf("failed to create MLflow artifact request: %w", err))
+	}
+
+	// Add authorization if token is available
+	if authToken := os.Getenv("AUTH_TOKEN"); authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	// Required for tenant-scoped MLflow access
+	req.Header.Set("X-MLFLOW-WORKSPACE", workspace)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		tc.mlflowArtifactError = err
+		return tc.logError(fmt.Errorf("failed to fetch MLflow artifact: %w", err))
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		tc.mlflowArtifactError = err
+		return tc.logError(fmt.Errorf("failed to read MLflow artifact response: %w", err))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		tc.mlflowArtifactError = fmt.Errorf("MLflow artifact fetch returned status %d: %s", resp.StatusCode, string(body))
+		return tc.logError(tc.mlflowArtifactError)
+	}
+
+	tc.mlflowArtifactBody = body
+	tc.mlflowArtifactError = nil
+	tc.logDebug("MLflow artifact fetched successfully (%d bytes)\n", len(body))
+	return nil
+}
+
+func (tc *scenarioConfig) theMLflowArtifactShouldExist() error {
+	if tc.mlflowArtifactError != nil {
+		return tc.logError(fmt.Errorf("MLflow artifact fetch failed: %w", tc.mlflowArtifactError))
+	}
+	if len(tc.mlflowArtifactBody) == 0 {
+		return tc.logError(fmt.Errorf("MLflow artifact is empty"))
+	}
+	return nil
+}
+
+func (tc *scenarioConfig) theMLflowArtifactShouldContain(pathOrString string) error {
+	if tc.mlflowArtifactError != nil {
+		return tc.logError(fmt.Errorf("MLflow artifact fetch failed: %w", tc.mlflowArtifactError))
+	}
+
+	// If it looks like a JSONPath (contains . or [), validate as path
+	if strings.Contains(pathOrString, ".") || strings.Contains(pathOrString, "[") {
+		var jsonData interface{}
+		if err := json.Unmarshal(tc.mlflowArtifactBody, &jsonData); err != nil {
+			return tc.logError(fmt.Errorf("failed to parse MLflow artifact as JSON: %w", err))
+		}
+
+		jsonPath := "$." + pathOrString
+		_, err := jsonpath.Get(jsonPath, jsonData)
+		if err != nil {
+			return tc.logError(fmt.Errorf("MLflow artifact does not contain path %q: %w. Body: %s", pathOrString, err, string(tc.mlflowArtifactBody)))
+		}
+		return nil
+	}
+
+	// Otherwise do literal string search
+	if !strings.Contains(string(tc.mlflowArtifactBody), pathOrString) {
+		return tc.logError(fmt.Errorf("MLflow artifact does not contain %q. Body: %s", pathOrString, string(tc.mlflowArtifactBody)))
+	}
+	return nil
+}
+
+func (tc *scenarioConfig) theMLflowArtifactShouldContainValueAtPath(expected, jsonPath string) error {
+	if tc.mlflowArtifactError != nil {
+		return tc.logError(fmt.Errorf("MLflow artifact fetch failed: %w", tc.mlflowArtifactError))
+	}
+
+	// Parse artifact as JSON
+	var artifactData interface{}
+	if err := json.Unmarshal(tc.mlflowArtifactBody, &artifactData); err != nil {
+		return tc.logError(fmt.Errorf("failed to parse MLflow artifact as JSON: %w", err))
+	}
+
+	// Evaluate JSONPath
+	result, err := jsonpath.Get(jsonPath, artifactData)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to evaluate JSONPath %q on MLflow artifact: %w", jsonPath, err))
+	}
+
+	// Convert result to string for comparison
+	var resultStr string
+	switch v := result.(type) {
+	case string:
+		resultStr = v
+	case float64:
+		resultStr = fmt.Sprintf("%g", v)
+	case bool:
+		resultStr = fmt.Sprintf("%t", v)
+	default:
+		resultBytes, _ := json.Marshal(v)
+		resultStr = string(resultBytes)
+	}
+
+	// Resolve expected value from saved values
+	expectedResolved, err := tc.getValue(expected)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to resolve expected value %q: %w", expected, err))
+	}
+
+	if resultStr != expectedResolved {
+		return tc.logError(fmt.Errorf("MLflow artifact path %q = %q, expected %q", jsonPath, resultStr, expectedResolved))
+	}
+
+	return nil
+}
+
+func (tc *scenarioConfig) iFetchMLflowArtifactByExperimentAndJob(artifactName, experimentID, jobID string) error {
+	// Resolve experiment ID and job ID from saved values
+	experimentIDResolved, err := tc.getValue(experimentID)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to resolve experiment ID %q: %w", experimentID, err))
+	}
+
+	jobIDResolved, err := tc.getValue(jobID)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to resolve job ID %q: %w", jobID, err))
+	}
+
+	// Search for the MLflow run with the matching evaluation_job_id tag
+	// First, get all runs for the experiment
+	mlflowBaseURL := os.Getenv("MLFLOW_URL")
+	if mlflowBaseURL == "" {
+		mlflowBaseURL = "https://mlflow.redhat-ods-applications.svc.cluster.local:8443"
+	}
+
+	searchURL := fmt.Sprintf("%s/mlflow/api/2.0/mlflow/runs/search", strings.TrimRight(mlflowBaseURL, "/"))
+	searchBody := map[string]interface{}{
+		"experiment_ids": []string{experimentIDResolved},
+		"filter":         fmt.Sprintf("tags.evaluation_job_id = '%s'", jobIDResolved),
+	}
+
+	searchJSON, err := json.Marshal(searchBody)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to marshal search request: %w", err))
+	}
+
+	req, err := http.NewRequest("POST", searchURL, bytes.NewBuffer(searchJSON))
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to create search request: %w", err))
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-MLFLOW-WORKSPACE", tc.reqHeaders["X-Tenant"])
+
+	// Add Authorization header (required for external MLflow access)
+	authToken := os.Getenv("AUTH_TOKEN")
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	client := getMLflowHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to search MLflow runs: %w", err))
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to read MLflow search response body: %w", err))
+	}
+	if resp.StatusCode != 200 {
+		return tc.logError(fmt.Errorf("MLflow run search failed with status %d: %s", resp.StatusCode, string(body)))
+	}
+
+	var searchResult map[string]interface{}
+	if err := json.Unmarshal(body, &searchResult); err != nil {
+		return tc.logError(fmt.Errorf("failed to parse search response: %w", err))
+	}
+
+	runs, ok := searchResult["runs"].([]interface{})
+	if !ok || len(runs) == 0 {
+		return tc.logError(fmt.Errorf("no MLflow run found for job %s in experiment %s", jobIDResolved, experimentIDResolved))
+	}
+
+	// Get the run_id from the first match
+	firstRun, ok := runs[0].(map[string]interface{})
+	if !ok {
+		return tc.logError(fmt.Errorf("unexpected MLflow run format: %T", runs[0]))
+	}
+	runInfo, ok := firstRun["info"].(map[string]interface{})
+	if !ok {
+		return tc.logError(fmt.Errorf("MLflow run missing 'info' field or wrong type"))
+	}
+	runID, ok := runInfo["run_id"].(string)
+	if !ok {
+		return tc.logError(fmt.Errorf("MLflow run_id is not a string: %T", runInfo["run_id"]))
+	}
+
+	// Now fetch the artifact using the experiment ID and run_id we already have
+	return tc.fetchMLflowArtifactWithExperimentID(artifactName, experimentIDResolved, runID)
+}
+
+func (tc *scenarioConfig) theMLflowArtifactShouldBeValidJSON() error {
+	if tc.mlflowArtifactError != nil {
+		return tc.logError(fmt.Errorf("MLflow artifact fetch failed: %w", tc.mlflowArtifactError))
+	}
+
+	var jsonData interface{}
+	if err := json.Unmarshal(tc.mlflowArtifactBody, &jsonData); err != nil {
+		return tc.logError(fmt.Errorf("MLflow artifact is not valid JSON: %w. Body: %s", err, string(tc.mlflowArtifactBody)))
+	}
+
+	tc.logDebug("MLflow artifact is valid JSON\n")
+	return nil
+}
+
+func (tc *scenarioConfig) theMLflowArtifactFieldShouldMatchISO8601(fieldPath string) error {
+	if tc.mlflowArtifactError != nil {
+		return tc.logError(fmt.Errorf("MLflow artifact fetch failed: %w", tc.mlflowArtifactError))
+	}
+
+	// Parse artifact as JSON
+	var jsonData interface{}
+	if err := json.Unmarshal(tc.mlflowArtifactBody, &jsonData); err != nil {
+		return tc.logError(fmt.Errorf("failed to parse MLflow artifact as JSON: %w", err))
+	}
+
+	// Extract value using JSONPath
+	jsonPath := "$." + fieldPath
+	results, err := jsonpath.Get(jsonPath, jsonData)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to evaluate JSONPath %q on MLflow artifact: %w", jsonPath, err))
+	}
+
+	resultStr, ok := results.(string)
+	if !ok {
+		return tc.logError(fmt.Errorf("MLflow artifact field %q is not a string: %T", fieldPath, results))
+	}
+
+	// ISO 8601 regex pattern (supports formats like: 2026-07-23T14:30:55.691568184Z, 2026-07-23T14:30:55Z, 2026-07-23T14:30:55+00:00)
+	iso8601Pattern := `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$`
+	matched, err := regexp.MatchString(iso8601Pattern, resultStr)
+	if err != nil {
+		return tc.logError(fmt.Errorf("failed to match ISO 8601 pattern: %w", err))
+	}
+
+	if !matched {
+		return tc.logError(fmt.Errorf("MLflow artifact field %q value %q does not match ISO 8601 format", fieldPath, resultStr))
+	}
+
+	tc.logDebug("MLflow artifact field %q is valid ISO 8601: %s\n", fieldPath, resultStr)
+	return nil
+}
+
+func (tc *scenarioConfig) iWaitForEvaluationJobStatusToMatch(statusPattern string) error {
+	deadline := time.Now().Add(tc.waitDeadline)
+	var lastErr error
+	var lastStatus string
+
+	for time.Now().Before(deadline) {
+		// Get current status using {id} pattern which auto-substitutes
+		if err := tc.iSendARequestImpl(http.MethodGet, "/api/v1/evaluations/jobs/{id}", "", "wait for evaluation job status to match pattern"); err != nil {
+			lastErr = err
+			time.Sleep(tc.waitInterval)
+			continue
+		}
+
+		if tc.response != nil && tc.response.StatusCode == http.StatusOK {
+			status, err := tc.getJsonPath("$.status.state")
+			if status != "" {
+				lastStatus = status
+			}
+			if err != nil {
+				lastErr = err
+				time.Sleep(tc.waitInterval)
+				continue
+			}
+
+			// Check if state matches the pattern (supports regex like "completed|failed")
+			matched, err := regexp.MatchString(statusPattern, status)
+			if err != nil {
+				return tc.logError(fmt.Errorf("invalid status pattern %q: %w", statusPattern, err))
+			}
+
+			if matched {
+				tc.logDebug("Job reached status matching %q: %s\n", statusPattern, status)
+				return nil
+			}
+
+			tc.logDebug("Waiting for job status to match %q, current: %s\n", statusPattern, status)
+		}
+
+		time.Sleep(tc.waitInterval)
+	}
+
+	if lastErr != nil {
+		return tc.logError(fmt.Errorf("timeout waiting for job status to match %q, last error: %w, last status: %s", statusPattern, lastErr, lastStatus))
+	}
+	return tc.logError(fmt.Errorf("timeout waiting for job status to match %q, last status: %s", statusPattern, lastStatus))
 }


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

 Add 24 BDD test scenarios covering EvalCard generation, validation and MLflow artifact fetching:
  - 22 scenarios in evaluation_jobs.feature (P0-P2 coverage)
  - 2 MCP integration scenarios in mcp.feature
  - 11 new step definitions for MLflow artifact validation
  - Helper functions for HTTP client management

  Tests cover card structure, metadata, context fields, benchmark results, collection handling, error cases, and MCP integration.
 

Closes #

Assisted-by: <!-- Cursor, Claude etc -->: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end scenarios validating generation and contents of the `evaluation-card.json` artifact for completed benchmark/collection jobs, including multi-benchmark results and distinct cards per job.
  * Verified required schema/versioning, ISO-8601 metadata timestamps, correct context fields, and status/error alignment (while ensuring valid JSON even on failures).
  * Confirmed no card export for pending jobs and that cards are still created when `pass_criteria` is absent.
  * Expanded MCP coverage to validate completion, artifact availability, and resource responses (including `mlflow_run_id`), and enhanced step definitions for artifact fetching and JSON/ISO assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->