### PR TITLE
fix: remove hard-coded sidecar image from config

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -83,7 +83,6 @@ sidecar:
   #   ca_cert_path: /etc/pki/ca-trust/source/anchors/registry-ca.crt  # optional
   #   insecure_skip_verify: false
   sidecar_container:
-    image: quay.io/rh-ee-nbs/nbs-dev:eval-hub_v27
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## What and why

remove hard-coded sidecar image from config

Closes #

Assisted-by: <!-- Cursor, Claude etc -->

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [X] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an obsolete sidecar container image configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->