### PR TITLE
feat(k8s): set evaluation-phase label on Job at creation

### DIFF
--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -93,6 +93,10 @@ const (
 	annotationProviderIDKey          = "eval-hub.github.io/provider_id"
 	annotationBenchmarkIDKey         = "eval-hub.github.io/benchmark_id"
 	labelKueueQueueNameKey           = "kueue.x-k8s.io/queue-name"
+	labelEvaluationPhaseKey          = "trustyai.opendatahub.io/evaluation-phase"
+	// EvaluationPhasePending is the initial value of the evaluation-phase label, set at Job creation.
+	// Subsequent phases are patched by the lifecycle signal code (KubernetesHelper.PatchJobPhaseLabel).
+	EvaluationPhasePending = "Pending"
 )
 
 var (
@@ -899,12 +903,13 @@ func jobLabels(cfg *jobConfig) map[string]string {
 		return map[string]string{}
 	}
 	m := map[string]string{
-		labelAppKey:            labelAppValue,
-		labelComponentKey:      labelComponentValue,
-		labelJobIDKey:          sanitizeLabelValue(cfg.jobID),
-		labelProviderIDKey:     sanitizeLabelValue(cfg.providerID),
-		labelBenchmarkIDKey:    sanitizeLabelValue(cfg.benchmarkID),
-		labelBenchmarkIndexKey: sanitizeLabelValue(strconv.Itoa(cfg.benchmarkIndex)),
+		labelAppKey:             labelAppValue,
+		labelComponentKey:       labelComponentValue,
+		labelJobIDKey:           sanitizeLabelValue(cfg.jobID),
+		labelProviderIDKey:      sanitizeLabelValue(cfg.providerID),
+		labelBenchmarkIDKey:     sanitizeLabelValue(cfg.benchmarkID),
+		labelBenchmarkIndexKey:  sanitizeLabelValue(strconv.Itoa(cfg.benchmarkIndex)),
+		labelEvaluationPhaseKey: EvaluationPhasePending,
 	}
 	if cfg.evalHubInstanceName != "" && cfg.evalHubCRNamespace != "" {
 		m[labelEvalHubInstanceNameKey] = sanitizeLabelValue(cfg.evalHubInstanceName)

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -193,6 +193,32 @@ func TestJobLabelsKueueQueueName(t *testing.T) {
 	}
 }
 
+func TestJobLabelsIncludesEvaluationPhasePending(t *testing.T) {
+	labels := jobLabels(&jobConfig{jobID: "j", providerID: "p", benchmarkID: "b", benchmarkIndex: 0})
+	if got := labels[labelEvaluationPhaseKey]; got != EvaluationPhasePending {
+		t.Fatalf("expected evaluation-phase label %q, got %q", EvaluationPhasePending, got)
+	}
+}
+
+func TestBuildJobHasEvaluationPhasePendingLabel(t *testing.T) {
+	cfg := &jobConfig{
+		jobID:          "job-123",
+		resourceGUID:   "guid-123",
+		benchmarkIndex: 0,
+		namespace:      "default",
+		providerID:     "provider-1",
+		benchmarkID:    "bench-1",
+		adapterImage:   "adapter:latest",
+	}
+	job, err := buildJob(cfg)
+	if err != nil {
+		t.Fatalf("buildJob: %v", err)
+	}
+	if got := job.Labels[labelEvaluationPhaseKey]; got != EvaluationPhasePending {
+		t.Fatalf("expected Job label %q=%q, got %q", labelEvaluationPhaseKey, EvaluationPhasePending, got)
+	}
+}
+
 func TestBuildJobRequiresAdapterImage(t *testing.T) {
 	cfg := &jobConfig{
 		jobID:          "job-123",


### PR DESCRIPTION
## What and why

Sets the `trustyai.opendatahub.io/evaluation-phase` label on every evaluation Job at creation time, with an initial value of `Pending`. This gives operators and tooling a queryable signal for the lifecycle phase of a Job from the moment it exists, without requiring a separate patch call at creation.

The label is patched to subsequent values (`Running`, `Completed`, `Failed`) by lifecycle signal code wired in PR 4, using `KubernetesHelper.PatchJobPhaseLabel` introduced in PR 2.

Part of RHAI-277 (EvalHub Server Kubernetes Event Emission and Job Lifecycle Signals).

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

`TestJobLabelsIncludesEvaluationPhasePending`: asserts the label is present in `jobLabels` output with value `Pending`. `TestBuildJobHasEvaluationPhasePendingLabel`: builds a full Job and asserts the label is on `job.Labels`.

## Breaking changes

None. Adding a label to new Jobs is additive; existing Jobs are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes evaluation jobs now include a visible “Pending” evaluation-phase status when created.

* **Bug Fixes**
  * Improved consistency of evaluation status labeling on newly generated jobs.

* **Tests**
  * Added coverage to verify pending status labels are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->