### PR TITLE
fix(mlflow): remove InsecureSkipVerify for MLflow TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Configuration is loaded from `config/config.yaml`, overridden by environment var
 | `DB_DRIVER` | Database driver (`sqlite` or `pgx`) | `sqlite` |
 | `DB_URL` | Database connection string | SQLite in-memory |
 | `MLFLOW_TRACKING_URI` | MLflow tracking server | `http://localhost:5000` |
-| `MLFLOW_INSECURE_SKIP_VERIFY` | Skip TLS verification for MLflow | `false` |
+| `MLFLOW_CA_CERT_PATH` | PEM CA bundle for MLflow TLS verification | (system roots) |
 | `LOG_LEVEL` | Logging level | `INFO` |
 
 Provider configurations live in `config/providers/` as YAML files. The default set includes lm-evaluation-harness (167 benchmarks), RAGAS, Garak, GuideLLM, LightEval, and MTEB.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,7 +23,6 @@ env_mappings:
   DB_URL: database.url
   MLFLOW_TRACKING_URI: mlflow.tracking_uri
   MLFLOW_CA_CERT_PATH: mlflow.ca_cert_path
-  MLFLOW_INSECURE_SKIP_VERIFY: mlflow.insecure_skip_verify
   MLFLOW_TOKEN_PATH: mlflow.token_path
   MLFLOW_WORKSPACE: mlflow.workspace
   EVALHUB_CA_CERT_PATH: sidecar.eval_hub.ca_cert_path

--- a/internal/eval_hub/config/mlflow_config.go
+++ b/internal/eval_hub/config/mlflow_config.go
@@ -6,12 +6,11 @@ import (
 )
 
 type MLFlowConfig struct {
-	TrackingURI        string        `mapstructure:"tracking_uri"`
-	HTTPTimeout        time.Duration `mapstructure:"http_timeout"`
-	CACertPath         string        `mapstructure:"ca_cert_path"`
-	InsecureSkipVerify bool          `mapstructure:"insecure_skip_verify"`
-	Token              string        `mapstructure:"token"`
-	TokenPath          string        `mapstructure:"token_path"`
-	Workspace          string        `mapstructure:"workspace"`
-	TLSConfig          *tls.Config   // not serialized
+	TrackingURI string        `mapstructure:"tracking_uri"`
+	HTTPTimeout time.Duration `mapstructure:"http_timeout"`
+	CACertPath  string        `mapstructure:"ca_cert_path"`
+	Token       string        `mapstructure:"token"`
+	TokenPath   string        `mapstructure:"token_path"`
+	Workspace   string        `mapstructure:"workspace"`
+	TLSConfig   *tls.Config   // not serialized
 }

--- a/internal/eval_hub/config/sidecar_config.go
+++ b/internal/eval_hub/config/sidecar_config.go
@@ -47,16 +47,16 @@ type EvalHubClientConfig struct {
 }
 
 // SidecarMLFlowConfig holds sidecar-specific MLflow settings (e.g. token cache TTL).
