### PR TITLE
feat(k8s): emit lifecycle Events and phase label on evaluation Job transitions

### DIFF
--- a/cmd/eval_hub/main.go
+++ b/cmd/eval_hub/main.go
@@ -261,6 +261,8 @@ func main() {
 
 	// stop Kubernetes EventBroadcaster goroutines started by the runtime (cluster mode only)
 	if closer, ok := runtime.(io.Closer); ok {
-		closer.Close()
+		if err := closer.Close(); err != nil {
+			logger.Error("Failed to close runtime", "error", err.Error())
+		}
 	}
 }

--- a/cmd/eval_hub/main.go
+++ b/cmd/eval_hub/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"io"
 	"log"
 	"log/slog"
 
@@ -256,5 +257,10 @@ func main() {
 	} else {
 		logger.Info("API Server shutdown gracefully")
 		_ = logShutdown() // ignore the error
+	}
+
+	// stop Kubernetes EventBroadcaster goroutines started by the runtime (cluster mode only)
+	if closer, ok := runtime.(io.Closer); ok {
+		closer.Close()
 	}
 }

--- a/internal/eval_hub/abstractions/runtime.go
+++ b/internal/eval_hub/abstractions/runtime.go
@@ -37,6 +37,11 @@ type Runtime interface {
 	// ValidateHardwareProfiles validates HardwareProfile refs on create (exist, enabled,
 	// namespace configured). No-op for runtimes that do not use cluster HardwareProfiles.
 	ValidateHardwareProfiles(benchmarks []api.EvaluationBenchmarkConfig) error
+	// NotifyJobPhaseTransition informs the runtime that a benchmark job has transitioned to a
+	// new phase. Implementations emit runtime-native signals (e.g., Kubernetes Events and label
+	// patches on the backing Job object). Errors are absorbed internally — lifecycle signals are
+	// best-effort and must never propagate to the caller.
+	NotifyJobPhaseTransition(ctx context.Context, evaluation *api.EvaluationJobResource, benchmarkIndex int, state api.State)
 }
 
 // This interface must be decoupled from the service HTTP layer

--- a/internal/eval_hub/handlers/evaluation_logs_test.go
+++ b/internal/eval_hub/handlers/evaluation_logs_test.go
@@ -42,6 +42,8 @@ func (r *logsRuntime) RunEvaluationJob(
 	return nil
 }
 func (r *logsRuntime) DeleteEvaluationJobResources(_ *api.EvaluationJobResource) error { return nil }
