### PR TITLE
chore(ci): group related GitHub Actions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,18 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      # Composite actions (e.g. codeql-action/init vs analyze) are separate
+      # Dependabot deps; group by prefix so related bumps share one PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
+      docker-actions:
+        patterns:
+          - "docker/*"
+      github-actions-core:
+        patterns:
+          - "actions/*"
 
   - package-ecosystem: gomod
     directory: /


### PR DESCRIPTION
## Summary
- Groups Dependabot GitHub Actions updates by related prefixes so composite actions (e.g. `codeql-action/init`, `analyze`, `autobuild`, `upload-sarif`) land in one PR instead of separate ones like #840.
- Also groups `docker/*` and `actions/*` the same way.

## Test plan
- [ ] Confirm `.github/dependabot.yml` validates (Dependabot config check on this PR)
- [ ] After merge, next CodeQL Action bump should open a single grouped PR covering all `github/codeql-action*` usages


Made with [Cursor](https://cursor.com)