### PR TITLE
feat(k8s): emit lifecycle Events and patch evaluation-phase label on transitions

### DIFF
--- a/internal/eval_hub/abstractions/runtime.go
+++ b/internal/eval_hub/abstractions/runtime.go
@@ -34,6 +34,11 @@ type Runtime interface {
 		benchmarkIndex *int,
 		opts api.EvaluationLogOptions,
 	) (string, error)
+	// NotifyJobPhaseTransition informs the runtime that a benchmark job has transitioned to a
+	// new phase. Implementations emit runtime-native signals (e.g., Kubernetes Events and label
+	// patches on the backing Job object). Errors are absorbed internally — lifecycle signals are
+	// best-effort and must never propagate to the caller.
+	NotifyJobPhaseTransition(ctx context.Context, evaluation *api.EvaluationJobResource, benchmarkIndex int, state api.State)
 }
 
 // This interface must be decoupled from the service HTTP layer

--- a/internal/eval_hub/handlers/evaluation_logs_test.go
+++ b/internal/eval_hub/handlers/evaluation_logs_test.go
@@ -42,6 +42,8 @@ func (r *logsRuntime) RunEvaluationJob(
 	return nil
 }
 func (r *logsRuntime) DeleteEvaluationJobResources(_ *api.EvaluationJobResource) error { return nil }
