### PR TITLE
test(k8s): add FVT scenarios for event emission and evaluation-phase label

### DIFF
--- a/tests/features/k8s_fvt_helper.go
+++ b/tests/features/k8s_fvt_helper.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -62,6 +64,79 @@ func (c *fvtK8sClient) listJobs(ctx context.Context, namespace, labelSelector st
 		return nil, fmt.Errorf("namespace is required")
 	}
 	list, err := c.clientset.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// getJobNameForEvalJob returns the name of the Kubernetes Job backing the given eval-hub job ID.
+func (c *fvtK8sClient) getJobNameForEvalJob(ctx context.Context, namespace, evalJobID string) (string, error) {
+	labelSelector := fmt.Sprintf("job_id=%s", evalJobID)
+	jobs, err := c.listJobs(ctx, namespace, labelSelector)
+	if err != nil {
+		return "", fmt.Errorf("list jobs for eval job %s: %w", evalJobID, err)
+	}
+	if len(jobs) == 0 {
+		return "", fmt.Errorf("no Kubernetes Job found for eval job %s in namespace %s", evalJobID, namespace)
+	}
+	return jobs[0].Name, nil
+}
+
+// getJobPhaseLabel returns the value of the trustyai.opendatahub.io/evaluation-phase label
+// on the Kubernetes Job backing the given eval-hub job ID, or "" if the label is absent.
+func (c *fvtK8sClient) getJobPhaseLabel(ctx context.Context, namespace, evalJobID string) (string, error) {
+	labelSelector := fmt.Sprintf("job_id=%s", evalJobID)
+	jobs, err := c.listJobs(ctx, namespace, labelSelector)
+	if err != nil {
+		return "", fmt.Errorf("list jobs for eval job %s: %w", evalJobID, err)
+	}
+	if len(jobs) == 0 {
+		return "", fmt.Errorf("no Kubernetes Job found for eval job %s in namespace %s", evalJobID, namespace)
+	}
+	return jobs[0].Labels["trustyai.opendatahub.io/evaluation-phase"], nil
+}
+
+// waitForEventOnJob polls the Kubernetes Events API until an event with the given reason is found
+// on the Job named jobName (involvedObject.kind=Job). It returns on the first match or when ctx
+// is cancelled.
+func (c *fvtK8sClient) waitForEventOnJob(ctx context.Context, namespace, jobName, reason string) error {
+	if namespace == "" || jobName == "" || reason == "" {
+		return fmt.Errorf("namespace, jobName and reason are required")
+	}
+	fieldSelector := fmt.Sprintf(
+		"involvedObject.name=%s,involvedObject.kind=Job,involvedObject.namespace=%s,reason=%s",
+		jobName, namespace, reason,
+	)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for Kubernetes Event reason=%s on Job %s/%s", reason, namespace, jobName)
+		case <-ticker.C:
+			list, err := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+				FieldSelector: fieldSelector,
+			})
+			if err != nil {
+				continue
+			}
+			if len(list.Items) > 0 {
+				return nil
+			}
+		}
+	}
+}
+
+// listEventsForJob returns all Kubernetes Events for the Job backing the given eval-hub job ID.
+func (c *fvtK8sClient) listEventsForJob(ctx context.Context, namespace, jobName string) ([]corev1.Event, error) {
+	fieldSelector := fmt.Sprintf(
+		"involvedObject.name=%s,involvedObject.kind=Job,involvedObject.namespace=%s",
+		jobName, namespace,
+	)
+	list, err := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: fieldSelector,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/tests/features/k8s_lifecycle_signals.feature
+++ b/tests/features/k8s_lifecycle_signals.feature
@@ -1,0 +1,47 @@
+@cluster
+@k8s_lifecycle
+Feature: Kubernetes Lifecycle Signals
+  As a platform operator
+  I want evaluation Jobs to emit Kubernetes Events and carry an evaluation-phase label
+  So that I can observe evaluation lifecycle transitions without direct EvalHub API access
+
+  Background:
+    Given I set the header "X-Tenant" to "{{env:X_TENANT|test-tenant}}"
+    And I set the header "X-User" to "{{env:X_USER|test-user}}"
+    And I set the wait deadline to "{{env:WAIT_DEADLINE|30m}}"
+    And the model endpoint is reachable
+    And the value "{{env:MODEL_AUTH_SECRET_REF}}" is not empty
+
+  Scenario: Kubernetes Events are emitted for a completed evaluation job
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
+    Then the response code should be 202
+    And I wait for the evaluation job status to be "completed"
+    Then I observe a Kubernetes Event with reason "EvaluationRunning" for the evaluation job within "60s"
+    And I observe a Kubernetes Event with reason "EvaluationCompleted" for the evaluation job within "60s"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+
+  Scenario: Evaluation Job carries the evaluation-phase label at each lifecycle state
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
+    Then the response code should be 202
+    And I wait for the Kubernetes evaluation Job to be created
+    And the evaluation Job should have label "trustyai.opendatahub.io/evaluation-phase" equal to "Pending"
+    And I wait for the evaluation Job to have label "trustyai.opendatahub.io/evaluation-phase" equal to "Running" within "5m"
+    And I wait for the evaluation job status to be "completed"
+    And the evaluation Job should have label "trustyai.opendatahub.io/evaluation-phase" equal to "Completed"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+
+  @negative
+  Scenario: EvaluationFailed event is emitted when an evaluation job fails
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_invalid_model.json"
+    Then the response code should be 202
+    And I wait for the evaluation job status to match "completed|failed"
+    Then I observe a Kubernetes Event with reason "EvaluationFailed" for the evaluation job within "60s"
+    And the evaluation Job should have label "trustyai.opendatahub.io/evaluation-phase" equal to "Failed"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+

--- a/tests/features/k8s_lifecycle_signals_step_definitions_test.go
+++ b/tests/features/k8s_lifecycle_signals_step_definitions_test.go
@@ -1,0 +1,170 @@
+package features
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+)
+
+type lifecycleSignalsState struct {
+	k8s *fvtK8sClient
+}
+
+func (s *lifecycleSignalsState) reset() {
+	s.k8s = nil
+}
+
+func (s *lifecycleSignalsState) initHelper() error {
+	if s.k8s != nil {
+		return nil
+	}
+	client, err := newFVTK8sClient()
+	if err != nil {
+		return fmt.Errorf("create fvt kubernetes client: %w", err)
+	}
+	s.k8s = client
+	return nil
+}
+
+// iObserveKubernetesEventWithReasonWithin polls the Events API until an event with the given
+// reason appears on the Kubernetes Job backing the current evaluation job, or the timeout elapses.
+func (tc *scenarioConfig) iObserveKubernetesEventWithReasonWithin(state *lifecycleSignalsState, reason, timeoutStr string) error {
+	if tc.lastId == "" {
+		return tc.logError(fmt.Errorf("no evaluation job ID found; submit a job before asserting events"))
+	}
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		return tc.logError(fmt.Errorf("parse timeout %q: %w", timeoutStr, err))
+	}
+	if err := state.initHelper(); err != nil {
+		return tc.logError(err)
+	}
+
+	namespace := tc.tenantNamespace()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	jobName, err := state.k8s.getJobNameForEvalJob(ctx, namespace, tc.lastId)
+	if err != nil {
+		return tc.logError(fmt.Errorf("find Kubernetes Job for eval job %s: %w", tc.lastId, err))
+	}
+	logDebug("Waiting for Kubernetes Event reason=%s on Job %s/%s within %s\n", reason, namespace, jobName, timeoutStr)
+
+	if err := state.k8s.waitForEventOnJob(ctx, namespace, jobName, reason); err != nil {
+		return tc.logError(err)
+	}
+	logDebug("Observed Kubernetes Event reason=%s on Job %s\n", reason, jobName)
+	return nil
+}
+
+// theEvaluationJobShouldHaveLabelEqualTo does an immediate (non-polling) check that the label
+// on the Kubernetes Job backing the current evaluation job matches the expected value.
+func (tc *scenarioConfig) theEvaluationJobShouldHaveLabelEqualTo(state *lifecycleSignalsState, labelKey, expectedValue string) error {
+	if tc.lastId == "" {
+		return tc.logError(fmt.Errorf("no evaluation job ID found"))
+	}
+	if err := state.initHelper(); err != nil {
+		return tc.logError(err)
+	}
+	namespace := tc.tenantNamespace()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if labelKey == "trustyai.opendatahub.io/evaluation-phase" {
+		actual, err := state.k8s.getJobPhaseLabel(ctx, namespace, tc.lastId)
+		if err != nil {
+			return tc.logError(err)
+		}
+		if actual != expectedValue {
+			return tc.logError(fmt.Errorf("expected label %s=%s on eval job %s, got %q", labelKey, expectedValue, tc.lastId, actual))
+		}
+		logDebug("Verified label %s=%s on Kubernetes Job for eval job %s\n", labelKey, actual, tc.lastId)
+		return nil
+	}
+	return tc.logError(fmt.Errorf("unsupported label key %q in lifecycle signal step", labelKey))
+}
+
+// iWaitForEvaluationJobToHaveLabelEqualToWithin polls until the label on the backing Kubernetes
+// Job equals expectedValue or the timeout elapses.
+func (tc *scenarioConfig) iWaitForEvaluationJobToHaveLabelEqualToWithin(state *lifecycleSignalsState, labelKey, expectedValue, timeoutStr string) error {
+	if tc.lastId == "" {
+		return tc.logError(fmt.Errorf("no evaluation job ID found"))
+	}
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		return tc.logError(fmt.Errorf("parse timeout %q: %w", timeoutStr, err))
+	}
+	if err := state.initHelper(); err != nil {
+		return tc.logError(err)
+	}
+
+	namespace := tc.tenantNamespace()
+
+	if labelKey != "trustyai.opendatahub.io/evaluation-phase" {
+		return tc.logError(fmt.Errorf("unsupported label key %q in lifecycle signal step", labelKey))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	logDebug("Waiting for label %s=%s on eval job %s within %s\n", labelKey, expectedValue, tc.lastId, timeoutStr)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			actual, _ := state.k8s.getJobPhaseLabel(context.Background(), namespace, tc.lastId)
+			return tc.logError(fmt.Errorf(
+				"timeout waiting for label %s=%s on eval job %s (last observed: %q)",
+				labelKey, expectedValue, tc.lastId, actual,
+			))
+		case <-ticker.C:
+			actual, err := state.k8s.getJobPhaseLabel(ctx, namespace, tc.lastId)
+			if err != nil {
+				continue
+			}
+			if actual == expectedValue {
+				logDebug("Label %s=%s observed on eval job %s\n", labelKey, actual, tc.lastId)
+				return nil
+			}
+		}
+	}
+}
+
+// InitializeLifecycleSignalSteps registers the Kubernetes lifecycle signal FVT steps.
+func InitializeLifecycleSignalSteps(ctx *godog.ScenarioContext, tc *scenarioConfig) {
+	state := &lifecycleSignalsState{}
+
+	ctx.Before(func(goCtx context.Context, sc *godog.Scenario) (context.Context, error) {
+		for _, t := range sc.Tags {
+			if strings.TrimPrefix(t.Name, "@") == "k8s_lifecycle" {
+				state.reset()
+				break
+			}
+		}
+		return goCtx, nil
+	})
+
+	ctx.Step(
+		`^I observe a Kubernetes Event with reason "([^"]*)" for the evaluation job within "([^"]*)"$`,
+		func(reason, timeout string) error {
+			return tc.iObserveKubernetesEventWithReasonWithin(state, reason, timeout)
+		},
+	)
+	ctx.Step(
+		`^the evaluation Job should have label "([^"]*)" equal to "([^"]*)"$`,
+		func(labelKey, expected string) error {
+			return tc.theEvaluationJobShouldHaveLabelEqualTo(state, labelKey, expected)
+		},
+	)
+	ctx.Step(
+		`^I wait for the evaluation Job to have label "([^"]*)" equal to "([^"]*)" within "([^"]*)"$`,
+		func(labelKey, expected, timeout string) error {
+			return tc.iWaitForEvaluationJobToHaveLabelEqualToWithin(state, labelKey, expected, timeout)
+		},
+	)
+}

