### PR TITLE
test(ociclient): reset mock connections to avoid port exhaustion

### DIFF
--- a/pkg/ociclient/auth_test.go
+++ b/pkg/ociclient/auth_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -58,7 +57,7 @@ func TestAuthenticatorRefreshToken(t *testing.T) {
 	t.Parallel()
 
 	const tokenPath = "/token"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.Header().Set("WWW-Authenticate", `Bearer realm="http://`+r.Host+tokenPath+`",service="test"`)
@@ -73,9 +72,7 @@ func TestAuthenticatorRefreshToken(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	auth := newAuthenticator(srv.URL, "org/repo", Credentials{Username: "user", Password: "pass"}, srv.Client())
+	auth := newAuthenticator(srv.URL, "org/repo", Credentials{Username: "user", Password: "pass"}, httpClient)
 	if err := auth.refreshToken(context.Background()); err != nil {
 		t.Fatalf("refreshToken() err = %v", err)
 	}
@@ -88,7 +85,7 @@ func TestAuthenticatorRefreshTokenAccessTokenField(t *testing.T) {
 	t.Parallel()
 
 	const tokenPath = "/token"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.Header().Set("WWW-Authenticate", `Bearer realm="http://`+r.Host+tokenPath+`",service="test"`)
@@ -99,9 +96,7 @@ func TestAuthenticatorRefreshTokenAccessTokenField(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	auth := newAuthenticator(srv.URL, "org/repo", Credentials{Username: "user", Password: "pass"}, srv.Client())
+	auth := newAuthenticator(srv.URL, "org/repo", Credentials{Username: "user", Password: "pass"}, httpClient)
 	if err := auth.refreshToken(context.Background()); err != nil {
 		t.Fatalf("refreshToken() err = %v", err)
 	}
@@ -113,16 +108,14 @@ func TestAuthenticatorRefreshTokenAccessTokenField(t *testing.T) {
 func TestAuthenticatorRefreshTokenNoAuthRequired(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/v2" {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 		http.NotFound(w, r)
 	}))
-	t.Cleanup(srv.Close)
-
-	auth := newAuthenticator(srv.URL, "org/repo", Credentials{}, srv.Client())
+	auth := newAuthenticator(srv.URL, "org/repo", Credentials{}, httpClient)
 	auth.token = "stale"
 	if err := auth.refreshToken(context.Background()); err != nil {
 		t.Fatalf("refreshToken() err = %v", err)
@@ -136,7 +129,7 @@ func TestAuthenticatorCreateNewTokenErrors(t *testing.T) {
 	t.Parallel()
 
 	const tokenPath = "/token"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.Header().Set("WWW-Authenticate", `Bearer realm="http://`+r.Host+tokenPath+`",service="test"`)
@@ -147,9 +140,7 @@ func TestAuthenticatorCreateNewTokenErrors(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	auth := newAuthenticator(srv.URL, "org/repo", Credentials{Username: "user", Password: "bad"}, srv.Client())
+	auth := newAuthenticator(srv.URL, "org/repo", Credentials{Username: "user", Password: "bad"}, httpClient)
 	if err := auth.refreshToken(context.Background()); err == nil {
 		t.Fatal("expected token request failure")
 	}
@@ -169,16 +160,14 @@ func TestAuthenticatorRefreshTokenCancelledContext(t *testing.T) {
 func TestAuthenticatorInitiateChallengeMissingWWWAuthenticate(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/v2" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 		http.NotFound(w, r)
 	}))
-	t.Cleanup(srv.Close)
-
-	auth := newAuthenticator(srv.URL, "org/repo", Credentials{}, srv.Client())
+	auth := newAuthenticator(srv.URL, "org/repo", Credentials{}, httpClient)
 	if _, err := auth.initiateChallenge(context.Background()); err == nil {
 		t.Fatal("expected missing WWW-Authenticate error")
 	}
@@ -187,16 +176,14 @@ func TestAuthenticatorInitiateChallengeMissingWWWAuthenticate(t *testing.T) {
 func TestAuthenticatorCreateNewTokenMissingToken(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/token" {
 			_ = json.NewEncoder(w).Encode(map[string]string{})
 			return
 		}
 		http.NotFound(w, r)
 	}))
-	t.Cleanup(srv.Close)
-
-	auth := newAuthenticator(srv.URL, "org/repo", Credentials{}, srv.Client())
+	auth := newAuthenticator(srv.URL, "org/repo", Credentials{}, httpClient)
 	if err := auth.createNewToken(context.Background(), srv.URL+"/token"); err == nil {
 		t.Fatal("expected missing token error")
 	}

--- a/pkg/ociclient/client_test.go
+++ b/pkg/ociclient/client_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -21,7 +20,7 @@ func TestPushEvaluationCard(t *testing.T) {
 	var mu sync.Mutex
 	tokenPath := "/token"
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.Header().Set("WWW-Authenticate", `Bearer realm="http://`+r.Host+tokenPath+`",service="test"`)
@@ -49,9 +48,7 @@ func TestPushEvaluationCard(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "test-org/test-repo", Credentials{Username: "user", Password: "pass"}, srv.Client())
+	client, err := NewClient(srv.URL, "test-org/test-repo", Credentials{Username: "user", Password: "pass"}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -101,7 +98,7 @@ func TestPushEvaluationCardSkipsExistingBlob(t *testing.T) {
 	t.Parallel()
 
 	uploads := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.WriteHeader(http.StatusOK)
@@ -116,9 +113,7 @@ func TestPushEvaluationCardSkipsExistingBlob(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "test-org/test-repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "test-org/test-repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -138,7 +133,7 @@ func TestUploadBlobChunked(t *testing.T) {
 	var patchRanges []string
 	var finalizeDigest string
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.WriteHeader(http.StatusOK)
@@ -158,9 +153,7 @@ func TestUploadBlobChunked(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "test-org/test-repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "test-org/test-repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -196,7 +189,7 @@ func TestUploadBlobChunkedFollowsRotatedLocation(t *testing.T) {
 	var patchURLs []string
 	var finalizeURL string
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.WriteHeader(http.StatusOK)
@@ -230,9 +223,7 @@ func TestUploadBlobChunkedFollowsRotatedLocation(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "test-org/test-repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "test-org/test-repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -285,7 +276,7 @@ func TestUploadBlobSkipsKnownDigest(t *testing.T) {
 	t.Parallel()
 
 	uploads := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.WriteHeader(http.StatusOK)
@@ -298,9 +289,7 @@ func TestUploadBlobSkipsKnownDigest(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "test-org/test-repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "test-org/test-repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -374,7 +363,7 @@ func TestPushEvaluationCardRetriesAuthOnUnauthorized(t *testing.T) {
 	var headAttempts int
 	var firstAuth, retryAuth string
 	var mu sync.Mutex
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.Header().Set("WWW-Authenticate", `Bearer realm="http://`+r.Host+tokenPath+`",service="test"`)
@@ -407,9 +396,7 @@ func TestPushEvaluationCardRetriesAuthOnUnauthorized(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "org/repo", Credentials{Username: "user", Password: "pass"}, srv.Client())
+	client, err := NewClient(srv.URL, "org/repo", Credentials{Username: "user", Password: "pass"}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -435,7 +422,7 @@ func TestPutManifestRetriesAuthWithReplayableBody(t *testing.T) {
 	const tokenPath = "/token"
 	var putAttempts int
 	var replayedBody bool
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.Header().Set("WWW-Authenticate", `Bearer realm="http://`+r.Host+tokenPath+`",service="test"`)
@@ -457,9 +444,7 @@ func TestPutManifestRetriesAuthWithReplayableBody(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "org/repo", Credentials{Username: "user", Password: "pass"}, srv.Client())
+	client, err := NewClient(srv.URL, "org/repo", Credentials{Username: "user", Password: "pass"}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -478,7 +463,7 @@ func TestEnsureBlobUsesMonolithicUploadForSmallContent(t *testing.T) {
 	t.Parallel()
 
 	var patchCalls int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.WriteHeader(http.StatusOK)
@@ -496,9 +481,7 @@ func TestEnsureBlobUsesMonolithicUploadForSmallContent(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "org/repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "org/repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -519,7 +502,7 @@ func TestEnsureBlobUsesChunkedUploadForLargeContent(t *testing.T) {
 	t.Parallel()
 
 	var patchCalls int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.WriteHeader(http.StatusOK)
@@ -538,9 +521,7 @@ func TestEnsureBlobUsesChunkedUploadForLargeContent(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "org/repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "org/repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -574,16 +555,14 @@ func TestResolveLocation(t *testing.T) {
 func TestBlobExistsServerError(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodHead {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		http.NotFound(w, r)
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "org/repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "org/repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -595,16 +574,14 @@ func TestBlobExistsServerError(t *testing.T) {
 func TestStartBlobUploadMissingLocation(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/blobs/uploads/") {
 			w.WriteHeader(http.StatusAccepted)
 			return
 		}
 		http.NotFound(w, r)
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "org/repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "org/repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -616,16 +593,14 @@ func TestStartBlobUploadMissingLocation(t *testing.T) {
 func TestPutManifestError(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/v2/org/repo/manifests/") {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		http.NotFound(w, r)
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "org/repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "org/repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -677,7 +652,7 @@ func TestDoRefreshTokenFailure(t *testing.T) {
 	t.Parallel()
 
 	const tokenPath = "/token"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodHead:
 			w.WriteHeader(http.StatusUnauthorized)
@@ -690,9 +665,7 @@ func TestDoRefreshTokenFailure(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "org/repo", Credentials{Username: "user", Password: "bad"}, srv.Client())
+	client, err := NewClient(srv.URL, "org/repo", Credentials{Username: "user", Password: "bad"}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -704,7 +677,7 @@ func TestDoRefreshTokenFailure(t *testing.T) {
 func TestUploadBlobMonolithicFailure(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.WriteHeader(http.StatusOK)
@@ -719,9 +692,7 @@ func TestUploadBlobMonolithicFailure(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "org/repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "org/repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}
@@ -733,7 +704,7 @@ func TestUploadBlobMonolithicFailure(t *testing.T) {
 func TestPatchBlobChunkFailure(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, httpClient := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2":
 			w.WriteHeader(http.StatusOK)
@@ -746,9 +717,7 @@ func TestPatchBlobChunkFailure(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	t.Cleanup(srv.Close)
-
-	client, err := NewClient(srv.URL, "org/repo", Credentials{}, srv.Client())
+	client, err := NewClient(srv.URL, "org/repo", Credentials{}, httpClient)
 	if err != nil {
 		t.Fatalf("NewClient() err = %v", err)
 	}

--- a/pkg/ociclient/httptest_test.go
+++ b/pkg/ociclient/httptest_test.go
@@ -1,0 +1,40 @@
+package ociclient
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// startTestServer starts an httptest server and returns a client whose connections
+// abort with SO_LINGER=0 (RST) instead of lingering in TIME_WAIT. That avoids
+// ephemeral-port exhaustion when many registry mock servers run under -count /
+// parallel package tests.
+func startTestServer(t *testing.T, handler http.Handler) (*httptest.Server, *http.Client) {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	client := &http.Client{
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				var d net.Dialer
+				c, err := d.DialContext(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				if tc, ok := c.(*net.TCPConn); ok {
+					_ = tc.SetLinger(0)
+				}
+				return c, nil
+			},
+		},
+	}
+	t.Cleanup(func() {
+		client.CloseIdleConnections()
+		srv.Close()
+	})
+	return srv, client
+}

--- a/tests/mlflow/Makefile
+++ b/tests/mlflow/Makefile
@@ -2,7 +2,7 @@
 
 # Local Python environment (uv). Isolated from the repo-root .venv used for FVT.
 VENV_DIR ?= .venv
-PYTHON ?= 3.14
+PYTHON ?= 3.12
 
 MLFLOW_OLD_VERSION ?= 3.8.1
 MLFLOW_LATEST_VERSION ?= 3.14.0

--- a/tests/mlflow/README.md
+++ b/tests/mlflow/README.md
@@ -34,7 +34,7 @@ Run `make help` for a short list.
 | Target | Description |
 |--------|-------------|
 | `help` | List targets and descriptions |
-| `init-python` | Create `$(VENV_DIR)` with `uv venv` (default `.venv`, Python `3.14`) |
+| `init-python` | Create `$(VENV_DIR)` with `uv venv` (default `.venv`, Python `3.12`) |
 | `install-mlflow` | Depends on `init-python`; installs MLflow with `uv pip` into the venv |
 | `start-mlflow` | Install (locked), stop this port, then start MLflow in the background |
 | `stop-mlflow` | Stop the server on `MLFLOW_PORT` only (PID file / port listen) |
@@ -51,7 +51,7 @@ Override defaults on the `make` command line or in the environment:
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `VENV_DIR` | `.venv` | uv virtualenv location (under `tests/mlflow`) |
-| `PYTHON` | `3.14` | Python version passed to `uv venv` |
+| `PYTHON` | `3.12` | Python version passed to `uv venv` |
 | `MLFLOW_VERSION` | `3.13.0` | MLflow package version for `uv pip install` (see **MLflow version note** below) |
 | `MLFLOW_HOST` | `127.0.0.1` | Server bind address |
 | `MLFLOW_PORT` | `5000` | Server port |


### PR DESCRIPTION
## What and why

- Introduce startTestServer with SO_LINGER=0 for registry mock HTTP servers so parallel package runs do not exhaust ephemeral ports to prevent random test failures.
- Pin the MLflow local test Python default to 3.12 and update its README.

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test server lifecycle management and connection cleanup for more reliable authentication and client tests.
  * Standardized HTTP client setup across test scenarios.

* **Documentation**
  * Updated MLflow testing instructions to use Python 3.12 by default.

* **Chores**
  * Updated the MLflow test environment configuration to provision Python 3.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->