+func (r *logsRuntime) NotifyJobPhaseTransition(_ context.Context, _ *api.EvaluationJobResource, _ int, _ api.State) {
+}
 func (r *logsRuntime) GetEvaluationLogs(
 	_ *api.EvaluationJobResource,
 	_ []api.EvaluationBenchmarkConfig,

--- a/internal/eval_hub/handlers/evaluations.go
+++ b/internal/eval_hub/handlers/evaluations.go
@@ -506,6 +506,10 @@ func (h *Handlers) HandleUpdateEvaluation(ctx *executioncontext.ExecutionContext
 				return err
 			}
 
+			if h.runtime != nil && status.BenchmarkStatusEvent != nil && job != nil {
+				h.runtime.NotifyJobPhaseTransition(runtimeCtx, job, status.BenchmarkStatusEvent.BenchmarkIndex, status.BenchmarkStatusEvent.Status)
+			}
+
 			h.onEvaluationJobUpdated(runtimeCtx, scoped, func() (*api.EvaluationJobResource, error) {
 				return scoped.GetEvaluationJob(evaluationJobID)
 			}, previousState, ctx.Logger)

--- a/internal/eval_hub/handlers/evaluations.go
+++ b/internal/eval_hub/handlers/evaluations.go
@@ -507,7 +507,7 @@ func (h *Handlers) HandleUpdateEvaluation(ctx *executioncontext.ExecutionContext
 			}
 
 			if h.runtime != nil && status.BenchmarkStatusEvent != nil && job != nil {
-				h.runtime.NotifyJobPhaseTransition(runtimeCtx, job, status.BenchmarkStatusEvent.BenchmarkIndex, status.BenchmarkStatusEvent.Status)
+				h.runtime.WithLogger(ctx.Logger).NotifyJobPhaseTransition(runtimeCtx, job, status.BenchmarkStatusEvent.BenchmarkIndex, status.BenchmarkStatusEvent.Status)
 			}
 
 			h.onEvaluationJobUpdated(runtimeCtx, scoped, func() (*api.EvaluationJobResource, error) {

--- a/internal/eval_hub/handlers/evaluations_test.go
+++ b/internal/eval_hub/handlers/evaluations_test.go
@@ -150,6 +150,8 @@ func (r *fakeRuntime) GetEvaluationLogs(
 	}
 	return "", nil
 }
+func (r *fakeRuntime) NotifyJobPhaseTransition(_ context.Context, _ *api.EvaluationJobResource, _ int, _ api.State) {
+}
 
 type listEvaluationsRequest struct {
 	*MockRequest

--- a/internal/eval_hub/handlers/evaluations_test.go
+++ b/internal/eval_hub/handlers/evaluations_test.go
@@ -117,8 +117,11 @@ func (f *fakeStorage) DeleteEvaluationJob(id string) error {
 }
 
 type fakeRuntime struct {
-	err    error
-	called bool
+	err                    error
+	called                 bool
+	notifiedJob            *api.EvaluationJobResource
+	notifiedBenchmarkIndex int
+	notifiedState          api.State
 }
 
 func (r *fakeRuntime) WithLogger(_ *slog.Logger) abstractions.Runtime { return r }
@@ -150,7 +153,10 @@ func (r *fakeRuntime) GetEvaluationLogs(
 	}
 	return "", nil
 }
-func (r *fakeRuntime) NotifyJobPhaseTransition(_ context.Context, _ *api.EvaluationJobResource, _ int, _ api.State) {
+func (r *fakeRuntime) NotifyJobPhaseTransition(_ context.Context, job *api.EvaluationJobResource, benchmarkIndex int, state api.State) {
+	r.notifiedJob = job
+	r.notifiedBenchmarkIndex = benchmarkIndex
+	r.notifiedState = state
 }
 
 type listEvaluationsRequest struct {
@@ -956,6 +962,51 @@ func TestHandleUpdateEvaluationRejectsInvalidPhase(t *testing.T) {
 	respBody := recorder.Body.String()
 	if !strings.Contains(respBody, "request_validation_failed") {
 		t.Fatalf("expected request_validation_failed in body, but got %q", respBody)
+	}
+}
+
+func TestHandleUpdateEvaluationDispatchesPhaseTransitionNotification(t *testing.T) {
+	t.Parallel()
+	job := &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{
+			Resource: api.Resource{ID: "job-notify"},
+		},
+	}
+	storage := &updateEvaluationStorage{fakeStorage: &fakeStorage{job: job}}
+	runtime := &fakeRuntime{}
+	validate := testhelpers.NewValidator(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := handlers.New(storage, validate, runtime, nil, nil, nil)
+
+	body := `{"benchmark_status_event":{"provider_id":"p1","id":"b1","status":"running","benchmark_index":2}}`
+	req := &bodyRequest{
+		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs/job-notify/events"),
+		body:        []byte(body),
+	}
+	reqWithPath := &updateEvaluationRequest{
+		bodyRequest: req,
+		pathValues:  map[string]string{"job_id": "job-notify"},
+	}
+	recorder := httptest.NewRecorder()
+	resp := MockResponseWrapper{recorder: recorder}
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-notify", logger, "test-user", "test-tenant")
+
+	h.HandleUpdateEvaluation(ctx, reqWithPath, resp)
+
+	if recorder.Code != 204 {
+		t.Fatalf("expected status 204, got %d body %s", recorder.Code, recorder.Body.String())
+	}
+	if runtime.notifiedJob == nil {
+		t.Fatal("expected NotifyJobPhaseTransition to be called with a non-nil job")
+	}
+	if runtime.notifiedJob.Resource.ID != job.Resource.ID {
+		t.Errorf("notified job ID = %q, want %q", runtime.notifiedJob.Resource.ID, job.Resource.ID)
+	}
+	if runtime.notifiedBenchmarkIndex != 2 {
+		t.Errorf("notified benchmark index = %d, want 2", runtime.notifiedBenchmarkIndex)
+	}
+	if runtime.notifiedState != api.StateRunning {
+		t.Errorf("notified state = %q, want %q", runtime.notifiedState, api.StateRunning)
 	}
 }
 

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle.go
@@ -1,0 +1,71 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/eval-hub/eval-hub/pkg/api"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NotifyJobPhaseTransition patches the evaluation-phase label on the backing Kubernetes Job and
+// emits a Kubernetes Event for the transition. Both operations are best-effort: failures are
+// logged at Warn level and never surfaced to the caller.
+func (r *K8sRuntime) NotifyJobPhaseTransition(ctx context.Context, evaluation *api.EvaluationJobResource, benchmarkIndex int, state api.State) {
+	phase, eventtype, reason, ok := lifecycleSignal(state)
+	if !ok {
+		return
+	}
+	namespace := resolveNamespace(string(evaluation.Resource.Tenant))
+	labelSelector := fmt.Sprintf(
+		"%s=%s,%s=%s",
+		labelJobIDKey, sanitizeLabelValue(evaluation.Resource.ID),
+		labelBenchmarkIndexKey, sanitizeLabelValue(strconv.Itoa(benchmarkIndex)),
+	)
+	jobs, err := r.helper.ListJobs(ctx, namespace, labelSelector)
+	if err != nil {
+		r.logger.WarnContext(ctx, "lifecycle signal: list jobs failed",
+			"job_id", evaluation.Resource.ID,
+			"benchmark_index", benchmarkIndex,
+			"phase", phase,
+			"error", err,
+		)
+		return
+	}
+	for i := range jobs {
+		job := &jobs[i]
+		if patchErr := r.helper.PatchJobPhaseLabel(ctx, namespace, job.Name, phase); patchErr != nil {
+			r.logger.WarnContext(ctx, "lifecycle signal: patch phase label failed",
+				"job_name", job.Name,
+				"phase", phase,
+				"error", patchErr,
+			)
+		}
+		messageFmt := "benchmark %d phase transition: %s"
+		if emitErr := r.helper.EmitEvent(job, eventtype, reason, messageFmt, benchmarkIndex, phase); emitErr != nil {
+			r.logger.WarnContext(ctx, "lifecycle signal: emit event failed",
+				"job_name", job.Name,
+				"reason", reason,
+				"error", emitErr,
+			)
+		}
+	}
+}
+
+// lifecycleSignal maps an evaluation benchmark state to the Kubernetes label value, event type,
+// and event reason for a lifecycle transition. Returns ok=false for states that do not produce
+// signals: Pending is stamped at Job creation (see EvaluationPhasePending in job_builders.go);
+// Cancelled has no corresponding Kubernetes job phase.
+func lifecycleSignal(state api.State) (phase, eventtype, reason string, ok bool) {
+	switch state {
+	case api.StateRunning:
+		return "Running", corev1.EventTypeNormal, "EvaluationRunning", true
+	case api.StateCompleted:
+		return "Completed", corev1.EventTypeNormal, "EvaluationCompleted", true
+	case api.StateFailed:
+		return "Failed", corev1.EventTypeWarning, "EvaluationFailed", true
+	default:
+		return "", "", "", false
+	}
+}

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle_test.go
@@ -1,0 +1,188 @@
+package k8s
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/eval-hub/eval-hub/pkg/api"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+)
+
+func TestLifecycleSignalMapping(t *testing.T) {
+	cases := []struct {
+		state      api.State
+		wantOK     bool
+		wantPhase  string
+		wantType   string
+		wantReason string
+	}{
+		{api.StateRunning, true, "Running", corev1.EventTypeNormal, "EvaluationRunning"},
+		{api.StateCompleted, true, "Completed", corev1.EventTypeNormal, "EvaluationCompleted"},
+		{api.StateFailed, true, "Failed", corev1.EventTypeWarning, "EvaluationFailed"},
+		{api.StatePending, false, "", "", ""},
+		{api.StateCancelled, false, "", "", ""},
+	}
+	for _, tc := range cases {
+		phase, eventtype, reason, ok := lifecycleSignal(tc.state)
+		if ok != tc.wantOK {
+			t.Errorf("lifecycleSignal(%q): ok=%v, want %v", tc.state, ok, tc.wantOK)
+		}
+		if !tc.wantOK {
+			continue
+		}
+		if phase != tc.wantPhase {
+			t.Errorf("lifecycleSignal(%q): phase=%q, want %q", tc.state, phase, tc.wantPhase)
+		}
+		if eventtype != tc.wantType {
+			t.Errorf("lifecycleSignal(%q): eventtype=%q, want %q", tc.state, eventtype, tc.wantType)
+		}
+		if reason != tc.wantReason {
+			t.Errorf("lifecycleSignal(%q): reason=%q, want %q", tc.state, reason, tc.wantReason)
+		}
+	}
+}
+
+func TestNotifyJobPhaseTransitionPatchesLabel(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eval-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelJobIDKey:          sanitizeLabelValue(evaluation.Resource.ID),
+				labelBenchmarkIndexKey: "0",
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(job)
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+	}
+
+	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateRunning)
+
+	updated, err := clientset.BatchV1().Jobs("default").Get(context.Background(), "eval-job", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if got := updated.Labels[labelEvaluationPhaseKey]; got != "Running" {
+		t.Fatalf("expected label value Running, got %q", got)
+	}
+}
+
+func TestNotifyJobPhaseTransitionEmitsEvent(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eval-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelJobIDKey:          sanitizeLabelValue(evaluation.Resource.ID),
+				labelBenchmarkIndexKey: "0",
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(job)
+	fakeRecorder := record.NewFakeRecorder(10)
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: NewKubernetesHelperWithRecorder(clientset, fakeRecorder),
+	}
+
+	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateCompleted)
+
+	select {
+	case msg := <-fakeRecorder.Events:
+		if !strings.Contains(msg, "EvaluationCompleted") {
+			t.Fatalf("expected EvaluationCompleted in event, got: %s", msg)
+		}
+	default:
+		t.Fatal("expected an event on the recorder channel")
+	}
+}
+
+func TestNotifyJobPhaseTransitionSkipsPendingState(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eval-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelJobIDKey:          sanitizeLabelValue(evaluation.Resource.ID),
+				labelBenchmarkIndexKey: "0",
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(job)
+	fakeRecorder := record.NewFakeRecorder(10)
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: NewKubernetesHelperWithRecorder(clientset, fakeRecorder),
+	}
+
+	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StatePending)
+
+	select {
+	case msg := <-fakeRecorder.Events:
+		t.Fatalf("expected no event for Pending state, got: %s", msg)
+	default:
+	}
+}
+
+func TestNotifyJobPhaseTransitionNoJobFound(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	clientset := fake.NewSimpleClientset()
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+	}
+	// No matching job — should be a no-op with no panic.
+	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateRunning)
+}
+
+func TestNotifyJobPhaseTransitionFailedState(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eval-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelJobIDKey:          sanitizeLabelValue(evaluation.Resource.ID),
+				labelBenchmarkIndexKey: "0",
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(job)
+	fakeRecorder := record.NewFakeRecorder(10)
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: NewKubernetesHelperWithRecorder(clientset, fakeRecorder),
+	}
+
+	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateFailed)
+
+	updated, err := clientset.BatchV1().Jobs("default").Get(context.Background(), "eval-job", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if got := updated.Labels[labelEvaluationPhaseKey]; got != "Failed" {
+		t.Fatalf("expected label value Failed, got %q", got)
+	}
+
+	select {
+	case msg := <-fakeRecorder.Events:
+		if !strings.Contains(msg, "EvaluationFailed") {
+			t.Fatalf("expected EvaluationFailed in event, got: %s", msg)
+		}
+	default:
+		t.Fatal("expected a Warning event for Failed state")
+	}
+}