--- a/tests/features/step_definitions_test.go
+++ b/tests/features/step_definitions_test.go
@@ -1989,6 +1989,9 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 
 	// Hardware profile steps (Kubernetes client-go via KUBECONFIG-first FVT helper)
 	InitializeHardwareProfileSteps(ctx, tc)
+
+	// Kubernetes lifecycle signal steps (event emission and evaluation-phase label)
+	InitializeLifecycleSignalSteps(ctx, tc)
 }
 
 // --- MLflow Artifact Step Definitions ---


### PR DESCRIPTION
## What and why

Adds cluster FVT scenarios (`@k8s_lifecycle`) for the Kubernetes lifecycle signals feature introduced in eval-hub#830–#832 (EventRecorder wiring, `evaluation-phase` label at Job creation, and lifecycle transitions).

These tests verify the feature is observable end-to-end against a live cluster without requiring direct EvalHub API access — which is the core motivation of RHAI-277 / RHOAIENG-80104.

Closes #RHOAIENG-80104

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

Three new `@cluster @k8s_lifecycle` Godog scenarios in `tests/features/k8s_lifecycle_signals.feature`:

1. **Event emission (happy path)** — submits an evaluation job, waits for completion, then asserts that `EvaluationRunning` and `EvaluationCompleted` Kubernetes Events appear on the backing Job within 60 s (AC-1, AC-2).