-// CACertPath and InsecureSkipVerify may also be set under sidecar.mlflow in YAML; when writing
-// sidecar_config.json for job pods, those fields are overwritten from top-level mlflow config.
+// CACertPath may also be set under sidecar.mlflow in YAML; when writing sidecar_config.json
+// for job pods, that field is overwritten from top-level mlflow config. TLS verification
+// is always enabled for MLflow; use CACertPath for custom CAs.
 type SidecarMLFlowConfig struct {
-	TrackingURI        string        `mapstructure:"tracking_uri,omitempty" json:"tracking_uri,omitempty"`
-	TokenPath          string        `mapstructure:"token_path,omitempty" json:"token_path,omitempty"`
-	Workspace          string        `mapstructure:"workspace,omitempty" json:"workspace,omitempty"`
-	TokenCacheTimeout  time.Duration `mapstructure:"token_cache_timeout" json:"token_cache_timeout,omitempty"`
-	HTTPTimeout        time.Duration `mapstructure:"http_timeout" json:"http_timeout,omitempty"`
-	CACertPath         string        `mapstructure:"ca_cert_path,omitempty" json:"ca_cert_path,omitempty"`
-	InsecureSkipVerify bool          `mapstructure:"insecure_skip_verify,omitempty" json:"insecure_skip_verify,omitempty"`
+	TrackingURI       string        `mapstructure:"tracking_uri,omitempty" json:"tracking_uri,omitempty"`
+	TokenPath         string        `mapstructure:"token_path,omitempty" json:"token_path,omitempty"`
+	Workspace         string        `mapstructure:"workspace,omitempty" json:"workspace,omitempty"`
+	TokenCacheTimeout time.Duration `mapstructure:"token_cache_timeout" json:"token_cache_timeout,omitempty"`
+	HTTPTimeout       time.Duration `mapstructure:"http_timeout" json:"http_timeout,omitempty"`
+	CACertPath        string        `mapstructure:"ca_cert_path,omitempty" json:"ca_cert_path,omitempty"`
 }
 
 type ServiceAccountConfig struct {

--- a/internal/eval_hub/mlflow/mlflow.go
+++ b/internal/eval_hub/mlflow/mlflow.go
@@ -76,11 +76,6 @@ func NewMLFlowClient(config *config.Config, logger *slog.Logger) (*mlflowclient.
 			logger.Info("Loaded MLflow CA certificate", "path", config.MLFlow.CACertPath)
 		}
 
-		if config.MLFlow.InsecureSkipVerify {
-			tlsConfig.InsecureSkipVerify = true
-			logger.Warn("MLflow TLS certificate verification is disabled")
-		}
-
 		config.MLFlow.TLSConfig = tlsConfig
 	}
 

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
@@ -42,7 +42,6 @@ func sidecarForJobPod(cfg *config.Config, jc *jobConfig) (*config.SidecarConfig,
 			export.MLFlow.Workspace = jc.mlflowWorkspace
 			if cfg != nil && cfg.MLFlow != nil {
 				export.MLFlow.HTTPTimeout = cfg.MLFlow.HTTPTimeout
-				export.MLFlow.InsecureSkipVerify = cfg.MLFlow.InsecureSkipVerify
 				if jc.serviceCAConfigMap != "" {
 					export.MLFlow.CACertPath = serviceCAMountPath + "/" + serviceCABundleFile
 				} else {

--- a/internal/eval_runtime_sidecar/config/sidecar_runtime_config.go
+++ b/internal/eval_runtime_sidecar/config/sidecar_runtime_config.go
@@ -45,12 +45,11 @@ func LoadSidecarRuntimeConfig(sidecarJSONPath, version, build, buildDate string)
 
 	if sc.MLFlow != nil && strings.TrimSpace(sc.MLFlow.TrackingURI) != "" {
 		cfg.MLFlow = &config.MLFlowConfig{
-			TrackingURI:        strings.TrimSpace(sc.MLFlow.TrackingURI),
-			HTTPTimeout:        sc.MLFlow.HTTPTimeout,
-			CACertPath:         sc.MLFlow.CACertPath,
-			InsecureSkipVerify: sc.MLFlow.InsecureSkipVerify,
-			TokenPath:          sc.MLFlow.TokenPath,
-			Workspace:          sc.MLFlow.Workspace,
+			TrackingURI: strings.TrimSpace(sc.MLFlow.TrackingURI),
+			HTTPTimeout: sc.MLFlow.HTTPTimeout,
+			CACertPath:  sc.MLFlow.CACertPath,
+			TokenPath:   sc.MLFlow.TokenPath,
+			Workspace:   sc.MLFlow.Workspace,
 		}
 	}
 

--- a/internal/eval_runtime_sidecar/proxy/http_client.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client.go
@@ -44,7 +44,7 @@ func newHTTPClient(timeout time.Duration, tlsConfig *tls.Config, isOTELEnabled b
 // When insecureSkipVerify is true, custom CA files are not read: verification is off, so loading a CA
 // would not affect trust and skipping avoids failing on missing paths in local/test environments.
 // When caCertPath is empty and insecureSkipVerify is false, system roots are used (default *tls.Config).
-// OCI callers always pass insecureSkipVerify=false; skip-verify is not supported for registry TLS.
+// MLflow and OCI callers always pass insecureSkipVerify=false; skip-verify is not supported for those TLS paths.
 func buildTLSConfig(caCertPath string, insecureSkipVerify bool, logger *slog.Logger, certLabel string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
@@ -119,7 +119,8 @@ func NewMLFlowHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logge
 		timeout = mlflowConfig.HTTPTimeout
 	}
 
-	tlsConfig, err := buildTLSConfig(mlflowConfig.CACertPath, mlflowConfig.InsecureSkipVerify, logger, "MLflow")
+	// TLS verification is always enabled for MLflow; use CACertPath for custom CAs.
+	tlsConfig, err := buildTLSConfig(mlflowConfig.CACertPath, false, logger, "MLflow")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Remove `InsecureSkipVerify` from MLflow config and the API MLflow client so TLS certificates are always verified
- Stop propagating the flag through sidecar_config.json and the sidecar MLflow HTTP client (same pattern as OCI)
- Drop `MLFLOW_INSECURE_SKIP_VERIFY` env mapping; document `MLFLOW_CA_CERT_PATH` for custom CA trust

## Test plan
- [ ] Unit tests for `internal/eval_hub/mlflow`, sidecar proxy/config, and k8s sidecar JSON packaging
- [ ] Confirm MLflow HTTPS with a custom CA via `MLFLOW_CA_CERT_PATH` / `ca_cert_path` still works
- [ ] Confirm self-signed MLflow without a trusted CA fails as expected (no skip-verify escape hatch)
- [ ] Spot-check job pod `sidecar_config.json` no longer includes `mlflow.insecure_skip_verify`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * MLflow TLS certificate verification is now always enabled.
  * Added support for custom PEM certificate authorities through `MLFLOW_CA_CERT_PATH`.
  * Removed the option to bypass MLflow TLS verification.

* **Documentation**
  * Updated configuration guidance to reflect the new certificate and verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->