--- a/internal/eval_hub/runtimes/local/local_runtime_lifecycle.go
+++ b/internal/eval_hub/runtimes/local/local_runtime_lifecycle.go
@@ -1,0 +1,12 @@
+package local
+
+import (
+	"context"
+
+	"github.com/eval-hub/eval-hub/pkg/api"
+)
+
+// NotifyJobPhaseTransition is a no-op for the local runtime: there are no Kubernetes objects
+// to label or emit Events against.
+func (r *LocalRuntime) NotifyJobPhaseTransition(_ context.Context, _ *api.EvaluationJobResource, _ int, _ api.State) {
+}

--- a/internal/eval_hub/server/server_test.go
+++ b/internal/eval_hub/server/server_test.go
@@ -96,6 +96,8 @@ func (r *stubRuntime) GetEvaluationLogs(
 ) (string, error) {
 	return "", nil
 }
+func (r *stubRuntime) NotifyJobPhaseTransition(_ context.Context, _ *api.EvaluationJobResource, _ int, _ api.State) {
+}
 
 func TestNewServer(t *testing.T) {
 	t.Run("creates server with default port", func(t *testing.T) {

--- a/internal/otel/job_logs_test.go
+++ b/internal/otel/job_logs_test.go
@@ -133,3 +133,5 @@ func (r *stubLogsRuntime) GetEvaluationLogs(_ *api.EvaluationJobResource, _ []ap
 	close(r.exported)
 	return r.logs, nil
 }
+func (r *stubLogsRuntime) NotifyJobPhaseTransition(_ context.Context, _ *api.EvaluationJobResource, _ int, _ api.State) {
+}


### PR DESCRIPTION
## What and why

Wires the lifecycle signal infrastructure from PRs 2 and 3 into the status-update path so that every sidecar-reported phase transition is reflected on the backing Kubernetes Job object in real time.

When the sidecar calls `PATCH /api/v1/evaluations/jobs/{id}`, the server now:
1. Patches the `trustyai.opendatahub.io/evaluation-phase` label on the matching K8s Job to `Running`, `Completed`, or `Failed`.
2. Emits a Kubernetes Event against the Job (`EvaluationRunning` / `EvaluationCompleted` / `EvaluationFailed`) so operators and tooling can observe transitions without polling status fields.

`Pending` is intentionally skipped here — it is stamped at Job creation time by PR 3.

Both operations are best-effort: failures are logged at Warn level and never surfaced to the caller.

Part of RHAI-277 (EvalHub Server Kubernetes Event Emission and Job Lifecycle Signals).

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

`TestLifecycleSignalMapping`: table-driven test covering all state→label/event mappings including non-emitting states (Pending, Cancelled).
`TestNotifyJobPhaseTransitionPatchesLabel`: verifies the Running label is patched on the K8s Job.
`TestNotifyJobPhaseTransitionEmitsEvent`: verifies a `EvaluationCompleted` event reaches the recorder channel.
`TestNotifyJobPhaseTransitionSkipsPendingState`: asserts no event or patch for the Pending state.
`TestNotifyJobPhaseTransitionNoJobFound`: verifies a graceful no-op when no matching Job exists.
`TestNotifyJobPhaseTransitionFailedState`: verifies both the label patch and `EvaluationFailed` Warning event for the Failed state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle notifications for evaluation benchmark phase changes.
  * Kubernetes-based evaluations now update job phase labels and emit events when benchmarks start, complete, or fail.
  * Unsupported or pending states are ignored without generating notifications.

* **Bug Fixes**
  * Lifecycle signaling failures are handled on a best-effort basis so they do not interrupt evaluation processing.

* **Tests**
  * Added coverage for phase mappings, label updates, event emission, and cases with no matching job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->