### PR TITLE
feat(k8s): wire EventRecorder into KubernetesHelper

### DIFF
--- a/internal/eval_hub/runtimes/k8s/k8s_helper.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper.go
@@ -3,6 +3,7 @@ package k8s
 // Helper wrapper around the Kubernetes clientset.
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -11,10 +12,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
 )
 
 // KubernetesHelper wraps the Kubernetes client-go client and exposes methods to interact with the cluster.
@@ -23,6 +28,7 @@ import (
 type KubernetesHelper struct {
 	clientset     kubernetes.Interface
 	dynamicClient dynamic.Interface
+	recorder      record.EventRecorder
 }
 
 var hardwareProfileGVR = schema.GroupVersionResource{
@@ -62,9 +68,13 @@ func NewKubernetesHelper() (*KubernetesHelper, error) {
 	if err != nil {
 		return nil, err
 	}
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientset.CoreV1().Events("")})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "evalhub-server"})
 	return &KubernetesHelper{
 		clientset:     clientset,
 		dynamicClient: dynamicClient,
+		recorder:      recorder,
 	}, nil
 }
 
@@ -72,6 +82,12 @@ func NewKubernetesHelper() (*KubernetesHelper, error) {
 // It is intended for unit tests that need deterministic Kubernetes API behavior.
 func NewKubernetesHelperWithClientset(clientset kubernetes.Interface) *KubernetesHelper {
 	return &KubernetesHelper{clientset: clientset}
+}
+
+// NewKubernetesHelperWithRecorder returns a helper backed by the given clientset and recorder.
+// It is intended for unit tests that need to assert on emitted Kubernetes Events.
+func NewKubernetesHelperWithRecorder(clientset kubernetes.Interface, recorder record.EventRecorder) *KubernetesHelper {
+	return &KubernetesHelper{clientset: clientset, recorder: recorder}
 }
 
 // GetHardwareProfile fetches a HardwareProfile custom resource by name in the given namespace.
@@ -270,6 +286,44 @@ func (h *KubernetesHelper) GetPodLogs(ctx context.Context, namespace, podName st
 		return "", err
 	}
 	return string(data), nil
+}
+
+// EmitEvent emits a Kubernetes Event against the given Job using the configured EventRecorder.
+// eventtype must be corev1.EventTypeNormal or corev1.EventTypeWarning.
+// Returns an error if the recorder is not configured or job is nil; the recorder records asynchronously.
+func (h *KubernetesHelper) EmitEvent(job *batchv1.Job, eventtype, reason, messageFmt string, args ...any) error {
+	if h.recorder == nil {
+		return fmt.Errorf("event recorder is not configured")
+	}
+	if job == nil {
+		return fmt.Errorf("job is required")
+	}
+	h.recorder.Eventf(job, eventtype, reason, messageFmt, args...)
+	return nil
+}
+
+// PatchJobPhaseLabel patches the trustyai.opendatahub.io/evaluation-phase label on a Job.
+// Patching metadata labels does not restart the Job or its Pods.
+func (h *KubernetesHelper) PatchJobPhaseLabel(ctx context.Context, namespace, name, phase string) error {
+	if namespace == "" || name == "" {
+		return fmt.Errorf("namespace and name are required")
+	}
+	if phase == "" {
+		return fmt.Errorf("phase is required")
+	}
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]string{
+				"trustyai.opendatahub.io/evaluation-phase": phase,
+			},
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshal patch: %w", err)
+	}
+	_, err = h.clientset.BatchV1().Jobs(namespace).Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	return err
 }
 
 // CreateConfigMapOptions holds optional metadata for CreateConfigMap.

--- a/internal/eval_hub/runtimes/k8s/k8s_helper.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper.go
@@ -308,6 +308,9 @@ func (h *KubernetesHelper) EmitEvent(job *batchv1.Job, eventtype, reason, messag
 	if job == nil {
 		return fmt.Errorf("job is required")
 	}
+	if eventtype != corev1.EventTypeNormal && eventtype != corev1.EventTypeWarning {
+		return fmt.Errorf("unsupported event type %q: must be %q or %q", eventtype, corev1.EventTypeNormal, corev1.EventTypeWarning)
+	}
 	h.recorder.Eventf(job, eventtype, reason, messageFmt, args...)
 	return nil
 }

--- a/internal/eval_hub/runtimes/k8s/k8s_helper.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper.go
@@ -29,6 +29,7 @@ type KubernetesHelper struct {
 	clientset     kubernetes.Interface
 	dynamicClient dynamic.Interface
 	recorder      record.EventRecorder
+	broadcaster   record.EventBroadcaster
 }
 
 var hardwareProfileGVR = schema.GroupVersionResource{
@@ -75,7 +76,16 @@ func NewKubernetesHelper() (*KubernetesHelper, error) {
 		clientset:     clientset,
 		dynamicClient: dynamicClient,
 		recorder:      recorder,
+		broadcaster:   broadcaster,
 	}, nil
+}
+
+// Close shuts down the event broadcaster, stopping its background goroutines.
+// It should be called when the helper is no longer needed.
+func (h *KubernetesHelper) Close() {
+	if h.broadcaster != nil {
+		h.broadcaster.Shutdown()
+	}
 }
 
 // NewKubernetesHelperWithClientset returns a helper backed by the given clientset.

