### PR TITLE
test: update FVT payloads for connected and disconnected clusters via jsonnet

### DIFF
--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -471,7 +471,7 @@ Feature: Collections Endpoint
                 "parameters": {
                     "num_examples": 10,
                     "num_fewshot": 0,
-                    "tokenizer": "google/flan-t5-small"
+                    "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
                 }
             },
             {
@@ -487,7 +487,7 @@ Feature: Collections Endpoint
                 "parameters": {
                     "num_examples": 10,
                     "num_fewshot": 0,
-                    "tokenizer": "google/flan-t5-small"
+                    "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
                 }
             }
         ]
@@ -544,7 +544,7 @@ Feature: Collections Endpoint
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "tokenizer": "google/flan-t5-small"
+              "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
           },
           {
@@ -553,7 +553,7 @@ Feature: Collections Endpoint
             "weight": 2,
             "parameters": {
               "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
+              "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
           }
         ]
@@ -580,7 +580,7 @@ Feature: Collections Endpoint
         "provider_id": "lm_evaluation_harness",
         "weight": 3,
         "parameters": {
-            "tokenizer": "google/flan-t5-small"
+            "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
           }
         }
        ]

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -172,7 +172,7 @@ Feature: Evaluation Jobs
             "provider_id": "lm_evaluation_harness",
             "parameters": {
               "num_examples": 3,
-              "tokenizer": "google/flan-t5-small"
+              "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
           }
         ],
@@ -198,7 +198,7 @@ Feature: Evaluation Jobs
             "provider_id": "lm_evaluation_harness",
             "parameters": {
               "num_examples": 3,
-              "tokenizer": "google/flan-t5-small"
+              "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
           }
         ],
@@ -672,7 +672,7 @@ Feature: Evaluation Jobs
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "tokenizer": "google/flan-t5-small"
+              "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
           }
         ]
@@ -954,7 +954,7 @@ Feature: Evaluation Jobs
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "tokenizer": "google/flan-t5-small"
+              "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
           }
         ],
@@ -986,7 +986,7 @@ Feature: Evaluation Jobs
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "tokenizer": "google/flan-t5-small"
+              "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
           }
         ],
@@ -1091,7 +1091,7 @@ Feature: Evaluation Jobs
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "tokenizer": "google/flan-t5-small"
+              "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
           }
         ],
@@ -1123,7 +1123,7 @@ Feature: Evaluation Jobs
             "parameters": {
               "num_examples": 10,
               "num_fewshot": 3,
-              "tokenizer": "google/flan-t5-small"
+              "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
           }
         ],