+func (r *logsRuntime) NotifyJobPhaseTransition(_ context.Context, _ *api.EvaluationJobResource, _ int, _ api.State) {
+}
 func (r *logsRuntime) GetEvaluationLogs(
 	_ *api.EvaluationJobResource,
 	_ []api.EvaluationBenchmarkConfig,

--- a/internal/eval_hub/handlers/evaluations.go
+++ b/internal/eval_hub/handlers/evaluations.go
@@ -556,6 +556,10 @@ func (h *Handlers) HandleUpdateEvaluation(ctx *executioncontext.ExecutionContext
 				return err
 			}
 
+			if h.runtime != nil && status.BenchmarkStatusEvent != nil && job != nil {
+				h.runtime.WithLogger(ctx.Logger).NotifyJobPhaseTransition(runtimeCtx, job, status.BenchmarkStatusEvent.BenchmarkIndex, status.BenchmarkStatusEvent.Status)
+			}
+
 			h.onEvaluationJobUpdated(runtimeCtx, scoped, func() (*api.EvaluationJobResource, error) {
 				return scoped.GetEvaluationJob(evaluationJobID)
 			}, previousState, ctx.Logger)

--- a/internal/eval_hub/handlers/evaluations_test.go
+++ b/internal/eval_hub/handlers/evaluations_test.go
@@ -119,11 +119,14 @@ func (f *fakeStorage) DeleteEvaluationJob(id string) error {
 }
 
 type fakeRuntime struct {
-	err                  error
-	validateHWErr        error
-	called               bool
-	validateHWCalled     bool
-	validateHWBenchmarks []api.EvaluationBenchmarkConfig
+	err                    error
+	validateHWErr          error
+	called                 bool
+	validateHWCalled       bool
+	validateHWBenchmarks   []api.EvaluationBenchmarkConfig
+	notifiedJob            *api.EvaluationJobResource
+	notifiedBenchmarkIndex int
+	notifiedState          api.State
 }
 
 func (r *fakeRuntime) WithLogger(_ *slog.Logger) abstractions.Runtime { return r }
@@ -159,6 +162,11 @@ func (r *fakeRuntime) ValidateHardwareProfiles(benchmarks []api.EvaluationBenchm
 	r.validateHWCalled = true
 	r.validateHWBenchmarks = benchmarks
 	return r.validateHWErr
+}
+func (r *fakeRuntime) NotifyJobPhaseTransition(_ context.Context, job *api.EvaluationJobResource, benchmarkIndex int, state api.State) {
+	r.notifiedJob = job
+	r.notifiedBenchmarkIndex = benchmarkIndex
+	r.notifiedState = state
 }
 
 type listEvaluationsRequest struct {
@@ -1029,6 +1037,51 @@ func TestHandleUpdateEvaluationRejectsInvalidPhase(t *testing.T) {
 	respBody := recorder.Body.String()
 	if !strings.Contains(respBody, "request_validation_failed") {
 		t.Fatalf("expected request_validation_failed in body, but got %q", respBody)
+	}
+}
+
+func TestHandleUpdateEvaluationDispatchesPhaseTransitionNotification(t *testing.T) {
+	t.Parallel()
+	job := &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{
+			Resource: api.Resource{ID: "job-notify"},
+		},
+	}
+	storage := &updateEvaluationStorage{fakeStorage: &fakeStorage{job: job}}
+	runtime := &fakeRuntime{}
+	validate := testhelpers.NewValidator(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := handlers.New(storage, validate, runtime, nil, nil, nil)
+
+	body := `{"benchmark_status_event":{"provider_id":"p1","id":"b1","status":"running","benchmark_index":2}}`
+	req := &bodyRequest{
+		MockRequest: createMockRequest("POST", "/api/v1/evaluations/jobs/job-notify/events"),
+		body:        []byte(body),
+	}
+	reqWithPath := &updateEvaluationRequest{
+		bodyRequest: req,
+		pathValues:  map[string]string{"job_id": "job-notify"},
+	}
+	recorder := httptest.NewRecorder()
+	resp := MockResponseWrapper{recorder: recorder}
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-notify", logger, "test-user", "test-tenant")
+
+	h.HandleUpdateEvaluation(ctx, reqWithPath, resp)
+
+	if recorder.Code != 204 {
+		t.Fatalf("expected status 204, got %d body %s", recorder.Code, recorder.Body.String())
+	}
+	if runtime.notifiedJob == nil {
+		t.Fatal("expected NotifyJobPhaseTransition to be called with a non-nil job")
+	}
+	if runtime.notifiedJob.Resource.ID != job.Resource.ID {
+		t.Errorf("notified job ID = %q, want %q", runtime.notifiedJob.Resource.ID, job.Resource.ID)
+	}
+	if runtime.notifiedBenchmarkIndex != 2 {
+		t.Errorf("notified benchmark index = %d, want 2", runtime.notifiedBenchmarkIndex)
+	}
+	if runtime.notifiedState != api.StateRunning {
+		t.Errorf("notified state = %q, want %q", runtime.notifiedState, api.StateRunning)
 	}
 }
 

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -92,9 +92,6 @@ const (
 	labelKueueQueueNameKey           = "kueue.x-k8s.io/queue-name"
 	labelKueuePriorityClassKey       = "kueue.x-k8s.io/priority-class"
 	labelEvaluationPhaseKey          = "trustyai.opendatahub.io/evaluation-phase"
-	// EvaluationPhasePending is the initial value of the evaluation-phase label, set at Job creation.
-	// Subsequent phases are patched by the lifecycle signal code (KubernetesHelper.PatchJobPhaseLabel).
-	EvaluationPhasePending = "Pending"
 )
 
 var (

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -91,6 +91,10 @@ const (
 	annotationBenchmarkIDKey         = "eval-hub.github.io/benchmark_id"
 	labelKueueQueueNameKey           = "kueue.x-k8s.io/queue-name"
 	labelKueuePriorityClassKey       = "kueue.x-k8s.io/priority-class"
+	labelEvaluationPhaseKey          = "trustyai.opendatahub.io/evaluation-phase"
+	// EvaluationPhasePending is the initial value of the evaluation-phase label, set at Job creation.
+	// Subsequent phases are patched by the lifecycle signal code (KubernetesHelper.PatchJobPhaseLabel).
+	EvaluationPhasePending = "Pending"
 )
 
 var (

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -131,6 +131,25 @@ func TestBuildConfigMapSidecarConfigJSONContent(t *testing.T) {
 	}
 }
 
+func TestBuildJobHasEvaluationPhasePendingLabel(t *testing.T) {
+	cfg := &jobConfig{
+		jobID:          "job-123",
+		resourceGUID:   "guid-123",
+		benchmarkIndex: 0,
+		namespace:      "default",
+		providerID:     "provider-1",
+		benchmarkID:    "bench-1",
+		adapterImage:   "adapter:latest",
+	}
+	job, err := buildJob(cfg)
+	if err != nil {
+		t.Fatalf("buildJob: %v", err)
+	}
+	if got := job.Labels[labelEvaluationPhaseKey]; got != EvaluationPhasePending {
+		t.Fatalf("expected Job label %q=%q, got %q", labelEvaluationPhaseKey, EvaluationPhasePending, got)
+	}
+}
+
 func TestBuildJobRequiresAdapterImage(t *testing.T) {
 	cfg := &jobConfig{
 		jobID:          "job-123",

--- a/internal/eval_hub/runtimes/k8s/job_names.go
+++ b/internal/eval_hub/runtimes/k8s/job_names.go
@@ -61,12 +61,13 @@ func jobLabels(cfg *jobConfig) map[string]string {
 		return map[string]string{}
 	}
 	m := map[string]string{
-		labelAppKey:            labelAppValue,
-		labelComponentKey:      labelComponentValue,
-		labelJobIDKey:          sanitizeLabelValue(cfg.jobID),
-		labelProviderIDKey:     sanitizeLabelValue(cfg.providerID),
-		labelBenchmarkIDKey:    sanitizeLabelValue(cfg.benchmarkID),
-		labelBenchmarkIndexKey: sanitizeLabelValue(strconv.Itoa(cfg.benchmarkIndex)),
+		labelAppKey:             labelAppValue,
+		labelComponentKey:       labelComponentValue,
+		labelJobIDKey:           sanitizeLabelValue(cfg.jobID),
+		labelProviderIDKey:      sanitizeLabelValue(cfg.providerID),
+		labelBenchmarkIDKey:     sanitizeLabelValue(cfg.benchmarkID),
+		labelBenchmarkIndexKey:  sanitizeLabelValue(strconv.Itoa(cfg.benchmarkIndex)),
+		labelEvaluationPhaseKey: EvaluationPhasePending,
 	}
 	if cfg.evalHubInstanceName != "" && cfg.evalHubCRNamespace != "" {
 		m[labelEvalHubInstanceNameKey] = sanitizeLabelValue(cfg.evalHubInstanceName)

--- a/internal/eval_hub/runtimes/k8s/job_names_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_names_test.go
@@ -81,3 +81,10 @@ func TestJobLabelsKueueQueueName(t *testing.T) {
 		t.Fatal("expected no kueue queue label when queue kind is not kueue")
 	}
 }
+
+func TestJobLabelsIncludesEvaluationPhasePending(t *testing.T) {
+	labels := jobLabels(&jobConfig{jobID: "j", providerID: "p", benchmarkID: "b", benchmarkIndex: 0})
+	if got := labels[labelEvaluationPhaseKey]; got != EvaluationPhasePending {
+		t.Fatalf("expected evaluation-phase label %q, got %q", EvaluationPhasePending, got)
+	}
+}

--- a/internal/eval_hub/runtimes/k8s/k8s_helper.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper.go
@@ -3,6 +3,7 @@ package k8s
 // Helper wrapper around the Kubernetes clientset.
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -11,10 +12,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
 )
 
 // KubernetesHelper wraps the Kubernetes client-go client and exposes methods to interact with the cluster.
@@ -23,6 +28,8 @@ import (
 type KubernetesHelper struct {
 	clientset     kubernetes.Interface
 	dynamicClient dynamic.Interface
+	recorder      record.EventRecorder
+	broadcaster   record.EventBroadcaster
 }
 
 var hardwareProfileGVR = schema.GroupVersionResource{
@@ -62,16 +69,35 @@ func NewKubernetesHelper() (*KubernetesHelper, error) {
 	if err != nil {
 		return nil, err
 	}
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientset.CoreV1().Events("")})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "evalhub-server"})
 	return &KubernetesHelper{
 		clientset:     clientset,
 		dynamicClient: dynamicClient,
+		recorder:      recorder,
+		broadcaster:   broadcaster,
 	}, nil
+}
+
+// Close shuts down the event broadcaster, stopping its background goroutines.
+// It should be called when the helper is no longer needed.
+func (h *KubernetesHelper) Close() {
+	if h.broadcaster != nil {
+		h.broadcaster.Shutdown()
+	}
 }
 
 // NewKubernetesHelperWithClientset returns a helper backed by the given clientset.
 // It is intended for unit tests that need deterministic Kubernetes API behavior.
 func NewKubernetesHelperWithClientset(clientset kubernetes.Interface) *KubernetesHelper {
 	return &KubernetesHelper{clientset: clientset}
+}
+
+// NewKubernetesHelperWithRecorder returns a helper backed by the given clientset and recorder.
+// It is intended for unit tests that need to assert on emitted Kubernetes Events.
+func NewKubernetesHelperWithRecorder(clientset kubernetes.Interface, recorder record.EventRecorder) *KubernetesHelper {
+	return &KubernetesHelper{clientset: clientset, recorder: recorder}
 }
 
 // GetHardwareProfile fetches a HardwareProfile custom resource by name in the given namespace.
@@ -270,6 +296,47 @@ func (h *KubernetesHelper) GetPodLogs(ctx context.Context, namespace, podName st
 		return "", err
 	}
 	return string(data), nil
+}
+
+// EmitEvent emits a Kubernetes Event against the given Job using the configured EventRecorder.
+// eventtype must be corev1.EventTypeNormal or corev1.EventTypeWarning.
+// Returns an error if the recorder is not configured or job is nil; the recorder records asynchronously.
+func (h *KubernetesHelper) EmitEvent(job *batchv1.Job, eventtype, reason, messageFmt string, args ...any) error {
+	if h.recorder == nil {
+		return fmt.Errorf("event recorder is not configured")
+	}
+	if job == nil {
+		return fmt.Errorf("job is required")
+	}
+	if eventtype != corev1.EventTypeNormal && eventtype != corev1.EventTypeWarning {
+		return fmt.Errorf("unsupported event type %q: must be %q or %q", eventtype, corev1.EventTypeNormal, corev1.EventTypeWarning)
+	}
+	h.recorder.Eventf(job, eventtype, reason, messageFmt, args...)
+	return nil
+}
+
+// PatchJobPhaseLabel patches the trustyai.opendatahub.io/evaluation-phase label on a Job.
+// Patching metadata labels does not restart the Job or its Pods.
+func (h *KubernetesHelper) PatchJobPhaseLabel(ctx context.Context, namespace, name, phase string) error {
+	if namespace == "" || name == "" {
+		return fmt.Errorf("namespace and name are required")
+	}
+	if phase == "" {
+		return fmt.Errorf("phase is required")
+	}
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]string{
+				"trustyai.opendatahub.io/evaluation-phase": phase,
+			},
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshal patch: %w", err)
+	}
+	_, err = h.clientset.BatchV1().Jobs(namespace).Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	return err
 }
 
 // CreateConfigMapOptions holds optional metadata for CreateConfigMap.