--- a/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
@@ -2,11 +2,14 @@ package k8s
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 )
 
 func TestCreateConfigMapRequiresNamespaceAndName(t *testing.T) {
@@ -108,5 +111,72 @@ func TestGetPodLogsReturnsStreamContent(t *testing.T) {
 	}
 	if got != "fake logs" {
 		t.Fatalf("got %q, want fake logs", got)
+	}
+}
+
+func TestEmitEventRequiresRecorder(t *testing.T) {
+	helper := &KubernetesHelper{}
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "default"}}
+	if err := helper.EmitEvent(job, corev1.EventTypeNormal, "Reason", "msg"); err == nil {
+		t.Fatal("expected error when recorder is nil")
+	}
+}
+
+func TestEmitEventRequiresJob(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	helper := NewKubernetesHelperWithRecorder(fake.NewSimpleClientset(), fakeRecorder)
+	if err := helper.EmitEvent(nil, corev1.EventTypeNormal, "Reason", "msg"); err == nil {
+		t.Fatal("expected error when job is nil")
+	}
+}
+
+func TestEmitEventWritesToRecorder(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	helper := NewKubernetesHelperWithRecorder(fake.NewSimpleClientset(), fakeRecorder)
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "default"}}
+	if err := helper.EmitEvent(job, corev1.EventTypeNormal, "EvaluationStarted", "evaluation started"); err != nil {
+		t.Fatalf("EmitEvent: %v", err)
+	}
+	select {
+	case msg := <-fakeRecorder.Events:
+		if !strings.Contains(msg, "EvaluationStarted") {
+			t.Fatalf("expected EvaluationStarted in event, got: %s", msg)
+		}
+	default:
+		t.Fatal("expected an event on the recorder channel")
+	}
+}
+
+func TestPatchJobPhaseLabelRequiresNamespaceAndName(t *testing.T) {
+	helper := &KubernetesHelper{}
+	if err := helper.PatchJobPhaseLabel(context.Background(), "", "job-1", "Running"); err == nil {
+		t.Fatal("expected error for missing namespace")
+	}
+	if err := helper.PatchJobPhaseLabel(context.Background(), "default", "", "Running"); err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestPatchJobPhaseLabelRequiresPhase(t *testing.T) {
+	helper := &KubernetesHelper{}
+	if err := helper.PatchJobPhaseLabel(context.Background(), "default", "job-1", ""); err == nil {
+		t.Fatal("expected error for missing phase")
+	}
+}
+
+func TestPatchJobPhaseLabelUpdatesLabel(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "default"},
+	})
+	helper := NewKubernetesHelperWithClientset(clientset)
+	if err := helper.PatchJobPhaseLabel(context.Background(), "default", "job-1", "Running"); err != nil {
+		t.Fatalf("PatchJobPhaseLabel: %v", err)
+	}
+	updated, err := clientset.BatchV1().Jobs("default").Get(context.Background(), "job-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if got := updated.Labels["trustyai.opendatahub.io/evaluation-phase"]; got != "Running" {
+		t.Fatalf("expected label value Running, got %q", got)
 	}
 }

--- a/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
@@ -122,6 +122,15 @@ func TestEmitEventRequiresRecorder(t *testing.T) {
 	}
 }
 
+func TestEmitEventRejectsUnsupportedEventType(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	helper := NewKubernetesHelperWithRecorder(fake.NewSimpleClientset(), fakeRecorder)
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "default"}}
+	if err := helper.EmitEvent(job, "Unknown", "Reason", "msg"); err == nil {
+		t.Fatal("expected error for unsupported event type")
+	}
+}
+
 func TestEmitEventRequiresJob(t *testing.T) {
 	fakeRecorder := record.NewFakeRecorder(10)
 	helper := NewKubernetesHelperWithRecorder(fake.NewSimpleClientset(), fakeRecorder)


### PR DESCRIPTION
## What and why

Wires the `client-go` `EventRecorder` and a label-patch helper into `KubernetesHelper` as the infrastructure layer for RHAI-277 event emission. This PR introduces no callers (those come in PRs 3 and 4.)


## Type

- [x] feat

## Changes

- Add `recorder record.EventRecorder` field to `KubernetesHelper`
- Wire `EventBroadcaster` in `NewKubernetesHelper` with `EventSource{Component: "evalhub-server"}` (satisfies AC-9)
- Add `NewKubernetesHelperWithRecorder(clientset, recorder)` test constructor
- Add `EmitEvent(job, eventtype, reason, messageFmt, args...)` — calls `recorder.Eventf`; returns error if recorder or job is nil (satisfies AC-8: no panics)
- Add `PatchJobPhaseLabel(ctx, namespace, name, phase)` — strategic merge patch on `trustyai.opendatahub.io/evaluation-phase`; safe to call mid-flight (label patch does not restart pods)

## Testing

- [x] Tests added: 6 new unit tests covering nil-guard paths and behaviour (fake recorder channel, fake clientset label assertion)
- [ ] Tested manually (no cluster behaviour observable — tested by PR 5 FVT)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes event reporting for evaluation Jobs.
  * Added support for updating a Job’s evaluation phase label.
  * Added validation to ensure event and label updates use valid Job and Kubernetes resource information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->