@@ -1332,45 +1332,7 @@ Feature: Evaluation Jobs
   @mlflow 
   Scenario: Card generated for completed job with benchmarks
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_benchmark_test",
-        "description": "Job for card testing with benchmarks",
-        "tags": ["evalcard", "test"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "weight": 0.6,
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            },
-            "primary_score": {
-              "metric": "accuracy",
-              "aggregation": "mean"
-            },
-            "pass_criteria": {
-              "threshold": 0.3
-            }
-          }
-        ],
-        "pass_criteria": {
-          "threshold": 0.3
-        },
-        "experiment": {
-          "name": "evalcard_test_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_benchmark.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1389,53 +1351,7 @@ Feature: Evaluation Jobs
   Scenario: Card generated for completed job with collection
     Given the service is running
     And there is a system collection with id "toxicity-and-ethical-principles"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_collection_test",
-        "description": "Job for card testing with collection",
-        "tags": ["evalcard", "collection"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "collection": {
-          "id": "toxicity-and-ethical-principles",
-          "benchmarks": [
-            {
-              "id": "toxigen",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            },
-            {
-              "id": "truthfulqa_mc1",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            },
-            {
-              "id": "bigbench_hhh_alignment_multiple_choice",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            }
-          ]
-        },
-        "pass_criteria": {
-          "threshold": 0.5
-        },
-        "experiment": {
-          "name": "evalcard_collection_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_collection.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1450,45 +1366,7 @@ Feature: Evaluation Jobs
   @mlflow 
   Scenario: Card generated for job with multiple benchmarks
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_multibenchmark_test",
-        "description": "Job for card testing with multiple benchmarks",
-        "tags": ["evalcard", "multi"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          },
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 3,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "pass_criteria": {
-          "threshold": 0.5
-        },
-        "experiment": {
-          "name": "evalcard_multi_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_multi_benchmark.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1503,34 +1381,7 @@ Feature: Evaluation Jobs
   @mlflow 
   Scenario: Card generated for completed benchmark job
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_completed_benchmark_test",
-        "description": "Job for card testing on completed benchmark",
-        "tags": ["evalcard", "benchmark"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_completed_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1543,34 +1394,7 @@ Feature: Evaluation Jobs
   @mlflow 
   Scenario: No card for pending job
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_pending_test",
-        "description": "Job to verify no card for pending",
-        "tags": ["evalcard", "pending"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_pending_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the response should contain the value "pending" at path "$.status.state"
     # EvalCards are only exported on completion, so pending jobs have no card
@@ -1578,34 +1402,7 @@ Feature: Evaluation Jobs
   @mlflow 
   Scenario: Multiple jobs in same experiment have different cards
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_shared_exp_job1",
-        "description": "First job in shared experiment",
-        "tags": ["evalcard", "shared"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_shared_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_shared_exp_job1.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job1_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1613,34 +1410,7 @@ Feature: Evaluation Jobs
     When I send a GET request to "/api/v1/evaluations/jobs/{{value:job1_id}}"
     Then the response code should be 200
     And the "results.benchmarks[0].mlflow_run_id" field in the response should be saved as "value:run_id_job1"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_shared_exp_job2",
-        "description": "Second job in shared experiment",
-        "tags": ["evalcard", "shared"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_shared_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_shared_exp_job2.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job2_id"
     And I wait for the evaluation job status to be "completed"
@@ -1657,34 +1427,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card has correct card_version and schema_version
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_version_test",
-        "description": "Test card version fields",
-        "tags": ["evalcard", "version"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_version_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1699,34 +1442,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card metadata contains all required timestamps in ISO 8601 format
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_timestamps_test",
-        "description": "Test card metadata timestamps",
-        "tags": ["evalcard", "metadata"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_timestamps_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1743,34 +1459,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card structure has all top-level fields
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_structure_test",
-        "description": "Test card top-level structure",
-        "tags": ["evalcard", "structure"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_structure_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1788,34 +1477,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card context.model contains url and name
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_model_fields_test",
-        "description": "Test card context model fields",
-        "tags": ["evalcard", "model"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_model_fields_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1830,34 +1492,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card context.benchmarks exists for benchmark job
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_benchmarks_array_test",
-        "description": "Test card context benchmarks array",
-        "tags": ["evalcard", "benchmarks"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_benchmarks_array_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1873,34 +1508,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card results.benchmarks contains metrics
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_metrics_test",
-        "description": "Test card results benchmark metrics",
-        "tags": ["evalcard", "metrics"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_metrics_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1915,34 +1523,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card results.benchmarks contains mlflow_run_id
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_mlflow_runid_test",
-        "description": "Test card results contains mlflow_run_id",
-        "tags": ["evalcard", "mlflow"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_mlflow_runid_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1956,34 +1537,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card results.status.state matches job status
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_status_state_test",
-        "description": "Test card results status state",
-        "tags": ["evalcard", "status"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_status_state_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -1998,50 +1552,7 @@ Feature: Evaluation Jobs
   Scenario: Card context.collection_id exists for collection job
     Given the service is running
     And there is a system collection with id "toxicity-and-ethical-principles"
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_collection_id_test",
-        "description": "Test card context has collection_id",
-        "tags": ["evalcard", "collection"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "collection": {
-          "id": "toxicity-and-ethical-principles",
-          "benchmarks": [
-            {
-              "id": "toxigen",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            },
-            {
-              "id": "truthfulqa_mc1",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            },
-            {
-              "id": "bigbench_hhh_alignment_multiple_choice",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            }
-          ]
-        },
-        "experiment": {
-          "name": "evalcard_collection_id_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_collection_id.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -2056,34 +1567,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card context.benchmarks contains correct benchmark IDs
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_benchmark_ids_test",
-        "description": "Test card context benchmarks have correct IDs",
-        "tags": ["evalcard", "benchmarks"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_benchmark_ids_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -2098,34 +1582,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card results.benchmarks array has expected structure
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_results_array_test",
-        "description": "Test card results.benchmarks array structure",
-        "tags": ["evalcard", "results"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_results_array_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -2142,34 +1599,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card results.benchmarks.status matches benchmark state for completed job
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_benchmark_status_test",
-        "description": "Test card benchmark status matches state",
-        "tags": ["evalcard", "status"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_benchmark_status_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_arc_easy.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -2183,31 +1613,7 @@ Feature: Evaluation Jobs
   @mlflow 
   Scenario: Card error_message structure is valid for failed benchmark
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_error_structure_test",
-        "description": "Test error_message structure in EvalCard for failed job",
-        "tags": ["evalcard", "error"],
-        "model": {
-          "url": "http://invalid-model.test/v1",
-          "name": "invalid-model"
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 2,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_error_test"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_invalid_model.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -2225,31 +1631,7 @@ Feature: Evaluation Jobs
   @mlflow 
   Scenario: EvalCard artifact is valid parseable JSON for failed job
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_json_validation_test",
-        "description": "Test that EvalCard artifact is valid JSON even for failed jobs",
-        "tags": ["evalcard", "validation"],
-        "model": {
-          "url": "http://invalid.test/v1",
-          "name": "invalid-model"
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 2,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_json_test"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_invalid_model_json.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -2264,34 +1646,7 @@ Feature: Evaluation Jobs
   @mlflow
   Scenario: Card generated for job with no pass_criteria
     Given the service is running
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_no_pass_criteria_test",
-        "description": "Test EvalCard generation for job without pass_criteria",
-        "tags": ["evalcard", "edge-case"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 2,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_no_criteria_test"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_no_pass_criteria.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"

--- a/tests/features/evaluations.feature
+++ b/tests/features/evaluations.feature
@@ -402,7 +402,7 @@ Feature: Evaluations Endpoint
     And the response should contain the value "arc_easy" at path "$.results.benchmarks[0].id"
     And the response should contain the value "lm_evaluation_harness" at path "$.results.benchmarks[0].provider_id"
     And the response should contain the value "10" at path "$.benchmarks[0].parameters.num_examples"
-    And the response should contain the value "google/flan-t5-small" at path "$.benchmarks[0].parameters.tokenizer"
+    And the response should contain the value "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}" at path "$.benchmarks[0].parameters.tokenizer"
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
 

--- a/tests/features/jsonnet_test.go
+++ b/tests/features/jsonnet_test.go
@@ -875,6 +875,9 @@ func TestEvaluateOobCollectionJobJsonnetDisconnectedAware(t *testing.T) {
 		minBenchmarks  int
 	}{
 		{"evaluation_job_oob_toxicity.jsonnet", "toxicity-and-ethical-principles", 3},
+		{"mcp_submit_cluster_collection.jsonnet", "toxicity-and-ethical-principles", 3},
+		{"evalcard_collection.jsonnet", "toxicity-and-ethical-principles", 3},
+		{"evalcard_collection_id.jsonnet", "toxicity-and-ethical-principles", 3},
 	}
 	for _, disconnected := range []bool{false, true} {
 		mode := "connected"
@@ -1092,6 +1095,51 @@ func TestEvaluateFVTJsonnetPayloadFiles(t *testing.T) {
 			minBenchmarks: 1,
 			wantQueueKind: "kueue",
 			wantQueueName: "  user-queue  ",
+		},
+		{
+			file:          "mcp_submit_cluster.jsonnet",
+			wantName:      "mcp_cluster_test",
+			minBenchmarks: 1,
+		},
+		{
+			file:          "mcp_submit_cluster_multi_benchmark.jsonnet",
+			wantName:      "mcp_cluster_multi_benchmark_test",
+			minBenchmarks: 2,
+		},
+		{
+			file:          "mcp_submit_cluster_results.jsonnet",
+			wantName:      "mcp_cluster_results_validation",
+			minBenchmarks: 1,
+		},
+		{
+			file:          "evalcard_benchmark.jsonnet",
+			wantName:      "evalcard_benchmark_test",
+			minBenchmarks: 1,
+		},
+		{
+			file:          "evalcard_multi_benchmark.jsonnet",
+			wantName:      "evalcard_multibenchmark_test",
+			minBenchmarks: 2,
+		},
+		{
+			file:          "evalcard_arc_easy.jsonnet",
+			wantName:      "evalcard_arc_easy_test",
+			minBenchmarks: 1,
+		},
+		{
+			file:          "evalcard_mcp.jsonnet",
+			wantName:      "evalcard_mcp_test",
+			minBenchmarks: 1,
+		},
+		{
+			file:          "evalcard_mcp_resource.jsonnet",
+			wantName:      "evalcard_mcp_resource_test",
+			minBenchmarks: 1,
+		},
+		{
+			file:          "evalcard_no_pass_criteria.jsonnet",
+			wantName:      "evalcard_no_pass_criteria_test",
+			minBenchmarks: 1,
 		},
 	}
 

--- a/tests/features/mcp.feature
+++ b/tests/features/mcp.feature
@@ -377,30 +377,7 @@ Feature: MCP Tools
   Scenario: Submit evaluation job via MCP to cluster and wait for completion
     Given the model endpoint is reachable
     And I set the wait interval to "10s"
-    When I call MCP tool "submit_evaluation" with arguments:
-      """
-      {
-        "name": "mcp_cluster_test",
-        "description": "Cluster test via MCP",
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_fewshot": 0,
-              "num_examples": 10
-            }
-          }
-        ]
-      }
-      """
+    When I call MCP tool "submit_evaluation" with arguments "file:/mcp_submit_cluster.json"
     Then the MCP tool call should succeed
     And the "job_id" field in the MCP response should be saved as "value:cluster_job_id"
     And I wait for the evaluation job status to be "completed"
@@ -418,46 +395,7 @@ Feature: MCP Tools
   Scenario: Submit evaluation job with collection via MCP to cluster and wait for completion
     Given the model endpoint is reachable
     And I set the wait interval to "10s"
-    When I call MCP tool "submit_evaluation" with arguments:
-      """
-      {
-        "name": "mcp_cluster_collection_test",
-        "description": "Cluster collection test via MCP",
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "collection": {
-          "id": "toxicity-and-ethical-principles",
-          "benchmarks": [
-            {
-              "id": "toxigen",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            },
-            {
-              "id": "truthfulqa_mc1",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            },
-            {
-              "id": "bigbench_hhh_alignment_multiple_choice",
-              "provider_id": "lm_evaluation_harness",
-              "parameters": {
-                "num_examples": 5
-              }
-            }
-          ]
-        }
-      }
-      """
+    When I call MCP tool "submit_evaluation" with arguments "file:/mcp_submit_cluster_collection.json"
     Then the MCP tool call should succeed
     And the "job_id" field in the MCP response should be saved as "value:cluster_collection_job_id"
     And I wait for the evaluation job status to be "completed"
@@ -475,38 +413,7 @@ Feature: MCP Tools
   Scenario: Submit evaluation job with multiple benchmarks via MCP to cluster and wait for completion
     Given the model endpoint is reachable
     And I set the wait interval to "10s"
-    When I call MCP tool "submit_evaluation" with arguments:
-      """
-      {
-        "name": "mcp_cluster_multi_benchmark_test",
-        "description": "Cluster multi-benchmark test via MCP",
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_fewshot": 0,
-              "num_examples": 3
-            }
-          },
-          {
-            "id": "truthfulqa_mc1",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_fewshot": 0,
-              "num_examples": 3
-            }
-          }
-        ]
-      }
-      """
+    When I call MCP tool "submit_evaluation" with arguments "file:/mcp_submit_cluster_multi_benchmark.json"
     Then the MCP tool call should succeed
     And the "job_id" field in the MCP response should be saved as "value:cluster_multi_job_id"
     And I wait for the evaluation job status to be "completed"
@@ -525,33 +432,7 @@ Feature: MCP Tools
   Scenario: Submit evaluation job with MLflow tracking via MCP to cluster and wait for completion
     Given the model endpoint is reachable
     And I set the wait interval to "10s"
-    When I call MCP tool "submit_evaluation" with arguments:
-      """
-      {
-        "name": "mcp_cluster_mlflow_test",
-        "description": "Cluster MLflow tracking test via MCP",
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_fewshot": 0,
-              "num_examples": 5
-            }
-          }
-        ],
-        "experiment": {
-          "name": "mcp_cluster_mlflow_experiment"
-        }
-      }
-      """
+    When I call MCP tool "submit_evaluation" with arguments "file:/mcp_submit_cluster_mlflow.json"
     Then the MCP tool call should succeed
     And the "job_id" field in the MCP response should be saved as "value:cluster_mlflow_job_id"
     And I wait for the evaluation job status to be "completed"
@@ -569,30 +450,7 @@ Feature: MCP Tools
   Scenario: Verify benchmark results and metrics via MCP resource after cluster job completion
     Given the model endpoint is reachable
     And I set the wait interval to "10s"
-    When I call MCP tool "submit_evaluation" with arguments:
-      """
-      {
-        "name": "mcp_cluster_results_validation",
-        "description": "Cluster test to validate benchmark results via MCP resource",
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_fewshot": 0,
-              "num_examples": 5
-            }
-          }
-        ]
-      }
-      """
+    When I call MCP tool "submit_evaluation" with arguments "file:/mcp_submit_cluster_results.json"
     Then the MCP tool call should succeed
     And the "job_id" field in the MCP response should be saved as "value:cluster_results_job_id"
     And I wait for the evaluation job status to be "completed"
@@ -839,34 +697,7 @@ Feature: MCP Tools
   Scenario: MCP can retrieve completed job that has evalcard exported
     Given the service is running
     And the model endpoint is reachable
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_mcp_test",
-        "description": "Job for MCP card testing",
-        "tags": ["evalcard", "mcp"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_mcp_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_mcp.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:mcp_job_id"
     And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
@@ -886,34 +717,7 @@ Feature: MCP Tools
   Scenario: MCP resource returns job with mlflow_run_id for completed job with evalcard
     Given the service is running
     And the model endpoint is reachable
-    When I send a POST request to "/api/v1/evaluations/jobs" with body:
-      """
-      {
-        "name": "evalcard_mcp_resource_test",
-        "description": "Test MCP resource includes mlflow_run_id",
-        "tags": ["evalcard", "mcp", "resource"],
-        "model": {
-          "url": "{{env:MODEL_URL|http://test.com}}",
-          "name": "{{env:MODEL_NAME|test}}",
-          "auth": {
-            "secret_ref": "{{env:MODEL_AUTH_SECRET_REF|test}}"
-          }
-        },
-        "benchmarks": [
-          {
-            "id": "arc_easy",
-            "provider_id": "lm_evaluation_harness",
-            "parameters": {
-              "num_examples": 5,
-              "tokenizer": "google/flan-t5-small"
-            }
-          }
-        ],
-        "experiment": {
-          "name": "evalcard_mcp_resource_experiment"
-        }
-      }
-      """
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_mcp_resource.json"
     Then the response code should be 202
     And the "resource.id" field in the response should be saved as "value:mcp_resource_job_id"
     And I wait for the evaluation job status to be "completed"

--- a/tests/features/mcp_step_definitions_test.go
+++ b/tests/features/mcp_step_definitions_test.go
@@ -87,10 +87,9 @@ func (tc *scenarioConfig) iCallMCPToolWithArguments(toolName, argsJSON string) e
 		return tc.logError(fmt.Errorf("MCP client session not initialized"))
 	}
 
-	// Substitute values ({{value:key}}) like HTTP steps do
-	substitutedArgs, err := tc.substituteValues(argsJSON)
+	substitutedArgs, err := tc.resolveMCPArgs(argsJSON)
 	if err != nil {
-		return tc.logError(fmt.Errorf("failed to substitute values in MCP args: %w", err))
+		return err
 	}
 
 	ctx, cancel := tc.mcpCallContext()
@@ -112,6 +111,24 @@ func (tc *scenarioConfig) iCallMCPToolWithArguments(toolName, argsJSON string) e
 	}
 
 	return nil
+}
+
+// resolveMCPArgs loads file:/ payloads (jsonnet/JSON via getFile) then applies {{...}} substitution,
+// matching HTTP getRequestBody so connected/disconnected defaults stay consistent.
+func (tc *scenarioConfig) resolveMCPArgs(argsJSON string) (string, error) {
+	body := argsJSON
+	var err error
+	if strings.HasPrefix(body, "file:/") {
+		body, err = tc.getFile(strings.TrimPrefix(body, "file:/"))
+		if err != nil {
+			return "", err
+		}
+	}
+	body, err = tc.substituteValues(body)
+	if err != nil {
+		return "", tc.logError(fmt.Errorf("failed to substitute values in MCP args: %w", err))
+	}
+	return body, nil
 }
 
 func (tc *scenarioConfig) iCallMCPToolWithInlineArguments(toolName string, argsJSON *godog.DocString) error {

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -819,9 +819,15 @@ func (tc *scenarioConfig) iWaitForEvaluationJobStatus(expectedStatus string) err
 
 var errTestFileNotFound = errors.New("test file not found")
 
+// fvtDisconnected reports whether FVT is targeting a disconnected cluster
+// (ENVIRONMENT_ID contains "disconnected").
+func fvtDisconnected() bool {
+	return strings.Contains(strings.ToLower(os.Getenv("ENVIRONMENT_ID")), "disconnected")
+}
+
 // fvtBenchmarkTokenizer returns the expected benchmark tokenizer for FVT assertions and payloads.
 func fvtBenchmarkTokenizer() string {
-	if strings.Contains(strings.ToLower(os.Getenv("ENVIRONMENT_ID")), "disconnected") {
+	if fvtDisconnected() {
 		return "/test_data/tokenizer"
 	}
 	return "google/flan-t5-small"

--- a/tests/features/test_data/collection.json
+++ b/tests/features/test_data/collection.json
@@ -9,7 +9,7 @@
       "parameters": {
         "num_examples": 10,
         "num_fewshot": 3,
-        "tokenizer": "google/flan-t5-small",
+        "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}",
         "weight": 3
       }
     }

--- a/tests/features/test_data/evalcard_arc_easy.jsonnet
+++ b/tests/features/test_data/evalcard_arc_easy.jsonnet
@@ -1,0 +1,9 @@
+local test = import 'test.libsonnet';
+
+// Shared EvalCard arc_easy + MLflow experiment payload (disconnected-aware via test.benchmark).
+test.evalCardArcEasyJob(
+  'evalcard_arc_easy_test',
+  'Job for EvalCard testing',
+  ['evalcard'],
+  'evalcard_arc_easy_experiment',
+)

--- a/tests/features/test_data/evalcard_benchmark.jsonnet
+++ b/tests/features/test_data/evalcard_benchmark.jsonnet
@@ -1,0 +1,28 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'evalcard_benchmark_test',
+  description: 'Job for card testing with benchmarks',
+  tags: ['evalcard', 'test'],
+  model: test.model(),
+  benchmarks: [
+    test.benchmark('arc_easy', 'lm_evaluation_harness', {
+      num_examples: 5,
+    }) + {
+      weight: 0.6,
+      primary_score: {
+        metric: 'accuracy',
+        aggregation: 'mean',
+      },
+      pass_criteria: {
+        threshold: 0.3,
+      },
+    },
+  ],
+  pass_criteria: {
+    threshold: 0.3,
+  },
+  experiment: {
+    name: 'evalcard_test_experiment',
+  },
+}

--- a/tests/features/test_data/evalcard_collection.jsonnet
+++ b/tests/features/test_data/evalcard_collection.jsonnet
@@ -1,0 +1,12 @@
+local test = import 'test.libsonnet';
+
+test.evalCardToxicityCollectionJob(
+  'evalcard_collection_test',
+  'Job for card testing with collection',
+  ['evalcard', 'collection'],
+  'evalcard_collection_experiment',
+) + {
+  pass_criteria: {
+    threshold: 0.5,
+  },
+}

--- a/tests/features/test_data/evalcard_collection_id.jsonnet
+++ b/tests/features/test_data/evalcard_collection_id.jsonnet
@@ -1,0 +1,8 @@
+local test = import 'test.libsonnet';
+
+test.evalCardToxicityCollectionJob(
+  'evalcard_collection_id_test',
+  'Test card context has collection_id',
+  ['evalcard', 'collection'],
+  'evalcard_collection_id_experiment',
+)

--- a/tests/features/test_data/evalcard_invalid_model.jsonnet
+++ b/tests/features/test_data/evalcard_invalid_model.jsonnet
@@ -1,0 +1,14 @@
+local test = import 'test.libsonnet';
+
+test.evalCardArcEasyJob(
+  'evalcard_error_structure_test',
+  'Test error_message structure in EvalCard for failed job',
+  ['evalcard', 'error'],
+  'evalcard_error_test',
+  2,
+) + {
+  model: {
+    url: 'http://invalid-model.test/v1',
+    name: 'invalid-model',
+  },
+}

--- a/tests/features/test_data/evalcard_invalid_model_json.jsonnet
+++ b/tests/features/test_data/evalcard_invalid_model_json.jsonnet
@@ -1,0 +1,14 @@
+local test = import 'test.libsonnet';
+
+test.evalCardArcEasyJob(
+  'evalcard_json_validation_test',
+  'Test that EvalCard artifact is valid JSON even for failed jobs',
+  ['evalcard', 'validation'],
+  'evalcard_json_test',
+  2,
+) + {
+  model: {
+    url: 'http://invalid.test/v1',
+    name: 'invalid-model',
+  },
+}

--- a/tests/features/test_data/evalcard_mcp.jsonnet
+++ b/tests/features/test_data/evalcard_mcp.jsonnet
@@ -1,0 +1,8 @@
+local test = import 'test.libsonnet';
+
+test.evalCardArcEasyJob(
+  'evalcard_mcp_test',
+  'Job for MCP card testing',
+  ['evalcard', 'mcp'],
+  'evalcard_mcp_experiment',
+)

--- a/tests/features/test_data/evalcard_mcp_resource.jsonnet
+++ b/tests/features/test_data/evalcard_mcp_resource.jsonnet
@@ -1,0 +1,8 @@
+local test = import 'test.libsonnet';
+
+test.evalCardArcEasyJob(
+  'evalcard_mcp_resource_test',
+  'Test MCP resource includes mlflow_run_id',
+  ['evalcard', 'mcp', 'resource'],
+  'evalcard_mcp_resource_experiment',
+)

--- a/tests/features/test_data/evalcard_multi_benchmark.jsonnet
+++ b/tests/features/test_data/evalcard_multi_benchmark.jsonnet
@@ -1,0 +1,18 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'evalcard_multibenchmark_test',
+  description: 'Job for card testing with multiple benchmarks',
+  tags: ['evalcard', 'multi'],
+  model: test.model(),
+  benchmarks: [
+    test.benchmark('arc_easy', 'lm_evaluation_harness', { num_examples: 5 }),
+    test.benchmark('arc_easy', 'lm_evaluation_harness', { num_examples: 3 }),
+  ],
+  pass_criteria: {
+    threshold: 0.5,
+  },
+  experiment: {
+    name: 'evalcard_multi_experiment',
+  },
+}

--- a/tests/features/test_data/evalcard_no_pass_criteria.jsonnet
+++ b/tests/features/test_data/evalcard_no_pass_criteria.jsonnet
@@ -1,0 +1,9 @@
+local test = import 'test.libsonnet';
+
+test.evalCardArcEasyJob(
+  'evalcard_no_pass_criteria_test',
+  'Test EvalCard generation for job without pass_criteria',
+  ['evalcard', 'edge-case'],
+  'evalcard_no_criteria_test',
+  2,
+)

--- a/tests/features/test_data/evalcard_shared_exp_job1.jsonnet
+++ b/tests/features/test_data/evalcard_shared_exp_job1.jsonnet
@@ -1,0 +1,8 @@
+local test = import 'test.libsonnet';
+
+test.evalCardArcEasyJob(
+  'evalcard_shared_exp_job1',
+  'First job in shared experiment',
+  ['evalcard', 'shared'],
+  'evalcard_shared_experiment',
+)

--- a/tests/features/test_data/evalcard_shared_exp_job2.jsonnet
+++ b/tests/features/test_data/evalcard_shared_exp_job2.jsonnet
@@ -1,0 +1,8 @@
+local test = import 'test.libsonnet';
+
+test.evalCardArcEasyJob(
+  'evalcard_shared_exp_job2',
+  'Second job in shared experiment',
+  ['evalcard', 'shared'],
+  'evalcard_shared_experiment',
+)

--- a/tests/features/test_data/evaluation_job_missing_model.json
+++ b/tests/features/test_data/evaluation_job_missing_model.json
@@ -6,7 +6,7 @@
       "parameters": {
         "num_fewshot": 3,
         "num_examples": 5,
-        "tokenizer": "google/flan-t5-small"
+        "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
       }
     }
   ],

--- a/tests/features/test_data/evaluation_job_missing_name.json
+++ b/tests/features/test_data/evaluation_job_missing_name.json
@@ -10,7 +10,7 @@
       "parameters": {
         "num_examples": 10,
         "num_fewshot": 3,
-        "tokenizer": "google/flan-t5-small"
+        "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
       }
     }
   ],

--- a/tests/features/test_data/evaluation_job_multiple_benchmark.json
+++ b/tests/features/test_data/evaluation_job_multiple_benchmark.json
@@ -15,7 +15,7 @@
             "provider_id": "lm_evaluation_harness",
             "parameters": {
                 "num_examples": 5,
-                "tokenizer": "google/flan-t5-small"
+                "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
         },
         {
@@ -23,7 +23,7 @@
             "provider_id": "lm_evaluation_harness",
             "parameters": {
                 "num_examples": 10,
-                "tokenizer": "google/flan-t5-small"
+                "tokenizer": "{{env:FVT_BENCHMARK_TOKENIZER|google/flan-t5-small}}"
             }
         }
     ],

--- a/tests/features/test_data/jsonnet/test.libsonnet
+++ b/tests/features/test_data/jsonnet/test.libsonnet
@@ -163,6 +163,37 @@ local harness = std.parseJson(std.extVar('harness'));
       },
     } else {},
 
+  // EvalCard @mlflow FVT job: disconnected-aware arc_easy + experiment (always present).
+  evalCardArcEasyJob(name, description, tags, experimentName, numExamples=5)::
+    {
+      name: name,
+      description: description,
+      tags: tags,
+      model: $.model(),
+      benchmarks: [
+        $.benchmark('arc_easy', 'lm_evaluation_harness', {
+          num_examples: numExamples,
+        }),
+      ],
+      experiment: {
+        name: experimentName,
+      },
+    },
+
+  // EvalCard collection job against toxicity-and-ethical-principles (disconnected-aware overrides).
+  evalCardToxicityCollectionJob(name, description, tags, experimentName)::
+    $.oobCollectionRefJobWithLimit(
+      name,
+      'toxicity-and-ethical-principles',
+      $.toxicityAndEthicalPrinciplesBenchmarkIds(),
+    ) + {
+      description: description,
+      tags: tags,
+      experiment: {
+        name: experimentName,
+      },
+    },
+
   // Merge base with an optional object; optional may be null (adds nothing).
   mergeOptional(base, optional)::
     if optional == null then base else base + optional,

--- a/tests/features/test_data/mcp_submit_cluster.jsonnet
+++ b/tests/features/test_data/mcp_submit_cluster.jsonnet
@@ -1,0 +1,13 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'mcp_cluster_test',
+  description: 'Cluster test via MCP',
+  model: test.model(),
+  benchmarks: [
+    test.benchmark('arc_easy', 'lm_evaluation_harness', {
+      num_fewshot: 0,
+      num_examples: 10,
+    }),
+  ],
+}

--- a/tests/features/test_data/mcp_submit_cluster_collection.jsonnet
+++ b/tests/features/test_data/mcp_submit_cluster_collection.jsonnet
@@ -1,0 +1,9 @@
+local test = import 'test.libsonnet';
+
+test.oobCollectionRefJobWithLimit(
+  'mcp_cluster_collection_test',
+  'toxicity-and-ethical-principles',
+  test.toxicityAndEthicalPrinciplesBenchmarkIds(),
+) + {
+  description: 'Cluster collection test via MCP',
+}

--- a/tests/features/test_data/mcp_submit_cluster_mlflow.jsonnet
+++ b/tests/features/test_data/mcp_submit_cluster_mlflow.jsonnet
@@ -1,0 +1,18 @@
+local test = import 'test.libsonnet';
+
+// MCP submit_evaluation expects experiment.tags as a string map (not HTTP API [{key,value}] arrays).
+// Omit tags here; name alone is enough for the FVT scenario.
+{
+  name: 'mcp_cluster_mlflow_test',
+  description: 'Cluster MLflow tracking test via MCP',
+  model: test.model(),
+  benchmarks: [
+    test.benchmark('arc_easy', 'lm_evaluation_harness', {
+      num_fewshot: 0,
+      num_examples: 5,
+    }),
+  ],
+  experiment: {
+    name: 'mcp_cluster_mlflow_experiment',
+  },
+}

--- a/tests/features/test_data/mcp_submit_cluster_multi_benchmark.jsonnet
+++ b/tests/features/test_data/mcp_submit_cluster_multi_benchmark.jsonnet
@@ -1,0 +1,17 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'mcp_cluster_multi_benchmark_test',
+  description: 'Cluster multi-benchmark test via MCP',
+  model: test.model(),
+  benchmarks: [
+    test.benchmark('arc_easy', 'lm_evaluation_harness', {
+      num_fewshot: 0,
+      num_examples: 3,
+    }),
+    test.benchmark('truthfulqa_mc1', 'lm_evaluation_harness', {
+      num_fewshot: 0,
+      num_examples: 3,
+    }),
+  ],
+}

--- a/tests/features/test_data/mcp_submit_cluster_results.jsonnet
+++ b/tests/features/test_data/mcp_submit_cluster_results.jsonnet
@@ -1,0 +1,13 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'mcp_cluster_results_validation',
+  description: 'Cluster test to validate benchmark results via MCP resource',
+  model: test.model(),
+  benchmarks: [
+    test.benchmark('arc_easy', 'lm_evaluation_harness', {
+      num_fewshot: 0,
+      num_examples: 5,
+    }),
+  ],
+}


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

- On disconnected clusters, FVT jobs use the local tokenizer and offline test data instead of Hugging Face.
- On connected clusters, they keep the normal Hugging Face tokenizer.
- MCP cluster and EvalCard tests now load these payloads from jsonnet files, same as the other evaluation job tests.

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

Disconnected:
https://jenkins-csb-wxai-main.dno.corp.redhat.com/job/3.5/job/evalhub-tests/226/console

Connected:
https://jenkins-csb-wxai-main.dno.corp.redhat.com/job/3.5/job/evalhub-tests/223/console

Below failure is expected:
```
2026-07-31 19:15:16        Error: Error: failed to search MLflow runs: Post "https://mlflow.redhat-ods-applications.svc.cluster.local:8443/mlflow/api/2.0/mlflow/runs/search": dial tcp: lookup mlflow.redhat-ods-applications.svc.cluster.local: no such host
```

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for evaluation cards, collections, benchmark results, MCP submissions, disconnected environments, invalid models, and edge cases.
  - Added scenarios for multi-benchmark evaluations, shared experiments, missing criteria, and resource metadata validation.
  - Test configurations now support runtime-selectable tokenizers with a reliable default.
  - Simplified request fixtures and added support for loading reusable payload files, improving consistency and maintainability of end-to-end validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->