--- a/internal/eval_hub/runtimes/k8s/k8s_helper.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper.go
@@ -82,10 +82,11 @@ func NewKubernetesHelper() (*KubernetesHelper, error) {
 
 // Close shuts down the event broadcaster, stopping its background goroutines.
 // It should be called when the helper is no longer needed.
-func (h *KubernetesHelper) Close() {
+func (h *KubernetesHelper) Close() error {
 	if h.broadcaster != nil {
 		h.broadcaster.Shutdown()
 	}
+	return nil
 }
 
 // NewKubernetesHelperWithClientset returns a helper backed by the given clientset.

--- a/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
@@ -14,12 +14,16 @@ import (
 
 func TestCloseWithNilBroadcaster(t *testing.T) {
 	h := &KubernetesHelper{}
-	h.Close() // must not panic when broadcaster is nil
+	if err := h.Close(); err != nil { // must not panic when broadcaster is nil
+		t.Fatalf("Close: %v", err)
+	}
 }
 
 func TestCloseShutdownsBroadcaster(t *testing.T) {
 	h := &KubernetesHelper{broadcaster: record.NewBroadcaster()}
-	h.Close() // must not panic
+	if err := h.Close(); err != nil { // must not panic
+		t.Fatalf("Close: %v", err)
+	}
 }
 
 func TestCreateConfigMapRequiresNamespaceAndName(t *testing.T) {

--- a/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
@@ -12,6 +12,16 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
+func TestCloseWithNilBroadcaster(t *testing.T) {
+	h := &KubernetesHelper{}
+	h.Close() // must not panic when broadcaster is nil
+}
+
+func TestCloseShutdownsBroadcaster(t *testing.T) {
+	h := &KubernetesHelper{broadcaster: record.NewBroadcaster()}
+	h.Close() // must not panic
+}
+
 func TestCreateConfigMapRequiresNamespaceAndName(t *testing.T) {
 	helper := &KubernetesHelper{}
 	if _, err := helper.CreateConfigMap(context.Background(), "", "name", map[string]string{}, nil); err == nil {

--- a/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
@@ -2,11 +2,14 @@ package k8s
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 )
 
 func TestCreateConfigMapRequiresNamespaceAndName(t *testing.T) {
@@ -108,5 +111,81 @@ func TestGetPodLogsReturnsStreamContent(t *testing.T) {
 	}
 	if got != "fake logs" {
 		t.Fatalf("got %q, want fake logs", got)
+	}
+}
+
+func TestEmitEventRequiresRecorder(t *testing.T) {
+	helper := &KubernetesHelper{}
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "default"}}
+	if err := helper.EmitEvent(job, corev1.EventTypeNormal, "Reason", "msg"); err == nil {
+		t.Fatal("expected error when recorder is nil")
+	}
+}
+
+func TestEmitEventRejectsUnsupportedEventType(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	helper := NewKubernetesHelperWithRecorder(fake.NewSimpleClientset(), fakeRecorder)
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "default"}}
+	if err := helper.EmitEvent(job, "Unknown", "Reason", "msg"); err == nil {
+		t.Fatal("expected error for unsupported event type")
+	}
+}
+
+func TestEmitEventRequiresJob(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	helper := NewKubernetesHelperWithRecorder(fake.NewSimpleClientset(), fakeRecorder)
+	if err := helper.EmitEvent(nil, corev1.EventTypeNormal, "Reason", "msg"); err == nil {
+		t.Fatal("expected error when job is nil")
+	}
+}
+
+func TestEmitEventWritesToRecorder(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	helper := NewKubernetesHelperWithRecorder(fake.NewSimpleClientset(), fakeRecorder)
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "default"}}
+	if err := helper.EmitEvent(job, corev1.EventTypeNormal, "EvaluationStarted", "evaluation started"); err != nil {
+		t.Fatalf("EmitEvent: %v", err)
+	}
+	select {
+	case msg := <-fakeRecorder.Events:
+		if !strings.Contains(msg, "EvaluationStarted") {
+			t.Fatalf("expected EvaluationStarted in event, got: %s", msg)
+		}
+	default:
+		t.Fatal("expected an event on the recorder channel")
+	}
+}
+
+func TestPatchJobPhaseLabelRequiresNamespaceAndName(t *testing.T) {
+	helper := &KubernetesHelper{}
+	if err := helper.PatchJobPhaseLabel(context.Background(), "", "job-1", "Running"); err == nil {
+		t.Fatal("expected error for missing namespace")
+	}
+	if err := helper.PatchJobPhaseLabel(context.Background(), "default", "", "Running"); err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestPatchJobPhaseLabelRequiresPhase(t *testing.T) {
+	helper := &KubernetesHelper{}
+	if err := helper.PatchJobPhaseLabel(context.Background(), "default", "job-1", ""); err == nil {
+		t.Fatal("expected error for missing phase")
+	}
+}
+
+func TestPatchJobPhaseLabelUpdatesLabel(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "default"},
+	})
+	helper := NewKubernetesHelperWithClientset(clientset)
+	if err := helper.PatchJobPhaseLabel(context.Background(), "default", "job-1", "Running"); err != nil {
+		t.Fatalf("PatchJobPhaseLabel: %v", err)
+	}
+	updated, err := clientset.BatchV1().Jobs("default").Get(context.Background(), "job-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if got := updated.Labels["trustyai.opendatahub.io/evaluation-phase"]; got != "Running" {
+		t.Fatalf("expected label value Running, got %q", got)
 	}
 }

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -54,6 +54,15 @@ func (r *K8sRuntime) WithContext(ctx context.Context) abstractions.Runtime {
 	}
 }
 