2. **Phase label transitions** — verifies the `trustyai.opendatahub.io/evaluation-phase` label is stamped `Pending` at Job creation, transitions to `Running` once the adapter starts, and settles at `Completed` after the job finishes. The label is queried directly via the Kubernetes Jobs API (no EvalHub API call), confirming informer-compatible access (AC-5, AC-10).

3. **EvaluationFailed event (`@negative`)** — submits a job with an invalid model endpoint, waits for a failed/completed terminal state, then asserts that an `EvaluationFailed` Warning Event was emitted and the phase label is `Failed` (AC-3).

New helpers in `k8s_fvt_helper.go` (all on the existing `fvtK8sClient`):
- `getJobNameForEvalJob` — resolves the K8s Job name from the eval job ID label
- `getJobPhaseLabel` — reads the `evaluation-phase` label value
- `waitForEventOnJob` — polls `CoreV1().Events()` with an involvedObject field selector
- `listEventsForJob` — lists all events on a named Job

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added acceptance coverage for Kubernetes evaluation lifecycle signals.
  * Verified evaluation Jobs emit Events for running, completed, and failed states.
  * Verified evaluation-phase labels for Pending, Running, Completed, and Failed states.
  * Added checks for evaluation Job identifiers, durations, and lifecycle transitions.
  * Added cleanup of test Jobs after scenarios complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->