+// Close stops the Kubernetes EventBroadcaster background goroutines started by NewKubernetesHelper.
+// WithLogger/WithContext copies share the same helper pointer, so Close must be called exactly once
+// on the root runtime returned by NewK8sRuntime.
+func (r *K8sRuntime) Close() {
+	if r.helper != nil {
+		r.helper.Close()
+	}
+}
+
 func (r *K8sRuntime) RunEvaluationJob(
 	evaluation *api.EvaluationJobResource,
 	benchmarks []api.EvaluationBenchmarkConfig,

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -57,10 +57,11 @@ func (r *K8sRuntime) WithContext(ctx context.Context) abstractions.Runtime {
 // Close stops the Kubernetes EventBroadcaster background goroutines started by NewKubernetesHelper.
 // WithLogger/WithContext copies share the same helper pointer, so Close must be called exactly once
 // on the root runtime returned by NewK8sRuntime.
-func (r *K8sRuntime) Close() {
-	if r.helper != nil {
-		r.helper.Close()
+func (r *K8sRuntime) Close() error {
+	if r.helper == nil {
+		return nil
 	}
+	return r.helper.Close()
 }
 
 func (r *K8sRuntime) RunEvaluationJob(

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle.go
@@ -1,0 +1,71 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/eval-hub/eval-hub/pkg/api"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NotifyJobPhaseTransition patches the evaluation-phase label on the backing Kubernetes Job and
+// emits a Kubernetes Event for the transition. Both operations are best-effort: failures are
+// logged at Warn level and never surfaced to the caller.
+func (r *K8sRuntime) NotifyJobPhaseTransition(ctx context.Context, evaluation *api.EvaluationJobResource, benchmarkIndex int, state api.State) {
+	phase, eventtype, reason, ok := lifecycleSignal(state)
+	if !ok {
+		return
+	}
+	namespace := resolveNamespace(string(evaluation.Resource.Tenant))
+	labelSelector := fmt.Sprintf(
+		"%s=%s,%s=%s",
+		labelJobIDKey, sanitizeLabelValue(evaluation.Resource.ID),
+		labelBenchmarkIndexKey, sanitizeLabelValue(strconv.Itoa(benchmarkIndex)),
+	)
+	jobs, err := r.helper.ListJobs(ctx, namespace, labelSelector)
+	if err != nil {
+		r.logger.WarnContext(ctx, "lifecycle signal: list jobs failed",
+			"job_id", evaluation.Resource.ID,
+			"benchmark_index", benchmarkIndex,
+			"phase", phase,
+			"error", err,
+		)
+		return
+	}
+	for i := range jobs {
+		job := &jobs[i]
+		if patchErr := r.helper.PatchJobPhaseLabel(ctx, namespace, job.Name, phase); patchErr != nil {
+			r.logger.WarnContext(ctx, "lifecycle signal: patch phase label failed",
+				"job_name", job.Name,
+				"phase", phase,
+				"error", patchErr,
+			)
+		}
+		messageFmt := "benchmark %d phase transition: %s"
+		if emitErr := r.helper.EmitEvent(job, eventtype, reason, messageFmt, benchmarkIndex, phase); emitErr != nil {
+			r.logger.WarnContext(ctx, "lifecycle signal: emit event failed",
+				"job_name", job.Name,
+				"reason", reason,
+				"error", emitErr,
+			)
+		}
+	}
+}
+
+// lifecycleSignal maps an evaluation benchmark state to the Kubernetes label value, event type,
+// and event reason for a lifecycle transition. Returns ok=false for states that do not produce
+// signals: Pending is stamped at Job creation (see EvaluationPhasePending in job_builders.go);
+// Cancelled has no corresponding Kubernetes job phase.
+func lifecycleSignal(state api.State) (phase, eventtype, reason string, ok bool) {
+	switch state {
+	case api.StateRunning:
+		return "Running", corev1.EventTypeNormal, "EvaluationRunning", true
+	case api.StateCompleted:
+		return "Completed", corev1.EventTypeNormal, "EvaluationCompleted", true
+	case api.StateFailed:
+		return "Failed", corev1.EventTypeWarning, "EvaluationFailed", true
+	default:
+		return "", "", "", false
+	}
+}

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/eval-hub/eval-hub/pkg/api"
 	corev1 "k8s.io/api/core/v1"
 )
+
+// lifecycleSignalTimeout caps each NotifyJobPhaseTransition call. Lifecycle signals are
+// best-effort; slow API operations should not hold the caller indefinitely.
+const lifecycleSignalTimeout = 10 * time.Second
 
 // NotifyJobPhaseTransition patches the evaluation-phase label on the backing Kubernetes Job and
 // emits a Kubernetes Event for the transition. Both operations are best-effort: failures are
@@ -17,15 +22,18 @@ func (r *K8sRuntime) NotifyJobPhaseTransition(ctx context.Context, evaluation *a
 	if !ok {
 		return
 	}
+	signalCtx, cancel := context.WithTimeout(ctx, lifecycleSignalTimeout)
+	defer cancel()
+
 	namespace := resolveNamespace(string(evaluation.Resource.Tenant))
 	labelSelector := fmt.Sprintf(
 		"%s=%s,%s=%s",
 		labelJobIDKey, sanitizeLabelValue(evaluation.Resource.ID),
 		labelBenchmarkIndexKey, sanitizeLabelValue(strconv.Itoa(benchmarkIndex)),
 	)
-	jobs, err := r.helper.ListJobs(ctx, namespace, labelSelector)
+	jobs, err := r.helper.ListJobs(signalCtx, namespace, labelSelector)
 	if err != nil {
-		r.logger.WarnContext(ctx, "lifecycle signal: list jobs failed",
+		r.logger.WarnContext(signalCtx, "lifecycle signal: list jobs failed",
 			"job_id", evaluation.Resource.ID,
 			"benchmark_index", benchmarkIndex,
 			"phase", phase,
@@ -35,8 +43,8 @@ func (r *K8sRuntime) NotifyJobPhaseTransition(ctx context.Context, evaluation *a
 	}
 	for i := range jobs {
 		job := &jobs[i]
-		if patchErr := r.helper.PatchJobPhaseLabel(ctx, namespace, job.Name, phase); patchErr != nil {
-			r.logger.WarnContext(ctx, "lifecycle signal: patch phase label failed",
+		if patchErr := r.helper.PatchJobPhaseLabel(signalCtx, namespace, job.Name, phase); patchErr != nil {
+			r.logger.WarnContext(signalCtx, "lifecycle signal: patch phase label failed",
 				"job_name", job.Name,
 				"phase", phase,
 				"error", patchErr,
@@ -44,7 +52,7 @@ func (r *K8sRuntime) NotifyJobPhaseTransition(ctx context.Context, evaluation *a
 		}
 		messageFmt := "benchmark %d phase transition: %s"
 		if emitErr := r.helper.EmitEvent(job, eventtype, reason, messageFmt, benchmarkIndex, phase); emitErr != nil {
-			r.logger.WarnContext(ctx, "lifecycle signal: emit event failed",
+			r.logger.WarnContext(signalCtx, "lifecycle signal: emit event failed",
 				"job_name", job.Name,
 				"reason", reason,
 				"error", emitErr,

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle.go
@@ -10,9 +10,24 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// lifecycleSignalTimeout caps each NotifyJobPhaseTransition call. Lifecycle signals are
-// best-effort; slow API operations should not hold the caller indefinitely.
-const lifecycleSignalTimeout = 10 * time.Second
+const (
+	// lifecycleSignalTimeout caps each NotifyJobPhaseTransition call. Lifecycle signals are
+	// best-effort; slow API operations should not hold the caller indefinitely.
+	lifecycleSignalTimeout = 10 * time.Second
+
+	// Evaluation phase label values — written to the trustyai.opendatahub.io/evaluation-phase
+	// label on the backing Kubernetes Job. Pending is stamped at creation; the rest are patched
+	// on each lifecycle transition via PatchJobPhaseLabel.
+	EvaluationPhasePending   = "Pending"
+	EvaluationPhaseRunning   = "Running"
+	EvaluationPhaseCompleted = "Completed"
+	EvaluationPhaseFailed    = "Failed"
+
+	// Kubernetes Event reasons emitted on lifecycle transitions.
+	eventReasonRunning   = "EvaluationRunning"
+	eventReasonCompleted = "EvaluationCompleted"
+	eventReasonFailed    = "EvaluationFailed"
+)
 
 // NotifyJobPhaseTransition patches the evaluation-phase label on the backing Kubernetes Job and
 // emits a Kubernetes Event for the transition. Both operations are best-effort: failures are
@@ -68,11 +83,11 @@ func (r *K8sRuntime) NotifyJobPhaseTransition(ctx context.Context, evaluation *a
 func lifecycleSignal(state api.State) (phase, eventtype, reason string, ok bool) {
 	switch state {
 	case api.StateRunning:
-		return "Running", corev1.EventTypeNormal, "EvaluationRunning", true
+		return EvaluationPhaseRunning, corev1.EventTypeNormal, eventReasonRunning, true
 	case api.StateCompleted:
-		return "Completed", corev1.EventTypeNormal, "EvaluationCompleted", true
+		return EvaluationPhaseCompleted, corev1.EventTypeNormal, eventReasonCompleted, true
 	case api.StateFailed:
-		return "Failed", corev1.EventTypeWarning, "EvaluationFailed", true
+		return EvaluationPhaseFailed, corev1.EventTypeWarning, eventReasonFailed, true
 	default:
 		return "", "", "", false
 	}

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle_test.go
@@ -1,0 +1,188 @@
+package k8s
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/eval-hub/eval-hub/pkg/api"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+)
+
+func TestLifecycleSignalMapping(t *testing.T) {
+	cases := []struct {
+		state      api.State
+		wantOK     bool
+		wantPhase  string
+		wantType   string
+		wantReason string
+	}{
+		{api.StateRunning, true, "Running", corev1.EventTypeNormal, "EvaluationRunning"},
+		{api.StateCompleted, true, "Completed", corev1.EventTypeNormal, "EvaluationCompleted"},
+		{api.StateFailed, true, "Failed", corev1.EventTypeWarning, "EvaluationFailed"},
+		{api.StatePending, false, "", "", ""},
+		{api.StateCancelled, false, "", "", ""},
+	}
+	for _, tc := range cases {
+		phase, eventtype, reason, ok := lifecycleSignal(tc.state)
+		if ok != tc.wantOK {
+			t.Errorf("lifecycleSignal(%q): ok=%v, want %v", tc.state, ok, tc.wantOK)
+		}
+		if !tc.wantOK {
+			continue
+		}
+		if phase != tc.wantPhase {
+			t.Errorf("lifecycleSignal(%q): phase=%q, want %q", tc.state, phase, tc.wantPhase)
+		}
+		if eventtype != tc.wantType {
+			t.Errorf("lifecycleSignal(%q): eventtype=%q, want %q", tc.state, eventtype, tc.wantType)
+		}
+		if reason != tc.wantReason {
+			t.Errorf("lifecycleSignal(%q): reason=%q, want %q", tc.state, reason, tc.wantReason)
+		}
+	}
+}
+
+func TestNotifyJobPhaseTransitionPatchesLabel(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eval-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelJobIDKey:          sanitizeLabelValue(evaluation.Resource.ID),
+				labelBenchmarkIndexKey: "0",
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(job)
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+	}
+
+	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateRunning)
+
+	updated, err := clientset.BatchV1().Jobs("default").Get(context.Background(), "eval-job", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if got := updated.Labels[labelEvaluationPhaseKey]; got != "Running" {
+		t.Fatalf("expected label value Running, got %q", got)
+	}
+}
+
+func TestNotifyJobPhaseTransitionEmitsEvent(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eval-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelJobIDKey:          sanitizeLabelValue(evaluation.Resource.ID),
+				labelBenchmarkIndexKey: "0",
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(job)
+	fakeRecorder := record.NewFakeRecorder(10)
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: NewKubernetesHelperWithRecorder(clientset, fakeRecorder),
+	}
+
+	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateCompleted)
+
+	select {
+	case msg := <-fakeRecorder.Events:
+		if !strings.Contains(msg, "EvaluationCompleted") {
+			t.Fatalf("expected EvaluationCompleted in event, got: %s", msg)
+		}
+	default:
+		t.Fatal("expected an event on the recorder channel")
+	}
+}
+
+func TestNotifyJobPhaseTransitionSkipsPendingState(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eval-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelJobIDKey:          sanitizeLabelValue(evaluation.Resource.ID),
+				labelBenchmarkIndexKey: "0",
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(job)
+	fakeRecorder := record.NewFakeRecorder(10)
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: NewKubernetesHelperWithRecorder(clientset, fakeRecorder),
+	}
+
+	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StatePending)
+
+	select {
+	case msg := <-fakeRecorder.Events:
+		t.Fatalf("expected no event for Pending state, got: %s", msg)
+	default:
+	}
+}
+
+func TestNotifyJobPhaseTransitionNoJobFound(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	clientset := fake.NewSimpleClientset()
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+	}
+	// No matching job — should be a no-op with no panic.
+	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateRunning)
+}
+
+func TestNotifyJobPhaseTransitionFailedState(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eval-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelJobIDKey:          sanitizeLabelValue(evaluation.Resource.ID),
+				labelBenchmarkIndexKey: "0",
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(job)
+	fakeRecorder := record.NewFakeRecorder(10)
+	runtime := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: NewKubernetesHelperWithRecorder(clientset, fakeRecorder),
+	}
+
+	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateFailed)
+
+	updated, err := clientset.BatchV1().Jobs("default").Get(context.Background(), "eval-job", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if got := updated.Labels[labelEvaluationPhaseKey]; got != "Failed" {
+		t.Fatalf("expected label value Failed, got %q", got)
+	}
+
+	select {
+	case msg := <-fakeRecorder.Events:
+		if !strings.Contains(msg, "EvaluationFailed") {
+			t.Fatalf("expected EvaluationFailed in event, got: %s", msg)
+		}
+	default:
+		t.Fatal("expected a Warning event for Failed state")
+	}
+}

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle_test.go
@@ -154,7 +154,9 @@ func TestNotifyJobPhaseTransitionNoJobFound(t *testing.T) {
 func TestNotifyJobPhaseTransitionListJobsError(t *testing.T) {
 	evaluation := sampleEvaluation("provider-1")
 	clientset := fake.NewSimpleClientset()
+	var listCalled int
 	clientset.PrependReactor("list", "jobs", func(_ ktesting.Action) (bool, kruntime.Object, error) {
+		listCalled++
 		return true, nil, fmt.Errorf("api unavailable")
 	})
 	rt := &K8sRuntime{
@@ -162,6 +164,9 @@ func TestNotifyJobPhaseTransitionListJobsError(t *testing.T) {
 		helper: &KubernetesHelper{clientset: clientset},
 	}
 	rt.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateRunning)
+	if listCalled != 1 {
+		t.Fatalf("expected list jobs to be called once, got %d", listCalled)
+	}
 }
 
 func TestNotifyJobPhaseTransitionPatchLabelError(t *testing.T) {
@@ -177,7 +182,9 @@ func TestNotifyJobPhaseTransitionPatchLabelError(t *testing.T) {
 		},
 	}
 	clientset := fake.NewSimpleClientset(job)
+	var patchCalled int
 	clientset.PrependReactor("patch", "jobs", func(_ ktesting.Action) (bool, kruntime.Object, error) {
+		patchCalled++
 		return true, nil, fmt.Errorf("patch forbidden")
 	})
 	fakeRecorder := record.NewFakeRecorder(10)
@@ -186,10 +193,16 @@ func TestNotifyJobPhaseTransitionPatchLabelError(t *testing.T) {
 		helper: NewKubernetesHelperWithRecorder(clientset, fakeRecorder),
 	}
 	rt.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateRunning)
-	// drain any event that may have been emitted despite the patch error
+	if patchCalled != 1 {
+		t.Fatalf("expected patch to be called once, got %d", patchCalled)
+	}
 	select {
-	case <-fakeRecorder.Events:
+	case msg := <-fakeRecorder.Events:
+		if !strings.Contains(msg, "EvaluationRunning") {
+			t.Fatalf("expected EvaluationRunning in event, got: %s", msg)
+		}
 	default:
+		t.Fatal("expected an event to be emitted even when patch fails")
 	}
 }
 

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -11,7 +12,9 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -146,6 +149,48 @@ func TestNotifyJobPhaseTransitionNoJobFound(t *testing.T) {
 	}
 	// No matching job — should be a no-op with no panic.
 	runtime.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateRunning)
+}
+
+func TestNotifyJobPhaseTransitionListJobsError(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	clientset := fake.NewSimpleClientset()
+	clientset.PrependReactor("list", "jobs", func(_ ktesting.Action) (bool, kruntime.Object, error) {
+		return true, nil, fmt.Errorf("api unavailable")
+	})
+	rt := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: &KubernetesHelper{clientset: clientset},
+	}
+	rt.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateRunning)
+}
+
+func TestNotifyJobPhaseTransitionPatchLabelError(t *testing.T) {
+	evaluation := sampleEvaluation("provider-1")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eval-job",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelJobIDKey:          sanitizeLabelValue(evaluation.Resource.ID),
+				labelBenchmarkIndexKey: "0",
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(job)
+	clientset.PrependReactor("patch", "jobs", func(_ ktesting.Action) (bool, kruntime.Object, error) {
+		return true, nil, fmt.Errorf("patch forbidden")
+	})
+	fakeRecorder := record.NewFakeRecorder(10)
+	rt := &K8sRuntime{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		helper: NewKubernetesHelperWithRecorder(clientset, fakeRecorder),
+	}
+	rt.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateRunning)
+	// drain any event that may have been emitted despite the patch error
+	select {
+	case <-fakeRecorder.Events:
+	default:
+	}
 }
 
 func TestNotifyJobPhaseTransitionFailedState(t *testing.T) {

--- a/internal/eval_hub/runtimes/local/local_runtime_lifecycle.go
+++ b/internal/eval_hub/runtimes/local/local_runtime_lifecycle.go
@@ -1,0 +1,12 @@
+package local
+
+import (
+	"context"
+
+	"github.com/eval-hub/eval-hub/pkg/api"
+)
+
+// NotifyJobPhaseTransition is a no-op for the local runtime: there are no Kubernetes objects
+// to label or emit Events against.
+func (r *LocalRuntime) NotifyJobPhaseTransition(_ context.Context, _ *api.EvaluationJobResource, _ int, _ api.State) {
+}

--- a/internal/eval_hub/server/oci_export.go
+++ b/internal/eval_hub/server/oci_export.go
@@ -38,28 +38,32 @@ func (g *kubernetesDockerConfigSecretGetter) GetDockerConfigJSON(ctx context.Con
 // newOCIPublisherFactory wires the real OCI exporter in cluster mode. Local mode uses a noop
 // factory; cluster initialization failures return an error-aware factory so OCI export requests
 // fail explicitly instead of being silently discarded.
-func newOCIPublisherFactory(logger *slog.Logger, serviceConfig *config.Config) evalcards.OCIPublisherFactory {
+// The returned cleanup func must be called when the factory is no longer needed to stop the
+// Kubernetes EventBroadcaster goroutines started by NewKubernetesHelper.
+func newOCIPublisherFactory(logger *slog.Logger, serviceConfig *config.Config) (evalcards.OCIPublisherFactory, func()) {
+	noop := func() {}
 	if serviceConfig == nil || serviceConfig.Service == nil || serviceConfig.Service.LocalMode {
-		return evalcards.NewNoopOCIPublisherFactory()
+		return evalcards.NewNoopOCIPublisherFactory(), noop
 	}
 	helper, err := k8s.NewKubernetesHelper()
 	if err != nil {
 		if logger != nil {
 			logger.Warn("OCI export unavailable: kubernetes client initialization failed", "error", err)
 		}
-		return newUnavailableOCIPublisherFactory(fmt.Errorf("oci export unavailable: kubernetes client: %w", err))
+		return newUnavailableOCIPublisherFactory(fmt.Errorf("oci export unavailable: kubernetes client: %w", err)), noop
 	}
 	httpClient, err := evalcards.NewOCIHTTPClient(serviceConfig, serviceConfig.IsOTELEnabled(), logger)
 	if err != nil {
+		helper.Close()
 		if logger != nil {
 			logger.Warn("OCI export unavailable: failed to create oci http client", "error", err)
 		}
-		return newUnavailableOCIPublisherFactory(fmt.Errorf("oci export unavailable: http client: %w", err))
+		return newUnavailableOCIPublisherFactory(fmt.Errorf("oci export unavailable: http client: %w", err)), noop
 	}
 	return evalcards.NewOCIPublisherFactory(
 		newKubernetesDockerConfigSecretGetter(helper),
 		httpClient,
-	)
+	), helper.Close
 }
 
 type unavailableOCIPublisherFactory struct {

--- a/internal/eval_hub/server/oci_export.go
+++ b/internal/eval_hub/server/oci_export.go
@@ -54,7 +54,7 @@ func newOCIPublisherFactory(logger *slog.Logger, serviceConfig *config.Config) (
 	}
 	httpClient, err := evalcards.NewOCIHTTPClient(serviceConfig, serviceConfig.IsOTELEnabled(), logger)
 	if err != nil {
-		helper.Close()
+		_ = helper.Close()
 		if logger != nil {
 			logger.Warn("OCI export unavailable: failed to create oci http client", "error", err)
 		}
@@ -63,7 +63,7 @@ func newOCIPublisherFactory(logger *slog.Logger, serviceConfig *config.Config) (
 	return evalcards.NewOCIPublisherFactory(
 		newKubernetesDockerConfigSecretGetter(helper),
 		httpClient,
-	), helper.Close
+	), func() { _ = helper.Close() }
 }
 
 type unavailableOCIPublisherFactory struct {

--- a/internal/eval_hub/server/oci_export_test.go
+++ b/internal/eval_hub/server/oci_export_test.go
@@ -19,9 +19,10 @@ import (
 func TestNewOCIPublisherFactoryLocalModeReturnsNoop(t *testing.T) {
 	t.Parallel()
 
-	factory := newOCIPublisherFactory(nil, &config.Config{
+	factory, cleanup := newOCIPublisherFactory(nil, &config.Config{
 		Service: &config.ServiceConfig{LocalMode: true},
 	})
+	defer cleanup()
 	publisher, err := factory.NewPublisher(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("NewPublisher() err = %v", err)
@@ -37,7 +38,8 @@ func TestNewOCIPublisherFactoryLocalModeReturnsNoop(t *testing.T) {
 func TestNewOCIPublisherFactoryNilConfigReturnsNoop(t *testing.T) {
 	t.Parallel()
 
-	factory := newOCIPublisherFactory(nil, nil)
+	factory, cleanup := newOCIPublisherFactory(nil, nil)
+	defer cleanup()
 	publisher, err := factory.NewPublisher(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("NewPublisher() err = %v", err)
@@ -59,12 +61,13 @@ func TestNewOCIPublisherFactoryReturnsErrorWhenHTTPClientInitFails(t *testing.T)
 		t.Fatalf("WriteFile() err = %v", err)
 	}
 
-	factory := newOCIPublisherFactory(nil, &config.Config{
+	factory, cleanup := newOCIPublisherFactory(nil, &config.Config{
 		Service: &config.ServiceConfig{LocalMode: false},
 		Sidecar: &config.SidecarConfig{
 			OCI: &config.SidecarOCIConfig{CACertPath: badCA},
 		},
 	})
+	defer cleanup()
 	_, err := factory.NewPublisher(context.Background(), &api.EvaluationJobResource{
 		EvaluationJobConfig: api.EvaluationJobConfig{
 			Exports: &api.EvaluationExports{OCI: &api.EvaluationExportsOCI{}},
@@ -122,9 +125,10 @@ func TestNewOCIPublisherFactoryClusterModeUsesRealFactory(t *testing.T) {
 		t.Skipf("kubernetes client unavailable: %v", err)
 	}
 
-	factory := newOCIPublisherFactory(nil, &config.Config{
+	factory, cleanup := newOCIPublisherFactory(nil, &config.Config{
 		Service: &config.ServiceConfig{LocalMode: false},
 	})
+	defer cleanup()
 	_, err := factory.NewPublisher(context.Background(), &api.EvaluationJobResource{
 		Resource: api.EvaluationResource{Resource: api.Resource{ID: "job-1", Tenant: "tenant-a"}},
 		EvaluationJobConfig: api.EvaluationJobConfig{

--- a/internal/eval_hub/server/server.go
+++ b/internal/eval_hub/server/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	runtime         abstractions.Runtime
 	mlflowClient    *mlflowclient.Client
 	resultsExporter evalcards.ResultsExporter
+	ociCleanup      func()
 }
 
 func (s *Server) isOTELEnabled() bool {
@@ -84,9 +85,10 @@ func NewServer(logger *slog.Logger,
 		return nil, fmt.Errorf("validator is required for the server")
 	}
 
+	ociFactory, ociCleanup := newOCIPublisherFactory(logger, serviceConfig)
 	resultsExporter := evalcards.NewManager(logger, evalcards.ManagerConfig{
 		MLFlowClient:        mlflowClient,
-		OCIPublisherFactory: newOCIPublisherFactory(logger, serviceConfig),
+		OCIPublisherFactory: ociFactory,
 	})
 
 	return &Server{
@@ -98,6 +100,7 @@ func NewServer(logger *slog.Logger,
 		runtime:         runtime,
 		mlflowClient:    mlflowClient,
 		resultsExporter: resultsExporter,
+		ociCleanup:      ociCleanup,
 	}, nil
 }
 
@@ -545,6 +548,9 @@ func (s *Server) Start() error {
 
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Info("Shutting down API server gracefully...")
+	if s.ociCleanup != nil {
+		s.ociCleanup()
+	}
 	return s.httpServer.Shutdown(ctx)
 }
 

--- a/internal/eval_hub/server/server_test.go
+++ b/internal/eval_hub/server/server_test.go
@@ -96,6 +96,8 @@ func (r *stubRuntime) GetEvaluationLogs(
 ) (string, error) {
 	return "", nil
 }
+func (r *stubRuntime) NotifyJobPhaseTransition(_ context.Context, _ *api.EvaluationJobResource, _ int, _ api.State) {
+}
 
 func (r *stubRuntime) ValidateHardwareProfiles(_ []api.EvaluationBenchmarkConfig) error {
 	return nil

--- a/internal/otel/job_logs_test.go
+++ b/internal/otel/job_logs_test.go
@@ -136,3 +136,5 @@ func (r *stubLogsRuntime) GetEvaluationLogs(_ *api.EvaluationJobResource, _ []ap
 func (r *stubLogsRuntime) ValidateHardwareProfiles(_ []api.EvaluationBenchmarkConfig) error {
 	return nil
 }
+func (r *stubLogsRuntime) NotifyJobPhaseTransition(_ context.Context, _ *api.EvaluationJobResource, _ int, _ api.State) {
+}

--- a/tests/features/k8s_fvt_helper.go
+++ b/tests/features/k8s_fvt_helper.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -128,17 +127,3 @@ func (c *fvtK8sClient) waitForEventOnJob(ctx context.Context, namespace, jobName
 	}
 }
 
-// listEventsForJob returns all Kubernetes Events for the Job backing the given eval-hub job ID.
-func (c *fvtK8sClient) listEventsForJob(ctx context.Context, namespace, jobName string) ([]corev1.Event, error) {
-	fieldSelector := fmt.Sprintf(
-		"involvedObject.name=%s,involvedObject.kind=Job,involvedObject.namespace=%s",
-		jobName, namespace,
-	)
-	list, err := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
-		FieldSelector: fieldSelector,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return list.Items, nil
-}

--- a/tests/features/k8s_fvt_helper.go
+++ b/tests/features/k8s_fvt_helper.go
@@ -126,4 +126,3 @@ func (c *fvtK8sClient) waitForEventOnJob(ctx context.Context, namespace, jobName
 		}
 	}
 }
-

--- a/tests/features/k8s_fvt_helper.go
+++ b/tests/features/k8s_fvt_helper.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -62,6 +64,79 @@ func (c *fvtK8sClient) listJobs(ctx context.Context, namespace, labelSelector st
 		return nil, fmt.Errorf("namespace is required")
 	}
 	list, err := c.clientset.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// getJobNameForEvalJob returns the name of the Kubernetes Job backing the given eval-hub job ID.
+func (c *fvtK8sClient) getJobNameForEvalJob(ctx context.Context, namespace, evalJobID string) (string, error) {
+	labelSelector := fmt.Sprintf("job_id=%s", evalJobID)
+	jobs, err := c.listJobs(ctx, namespace, labelSelector)
+	if err != nil {
+		return "", fmt.Errorf("list jobs for eval job %s: %w", evalJobID, err)
+	}
+	if len(jobs) == 0 {
+		return "", fmt.Errorf("no Kubernetes Job found for eval job %s in namespace %s", evalJobID, namespace)
+	}
+	return jobs[0].Name, nil
+}
+
+// getJobPhaseLabel returns the value of the trustyai.opendatahub.io/evaluation-phase label
+// on the Kubernetes Job backing the given eval-hub job ID, or "" if the label is absent.
+func (c *fvtK8sClient) getJobPhaseLabel(ctx context.Context, namespace, evalJobID string) (string, error) {
+	labelSelector := fmt.Sprintf("job_id=%s", evalJobID)
+	jobs, err := c.listJobs(ctx, namespace, labelSelector)
+	if err != nil {
+		return "", fmt.Errorf("list jobs for eval job %s: %w", evalJobID, err)
+	}
+	if len(jobs) == 0 {
+		return "", fmt.Errorf("no Kubernetes Job found for eval job %s in namespace %s", evalJobID, namespace)
+	}
+	return jobs[0].Labels["trustyai.opendatahub.io/evaluation-phase"], nil
+}
+
+// waitForEventOnJob polls the Kubernetes Events API until an event with the given reason is found
+// on the Job named jobName (involvedObject.kind=Job). It returns on the first match or when ctx
+// is cancelled.
+func (c *fvtK8sClient) waitForEventOnJob(ctx context.Context, namespace, jobName, reason string) error {
+	if namespace == "" || jobName == "" || reason == "" {
+		return fmt.Errorf("namespace, jobName and reason are required")
+	}
+	fieldSelector := fmt.Sprintf(
+		"involvedObject.name=%s,involvedObject.kind=Job,involvedObject.namespace=%s,reason=%s",
+		jobName, namespace, reason,
+	)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for Kubernetes Event reason=%s on Job %s/%s", reason, namespace, jobName)
+		case <-ticker.C:
+			list, err := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+				FieldSelector: fieldSelector,
+			})
+			if err != nil {
+				continue
+			}
+			if len(list.Items) > 0 {
+				return nil
+			}
+		}
+	}
+}
+
+// listEventsForJob returns all Kubernetes Events for the Job backing the given eval-hub job ID.
+func (c *fvtK8sClient) listEventsForJob(ctx context.Context, namespace, jobName string) ([]corev1.Event, error) {
+	fieldSelector := fmt.Sprintf(
+		"involvedObject.name=%s,involvedObject.kind=Job,involvedObject.namespace=%s",
+		jobName, namespace,
+	)
+	list, err := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: fieldSelector,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/tests/features/k8s_lifecycle_signals.feature
+++ b/tests/features/k8s_lifecycle_signals.feature
@@ -27,7 +27,7 @@ Feature: Kubernetes Lifecycle Signals
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
     Then the response code should be 202
     And I wait for the Kubernetes evaluation Job to be created
-    And the evaluation Job should have label "trustyai.opendatahub.io/evaluation-phase" equal to "Pending"
+    And I wait for the evaluation Job to have label "trustyai.opendatahub.io/evaluation-phase" equal to "Pending" within "30s"
     And I wait for the evaluation Job to have label "trustyai.opendatahub.io/evaluation-phase" equal to "Running" within "5m"
     And I wait for the evaluation job status to be "completed"
     And the evaluation Job should have label "trustyai.opendatahub.io/evaluation-phase" equal to "Completed"

--- a/tests/features/k8s_lifecycle_signals.feature
+++ b/tests/features/k8s_lifecycle_signals.feature
@@ -1,0 +1,47 @@
+@cluster
+@k8s_lifecycle
+Feature: Kubernetes Lifecycle Signals
+  As a platform operator
+  I want evaluation Jobs to emit Kubernetes Events and carry an evaluation-phase label
+  So that I can observe evaluation lifecycle transitions without direct EvalHub API access
+
+  Background:
+    Given I set the header "X-Tenant" to "{{env:X_TENANT|test-tenant}}"
+    And I set the header "X-User" to "{{env:X_USER|test-user}}"
+    And I set the wait deadline to "{{env:WAIT_DEADLINE|30m}}"
+    And the model endpoint is reachable
+    And the value "{{env:MODEL_AUTH_SECRET_REF}}" is not empty
+
+  Scenario: Kubernetes Events are emitted for a completed evaluation job
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
+    Then the response code should be 202
+    And I wait for the evaluation job status to be "completed"
+    Then I observe a Kubernetes Event with reason "EvaluationRunning" for the evaluation job within "60s"
+    And I observe a Kubernetes Event with reason "EvaluationCompleted" for the evaluation job within "60s"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+
+  Scenario: Evaluation Job carries the evaluation-phase label at each lifecycle state
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job.json"
+    Then the response code should be 202
+    And I wait for the Kubernetes evaluation Job to be created
+    And the evaluation Job should have label "trustyai.opendatahub.io/evaluation-phase" equal to "Pending"
+    And I wait for the evaluation Job to have label "trustyai.opendatahub.io/evaluation-phase" equal to "Running" within "5m"
+    And I wait for the evaluation job status to be "completed"
+    And the evaluation Job should have label "trustyai.opendatahub.io/evaluation-phase" equal to "Completed"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+
+  @negative
+  Scenario: EvaluationFailed event is emitted when an evaluation job fails
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_invalid_model.json"
+    Then the response code should be 202
+    And I wait for the evaluation job status to match "completed|failed"
+    Then I observe a Kubernetes Event with reason "EvaluationFailed" for the evaluation job within "60s"
+    And the evaluation Job should have label "trustyai.opendatahub.io/evaluation-phase" equal to "Failed"
+    When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
+    Then the response code should be 204
+

--- a/tests/features/k8s_lifecycle_signals_step_definitions_test.go
+++ b/tests/features/k8s_lifecycle_signals_step_definitions_test.go
@@ -114,19 +114,20 @@ func (tc *scenarioConfig) iWaitForEvaluationJobToHaveLabelEqualToWithin(state *l
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
+	var lastObserved string
 	for {
 		select {
 		case <-ctx.Done():
-			actual, _ := state.k8s.getJobPhaseLabel(context.Background(), namespace, tc.lastId)
 			return tc.logError(fmt.Errorf(
 				"timeout waiting for label %s=%s on eval job %s (last observed: %q)",
-				labelKey, expectedValue, tc.lastId, actual,
+				labelKey, expectedValue, tc.lastId, lastObserved,
 			))
 		case <-ticker.C:
 			actual, err := state.k8s.getJobPhaseLabel(ctx, namespace, tc.lastId)
 			if err != nil {
 				continue
 			}
+			lastObserved = actual
 			if actual == expectedValue {
 				logDebug("Label %s=%s observed on eval job %s\n", labelKey, actual, tc.lastId)
 				return nil

--- a/tests/features/k8s_lifecycle_signals_step_definitions_test.go
+++ b/tests/features/k8s_lifecycle_signals_step_definitions_test.go
@@ -1,0 +1,170 @@
+package features
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+)
+
+type lifecycleSignalsState struct {
+	k8s *fvtK8sClient
+}
+
+func (s *lifecycleSignalsState) reset() {
+	s.k8s = nil
+}
+
+func (s *lifecycleSignalsState) initHelper() error {
+	if s.k8s != nil {
+		return nil
+	}
+	client, err := newFVTK8sClient()
+	if err != nil {
+		return fmt.Errorf("create fvt kubernetes client: %w", err)
+	}
+	s.k8s = client
+	return nil
+}
+
+// iObserveKubernetesEventWithReasonWithin polls the Events API until an event with the given
+// reason appears on the Kubernetes Job backing the current evaluation job, or the timeout elapses.
+func (tc *scenarioConfig) iObserveKubernetesEventWithReasonWithin(state *lifecycleSignalsState, reason, timeoutStr string) error {
+	if tc.lastId == "" {
+		return tc.logError(fmt.Errorf("no evaluation job ID found; submit a job before asserting events"))
+	}
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		return tc.logError(fmt.Errorf("parse timeout %q: %w", timeoutStr, err))
+	}
+	if err := state.initHelper(); err != nil {
+		return tc.logError(err)
+	}
+
+	namespace := tc.tenantNamespace()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	jobName, err := state.k8s.getJobNameForEvalJob(ctx, namespace, tc.lastId)
+	if err != nil {
+		return tc.logError(fmt.Errorf("find Kubernetes Job for eval job %s: %w", tc.lastId, err))
+	}
+	logDebug("Waiting for Kubernetes Event reason=%s on Job %s/%s within %s\n", reason, namespace, jobName, timeoutStr)
+
+	if err := state.k8s.waitForEventOnJob(ctx, namespace, jobName, reason); err != nil {
+		return tc.logError(err)
+	}
+	logDebug("Observed Kubernetes Event reason=%s on Job %s\n", reason, jobName)
+	return nil
+}
+
+// theEvaluationJobShouldHaveLabelEqualTo does an immediate (non-polling) check that the label
+// on the Kubernetes Job backing the current evaluation job matches the expected value.
+func (tc *scenarioConfig) theEvaluationJobShouldHaveLabelEqualTo(state *lifecycleSignalsState, labelKey, expectedValue string) error {
+	if tc.lastId == "" {
+		return tc.logError(fmt.Errorf("no evaluation job ID found"))
+	}
+	if err := state.initHelper(); err != nil {
+		return tc.logError(err)
+	}
+	namespace := tc.tenantNamespace()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if labelKey == "trustyai.opendatahub.io/evaluation-phase" {
+		actual, err := state.k8s.getJobPhaseLabel(ctx, namespace, tc.lastId)
+		if err != nil {
+			return tc.logError(err)
+		}
+		if actual != expectedValue {
+			return tc.logError(fmt.Errorf("expected label %s=%s on eval job %s, got %q", labelKey, expectedValue, tc.lastId, actual))
+		}
+		logDebug("Verified label %s=%s on Kubernetes Job for eval job %s\n", labelKey, actual, tc.lastId)
+		return nil
+	}
+	return tc.logError(fmt.Errorf("unsupported label key %q in lifecycle signal step", labelKey))
+}
+
+// iWaitForEvaluationJobToHaveLabelEqualToWithin polls until the label on the backing Kubernetes
+// Job equals expectedValue or the timeout elapses.
+func (tc *scenarioConfig) iWaitForEvaluationJobToHaveLabelEqualToWithin(state *lifecycleSignalsState, labelKey, expectedValue, timeoutStr string) error {
+	if tc.lastId == "" {
+		return tc.logError(fmt.Errorf("no evaluation job ID found"))
+	}
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		return tc.logError(fmt.Errorf("parse timeout %q: %w", timeoutStr, err))
+	}
+	if err := state.initHelper(); err != nil {
+		return tc.logError(err)
+	}
+
+	namespace := tc.tenantNamespace()
+
+	if labelKey != "trustyai.opendatahub.io/evaluation-phase" {
+		return tc.logError(fmt.Errorf("unsupported label key %q in lifecycle signal step", labelKey))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	logDebug("Waiting for label %s=%s on eval job %s within %s\n", labelKey, expectedValue, tc.lastId, timeoutStr)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			actual, _ := state.k8s.getJobPhaseLabel(context.Background(), namespace, tc.lastId)
+			return tc.logError(fmt.Errorf(
+				"timeout waiting for label %s=%s on eval job %s (last observed: %q)",
+				labelKey, expectedValue, tc.lastId, actual,
+			))
+		case <-ticker.C:
+			actual, err := state.k8s.getJobPhaseLabel(ctx, namespace, tc.lastId)
+			if err != nil {
+				continue
+			}
+			if actual == expectedValue {
+				logDebug("Label %s=%s observed on eval job %s\n", labelKey, actual, tc.lastId)
+				return nil
+			}
+		}
+	}
+}
+
+// InitializeLifecycleSignalSteps registers the Kubernetes lifecycle signal FVT steps.
+func InitializeLifecycleSignalSteps(ctx *godog.ScenarioContext, tc *scenarioConfig) {
+	state := &lifecycleSignalsState{}
+
+	ctx.Before(func(goCtx context.Context, sc *godog.Scenario) (context.Context, error) {
+		for _, t := range sc.Tags {
+			if strings.TrimPrefix(t.Name, "@") == "k8s_lifecycle" {
+				state.reset()
+				break
+			}
+		}
+		return goCtx, nil
+	})
+
+	ctx.Step(
+		`^I observe a Kubernetes Event with reason "([^"]*)" for the evaluation job within "([^"]*)"$`,
+		func(reason, timeout string) error {
+			return tc.iObserveKubernetesEventWithReasonWithin(state, reason, timeout)
+		},
+	)
+	ctx.Step(
+		`^the evaluation Job should have label "([^"]*)" equal to "([^"]*)"$`,
+		func(labelKey, expected string) error {
+			return tc.theEvaluationJobShouldHaveLabelEqualTo(state, labelKey, expected)
+		},
+	)
+	ctx.Step(
+		`^I wait for the evaluation Job to have label "([^"]*)" equal to "([^"]*)" within "([^"]*)"$`,
+		func(labelKey, expected, timeout string) error {
+			return tc.iWaitForEvaluationJobToHaveLabelEqualToWithin(state, labelKey, expected, timeout)
+		},
+	)
+}

--- a/tests/features/suite_bootstrap_test.go
+++ b/tests/features/suite_bootstrap_test.go
@@ -596,4 +596,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 
 	// Hardware profile steps (Kubernetes client-go via KUBECONFIG-first FVT helper)
 	InitializeHardwareProfileSteps(ctx, tc)
+
+	// Kubernetes lifecycle signal steps (event emission and evaluation-phase label)
+	InitializeLifecycleSignalSteps(ctx, tc)
 }


### PR DESCRIPTION
 ## What and why

Extends the EvalHub server to emit Kubernetes Events and maintain a `trustyai.opendatahub.io/evaluation-phase` label on evaluation Job resources as they transition through their lifecycle. This makes evaluation state observable via `kubectl get events`, Kubernetes watch/informer patterns, and label-selector queries — without requiring direct EvalHub API access.

Closes RHAI-277 / RHOAIENG-80105 / RHOAIENG-80106 / RHOAIENG-80107 / RHOAIENG-80104

> **Note:** RBAC changes (events:create, jobs:patch/get) are tracked separately
> in the operator repo under RHOAIENG-80108.

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

Unit tests cover `EmitEvent`, `PatchJobPhaseLabel`, and `NotifyJobPhaseTransition` including best-effort error paths.

Three `@cluster @k8s_lifecycle` Godog FVT scenarios verify end-to-end behaviour against a live cluster:

1. **Event emission (happy path)** — `EvaluationRunning` and `EvaluationCompleted` Events appear on the backing Job within 60 s.
2. **Phase label transitions** — label progresses `Pending → Running → Completed` and is queryable by label selector without EvalHub API access (informer-compatible).
3. **EvaluationFailed (`@negative`)** — failed job emits an `EvaluationFailed` Warning Event and the label is set to `Failed`.

## Breaking changes

None. Event emission and label patching are best-effort side effects; evaluation job lifecycle is unaffected if the Kubernetes API server is temporarily unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubernetes evaluation Jobs now display phase labels for pending, running, completed, and failed states.
  * Kubernetes Events are emitted when evaluations complete or fail, improving lifecycle visibility.
  * Evaluation updates now trigger runtime lifecycle notifications.
  * Runtime and server shutdowns now clean up Kubernetes resources gracefully.

* **Tests**
  * Added coverage for lifecycle labels, Kubernetes Events, state transitions, error handling, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->