### PR TITLE
fix(evalhubclient): remove InsecureSkipVerify for API TLS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,9 +186,9 @@ make build-mcp
 go test -v ./cmd/evalhub_mcp/ ./internal/evalhub_mcp/...
 ```
 
-**CLI flags:** `--transport stdio|http|http-sse` (`http` = Streamable HTTP, default for remote; `http-sse` = legacy HTTP+SSE only), `--host`, `--port`, `--config`, `--insecure`, `--version`
+**CLI flags:** `--transport stdio|http|http-sse` (`http` = Streamable HTTP, default for remote; `http-sse` = legacy HTTP+SSE only), `--host`, `--port`, `--config`, `--version`
 
-**Configuration precedence:** CLI flags > env vars (`EVALHUB_BASE_URL`, `EVALHUB_TOKEN`, `EVALHUB_TENANT`, `EVALHUB_INSECURE`, `EVALHUB_LIST_PAGE_LIMIT`) > YAML config (`~/.evalhub/config.yaml`)
+**Configuration precedence:** CLI flags > env vars (`EVALHUB_BASE_URL`, `EVALHUB_TOKEN`, `EVALHUB_TENANT`, `EVALHUB_CA_CERT_PATH`, `EVALHUB_LIST_PAGE_LIMIT`) > YAML config (`~/.evalhub/config.yaml`)
 
 **Architecture:**
 

--- a/MCP.md
+++ b/MCP.md
@@ -68,6 +68,8 @@ export EVALHUB_TOKEN="<your-token>"
 export EVALHUB_TENANT="<your-tenant>"
 ```
 
+For APIs that present a private or cluster CA (for example OpenShift service CA), set `ca_cert_path` / `EVALHUB_CA_CERT_PATH` to a PEM bundle. TLS certificate verification is always enabled; there is no skip-verify option.
+
 For stdio transport (Cursor, VS Code, Claude Code), pass these in the MCP client's `env` block rather than in HTTP headers.
 
 ### Configuration reference
@@ -77,14 +79,14 @@ YAML keys and environment variables (env overrides YAML):
 | Setting | YAML key | Environment variable |
 |---------|----------|----------------------|
 | Auth mode | `auth_type` | `EVALHUB_AUTH_TYPE` |
-| Skip TLS verification (eval-hub API) | `insecure` | `EVALHUB_INSECURE` |
 | Eval-hub API URL | `base_url` | `EVALHUB_BASE_URL` |
 | Eval-hub token | `token` | `EVALHUB_TOKEN` |
 | Eval-hub tenant | `tenant` | `EVALHUB_TENANT` |
+| Custom CA for eval-hub API TLS | `ca_cert_path` | `EVALHUB_CA_CERT_PATH` |
 | Transport | `transport` | `EVALHUB_TRANSPORT` |
 | HTTP host / port | `host`, `port` | `EVALHUB_HOST`, `EVALHUB_PORT` |
 
-CLI flags override YAML and environment variables when set: `--auth-type`, `--transport`, `--host`, `--port`, `--insecure`, `--tls-cert`, `--tls-key`.
+CLI flags override YAML and environment variables when set: `--auth-type`, `--transport`, `--host`, `--port`, `--tls-cert`, `--tls-key`.
 
 Load a config file with `--config /path/to/config.yaml` or `~/.evalhub/config.yaml`.
 

--- a/cmd/evalhub_mcp/main.go
+++ b/cmd/evalhub_mcp/main.go
@@ -38,7 +38,6 @@ func run(args []string) int {
 	host := fs.String("host", "localhost", "Host to bind HTTP server to")
 	port := fs.Int("port", 3001, "Port for HTTP server")
 	configPath := fs.String("config", "", "Path to configuration file")
-	insecure := fs.Bool("insecure", false, "Disable TLS certificate verification")
 	tlsCertFile := fs.String("tls-cert", "", "Path to TLS certificate file")
 	tlsKeyFile := fs.String("tls-key", "", "Path to TLS private key file")
 	authType := fs.String("auth-type", "none", "Inbound HTTP authentication: none or rbac-proxy")
@@ -71,9 +70,6 @@ func run(args []string) int {
 	}
 	if fs.Changed("port") {
 		flags.Port = port
-	}
-	if fs.Changed("insecure") {
-		flags.Insecure = insecure
 	}
 	if fs.Changed("tls-cert") {
 		flags.TLSCertFile = tlsCertFile

--- a/config/mcp_local.yaml
+++ b/config/mcp_local.yaml
@@ -1,7 +1,6 @@
 base_url: http://localhost:8080
 token: token
 tenant: tenant
-insecure: false
 # Streamable HTTP (default for remote); use http-sse only for legacy MCP clients.
 transport: http
 host: localhost

--- a/internal/evalhub_mcp/config/config.go
+++ b/internal/evalhub_mcp/config/config.go
@@ -30,7 +30,6 @@ type Config struct {
 	BaseURL       string `mapstructure:"base_url,omitempty" validate:"omitempty,url"`
 	Token         string `mapstructure:"token"`
 	Tenant        string `mapstructure:"tenant"`
-	Insecure      bool   `mapstructure:"insecure"`
 	Transport     string `mapstructure:"transport" validate:"required,oneof=stdio http http-sse"` // default stdio; use http for remote
 	Host          string `mapstructure:"host"      validate:"required"`
 	Port          int    `mapstructure:"port,omitempty" validate:"omitempty,min=1,max=65535"`
@@ -45,7 +44,6 @@ type Flags struct {
 	Transport   *string
 	Host        *string
 	Port        *int
-	Insecure    *bool
 	AuthType    *string
 	ConfigPath  string
 	TLSCertFile *string
@@ -172,7 +170,6 @@ func applyYAMLConfig(cfg *Config, path string) (*Config, error) {
 		"base_url", "EVALHUB_BASE_URL",
 		"token", "EVALHUB_TOKEN",
 		"tenant", "EVALHUB_TENANT",
-		"insecure", "EVALHUB_INSECURE",
 		"transport", "EVALHUB_TRANSPORT",
 		"host", "EVALHUB_HOST",
 		"port", "EVALHUB_PORT",
@@ -190,7 +187,6 @@ func applyYAMLConfig(cfg *Config, path string) (*Config, error) {
 		v.SetDefault("base_url", cfg.BaseURL)
 		v.SetDefault("token", cfg.Token)
 		v.SetDefault("tenant", cfg.Tenant)
-		v.SetDefault("insecure", cfg.Insecure)
 		v.SetDefault("transport", cfg.Transport)
 		v.SetDefault("host", cfg.Host)
 		v.SetDefault("port", cfg.Port)
@@ -245,9 +241,6 @@ func applyFlags(cfg *Config, flags *Flags) {
 	}
 	if flags.Port != nil {
 		cfg.Port = *flags.Port
-	}
-	if flags.Insecure != nil {
-		cfg.Insecure = *flags.Insecure
 	}
 	if flags.TLSCertFile != nil {
 		cfg.TLSCertFile = *flags.TLSCertFile

--- a/internal/evalhub_mcp/config/config_test.go
+++ b/internal/evalhub_mcp/config/config_test.go
@@ -30,9 +30,6 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Tenant != "" {
 		t.Errorf("expected empty default tenant, got %q", cfg.Tenant)
 	}
-	if cfg.Insecure {
-		t.Error("expected default insecure to be false")
-	}
 	if cfg.ListPageLimit != evalhubclient.DefaultListPageLimit {
 		t.Errorf("expected default list_page_limit %d, got %d", evalhubclient.DefaultListPageLimit, cfg.ListPageLimit)
 	}
@@ -60,7 +57,6 @@ func TestLoadEnvVars(t *testing.T) {
 	t.Setenv("EVALHUB_BASE_URL", "http://env-host:9090")
 	t.Setenv("EVALHUB_TOKEN", "env-token")
 	t.Setenv("EVALHUB_TENANT", "env-tenant")
-	t.Setenv("EVALHUB_INSECURE", "true")
 
 	cfg, err := Load(nil, nil)
 	if err != nil {
@@ -76,9 +72,6 @@ func TestLoadEnvVars(t *testing.T) {
 	}
 	if cfg.Tenant != "env-tenant" {
 		t.Errorf("expected tenant from env, got %q", cfg.Tenant)
-	}
-	if !cfg.Insecure {
-		t.Error("expected insecure=true from env")
 	}
 }
 
@@ -132,20 +125,17 @@ func TestLoadCLIFlagsOverrideYAMLAndEnv(t *testing.T) {
 
 	configFile := writeConfig(t, `
     base_url: http://yaml-host:8080
-    insecure: false
 `)
 
 	transport := "http"
 	host := "0.0.0.0"
 	port := 4000
-	insecure := true
 
 	flags := &Flags{
 		ConfigPath: configFile,
 		Transport:  &transport,
 		Host:       &host,
 		Port:       &port,
-		Insecure:   &insecure,
 	}
 	cfg, err := Load(flags, nil)
 	if err != nil {
@@ -160,9 +150,6 @@ func TestLoadCLIFlagsOverrideYAMLAndEnv(t *testing.T) {
 	}
 	if cfg.Port != 4000 {
 		t.Errorf("expected CLI port 4000, got %d", cfg.Port)
-	}
-	if !cfg.Insecure {
-		t.Error("expected CLI insecure=true to override YAML")
 	}
 	if cfg.BaseURL != "http://env-host:9090" {
 		t.Errorf("expected YAML base_url (not env), got %q", cfg.BaseURL)
@@ -201,40 +188,21 @@ func TestLoadMalformedYAML(t *testing.T) {
 	}
 }
 
-func TestLoadProfileInsecurePointer(t *testing.T) {
+func TestLoadProfileWithEnvOverride(t *testing.T) {
 	clearEnv(t)
 	defer clearEnv(t)
+	t.Setenv("EVALHUB_TOKEN", "my-token")
 
 	configFile := writeConfig(t, `
-    base_url: http://localhost:8080
-    insecure: false
+    token: old-token
 `)
 
 	cfg, err := Load(&Flags{ConfigPath: configFile}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Insecure {
-		t.Error("expected YAML insecure=false to override env insecure=true")
-	}
-}
-
-func TestLoadProfileInsecurePointerWithEnvOverride(t *testing.T) {
-	clearEnv(t)
-	defer clearEnv(t)
-	t.Setenv("EVALHUB_INSECURE", "true")
-
-	configFile := writeConfig(t, `
-    base_url: http://localhost:8080
-    insecure: false
-`)
-
-	cfg, err := Load(&Flags{ConfigPath: configFile}, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !cfg.Insecure {
-		t.Error("expected YAML insecure=false to override env insecure=true")
+	if cfg.Token != "my-token" {
+		t.Error("expected env token to override YAML token")
 	}
 }
 
@@ -348,16 +316,6 @@ func TestValidateBaseURL(t *testing.T) {
 			t.Error("expected invalid URL to fail validation")
 		}
 	})
-}
-
-func TestEnvVarInsecureInvalidValue(t *testing.T) {
-	clearEnv(t)
-	t.Setenv("EVALHUB_INSECURE", "not-a-bool")
-
-	_, err := Load(nil, nil)
-	if err == nil {
-		t.Fatal("expected error for invalid EVALHUB_INSECURE value")
-	}
 }
 
 func TestLoadEmptyProfilesSection(t *testing.T) {
@@ -610,7 +568,7 @@ func TestLoadFlagsTLS(t *testing.T) {
 func clearEnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
-		"EVALHUB_BASE_URL", "EVALHUB_TOKEN", "EVALHUB_TENANT", "EVALHUB_INSECURE",
+		"EVALHUB_BASE_URL", "EVALHUB_TOKEN", "EVALHUB_TENANT",
 		"EVALHUB_TRANSPORT", "EVALHUB_HOST", "EVALHUB_PORT",
 		"EVALHUB_LIST_PAGE_LIMIT", "EVALHUB_TLS_CERT_FILE", "EVALHUB_TLS_KEY_FILE",
 		"EVALHUB_AUTH_TYPE", "EVALHUB_CA_CERT_PATH",

--- a/internal/evalhub_mcp/server/server.go
+++ b/internal/evalhub_mcp/server/server.go
@@ -87,9 +87,6 @@ func NewEvalHubClient(cfg *config.Config, logger *slog.Logger) *evalhubclient.Cl
 	if cfg.Tenant != "" {
 		client = client.WithTenant(cfg.Tenant)
 	}
-	if cfg.Insecure {
-		client = client.WithInsecureSkipVerify()
-	}
 	if cfg.CACertPath != "" {
 		pemData, err := os.ReadFile(cfg.CACertPath)
 		if err != nil {
@@ -103,7 +100,7 @@ func NewEvalHubClient(cfg *config.Config, logger *slog.Logger) *evalhubclient.Cl
 			}
 		}
 	}
-	logger.Info("EvalHub client created", "baseURL", cfg.BaseURL, "tenant", cfg.Tenant, "insecure", cfg.Insecure, "caCertPath", cfg.CACertPath)
+	logger.Info("EvalHub client created", "baseURL", cfg.BaseURL, "tenant", cfg.Tenant, "caCertPath", cfg.CACertPath)
 	return client
 }
 

--- a/internal/evalhub_mcp/server/server_test.go
+++ b/internal/evalhub_mcp/server/server_test.go
@@ -62,10 +62,9 @@ func TestNewEvalHubClientNilWhenNoBaseURL(t *testing.T) {
 func TestNewEvalHubClientCreated(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{
-		BaseURL:  "http://localhost:8080",
-		Token:    "test-token",
-		Tenant:   "test-tenant",
-		Insecure: true,
+		BaseURL: "http://localhost:8080",
+		Token:   "test-token",
+		Tenant:  "test-tenant",
 	}
 	client := NewEvalHubClient(cfg, discardLogger)
 	if client == nil {

--- a/pkg/evalhubclient/client.go
+++ b/pkg/evalhubclient/client.go
@@ -142,29 +142,6 @@ func (c *Client) WithTimeout(timeout time.Duration) *Client {
 	return cp
 }
 
-// WithInsecureSkipVerify returns a copy of the client that skips TLS certificate verification.
-// Use only in development or test environments.
-func (c *Client) WithInsecureSkipVerify() *Client {
-	cp := c.clone()
-
-	// http.Transport contains a sync.Mutex and cannot be copied by value, so we
-	// always build a fresh transport. We do carry over any existing TLSClientConfig
-	// via its own safe Clone() so caller-configured cipher suites etc. are kept.
-	var tlsCfg *tls.Config
-	if existing, ok := c.httpClient.Transport.(*http.Transport); ok && existing.TLSClientConfig != nil {
-		tlsCfg = existing.TLSClientConfig.Clone()
-	} else {
-		tlsCfg = &tls.Config{} //nolint:gosec
-	}
-	tlsCfg.InsecureSkipVerify = true // #nosec G402
-
-	cp.httpClient = &http.Client{
-		Timeout:   c.httpClient.Timeout,
-		Transport: &http.Transport{TLSClientConfig: tlsCfg},
-	}
-	return cp
-}
-
 // WithCACert returns a copy of the client that trusts the PEM-encoded CA certificate(s)
 // in pemData in addition to the system certificate pool. Use this to trust a cluster-internal
 // CA (e.g. the OpenShift service CA) without disabling all certificate verification.

--- a/pkg/evalhubclient/client_test.go
+++ b/pkg/evalhubclient/client_test.go
@@ -279,31 +279,6 @@ func TestBackendUnreachable(t *testing.T) {
 	}
 }
 
-// ─── TLS InsecureSkipVerify ───────────────────────────────────────────────────
-
-func TestInsecureSkipVerify(t *testing.T) {
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(api.HealthResponse{Status: "ok"}) //nolint:errcheck
-	}))
-	t.Cleanup(srv.Close)
-
-	// Without InsecureSkipVerify the TLS server's self-signed cert will be rejected.
-	_, err := NewClient(srv.URL).WithMaxRetries(0).GetHealth()
-	if err == nil {
-		t.Fatal("expected TLS error without InsecureSkipVerify")
-	}
-
-	// With InsecureSkipVerify it should succeed.
-	got, err := NewClient(srv.URL).WithInsecureSkipVerify().GetHealth()
-	if err != nil {
-		t.Fatalf("GetHealth with InsecureSkipVerify: %v", err)
-	}
-	if got.Status != "ok" {
-		t.Errorf("Status = %q, want ok", got.Status)
-	}
-}
-
 // ─── Providers ────────────────────────────────────────────────────────────────
 
 func TestListProviders(t *testing.T) {

--- a/scripts/start_mcp.sh
+++ b/scripts/start_mcp.sh
@@ -20,7 +20,7 @@ run_mcp() {
   # Unset in this script (not a subshell) so SERVICE_PID=$! is the MCP process for PID_FILE and stop_server.sh.
   if [[ "${CONFIG_FILE}" != "" ]]; then
     unset EVALHUB_BASE_URL EVALHUB_TOKEN EVALHUB_TENANT
-    unset EVALHUB_TRANSPORT EVALHUB_HOST EVALHUB_PORT EVALHUB_LIST_PAGE_LIMIT
+    unset EVALHUB_TRANSPORT EVALHUB_HOST EVALHUB_PORT EVALHUB_LIST_PAGE_LIMIT EVALHUB_CA_CERT_PATH
     "${EXE}" --transport "${TRANSPORT}" --port "${MCP_PORT}" --config "${CONFIG_FILE}" >> "${LOGFILE}" 2>&1 &
   else
     "${EXE}" --transport "${TRANSPORT}" --port "${MCP_PORT}" >> "${LOGFILE}" 2>&1 &

--- a/scripts/start_mcp.sh
+++ b/scripts/start_mcp.sh
@@ -19,7 +19,7 @@ run_mcp() {
   # When using a config file, ignore stale EVALHUB_* from the shell (e.g. a bad test.env export).
   # Unset in this script (not a subshell) so SERVICE_PID=$! is the MCP process for PID_FILE and stop_server.sh.
   if [[ "${CONFIG_FILE}" != "" ]]; then
-    unset EVALHUB_BASE_URL EVALHUB_TOKEN EVALHUB_TENANT EVALHUB_INSECURE
+    unset EVALHUB_BASE_URL EVALHUB_TOKEN EVALHUB_TENANT
     unset EVALHUB_TRANSPORT EVALHUB_HOST EVALHUB_PORT EVALHUB_LIST_PAGE_LIMIT
     "${EXE}" --transport "${TRANSPORT}" --port "${MCP_PORT}" --config "${CONFIG_FILE}" >> "${LOGFILE}" 2>&1 &
   else

--- a/tests/mcp/CLAUDE_CODE_INTEGRATION.md
+++ b/tests/mcp/CLAUDE_CODE_INTEGRATION.md
@@ -20,7 +20,13 @@ Before starting integration verification, ensure:
    export EVALHUB_TENANT="<your-tenant>"
    ```
 
-   For dev/self-signed TLS environments, you may also need the `--insecure` flag on the binary.
+   For a backend that uses a private or cluster CA (self-signed or OpenShift service CA), also set:
+
+   ```bash
+   export EVALHUB_CA_CERT_PATH="/path/to/ca-bundle.pem"
+   ```
+
+   TLS verification is always enabled; use a CA bundle instead of disabling verification.
 
 ---
 
@@ -165,11 +171,7 @@ evalhub-mcp --transport http --host localhost --port 3001
 
 **Expected**: Server starts and logs indicate it is listening on `http://localhost:3001`.
 
-If using a dev environment with self-signed certs to the EvalHub backend:
-
-```bash
-evalhub-mcp --transport http --host localhost --port 3001 --insecure
-```
+If the EvalHub backend uses a private CA, set `EVALHUB_CA_CERT_PATH` (or `ca_cert_path` in the config file) before starting the server.
 
 ### Step 8 — Register the MCP Server in Claude Code (HTTP)
 

--- a/tests/mcp/vscode/test-scripts/common/mcp_client.sh
+++ b/tests/mcp/vscode/test-scripts/common/mcp_client.sh
@@ -43,7 +43,6 @@ mcp_stdio_start() {
   [[ -n "${EVALHUB_BASE_URL:-}" ]] && env_args+=(EVALHUB_BASE_URL="$EVALHUB_BASE_URL")
   [[ -n "${EVALHUB_TOKEN:-}" ]] && env_args+=(EVALHUB_TOKEN="$EVALHUB_TOKEN")
   [[ -n "${EVALHUB_TENANT:-}" ]] && env_args+=(EVALHUB_TENANT="$EVALHUB_TENANT")
-  [[ -n "${EVALHUB_INSECURE:-}" ]] && env_args+=(EVALHUB_INSECURE="$EVALHUB_INSECURE")
 
   if [[ ${#env_args[@]} -gt 0 ]]; then
     env "${env_args[@]}" "${cmd[@]}" \


### PR DESCRIPTION
## Summary
- Remove `WithInsecureSkipVerify` from `pkg/evalhubclient` and the MCP `--insecure` / `EVALHUB_INSECURE` / YAML `insecure` knobs that wired it.
- Keep TLS verification enabled for outbound eval-hub API calls; custom CAs remain supported via `WithCACert` / `EVALHUB_CA_CERT_PATH`.
- Update MCP docs and integration notes to document the CA-bundle path instead of skip-verify.

## Test plan
- [ ] `go test ./pkg/evalhubclient/ ./internal/evalhub_mcp/... ./cmd/evalhub_mcp/`
- [ ] Confirm MCP config no longer accepts `insecure` / `EVALHUB_INSECURE` / `--insecure`
- [ ] Confirm HTTPS eval-hub with a private CA works when `EVALHUB_CA_CERT_PATH` is set
- [ ] Confirm HTTPS eval-hub without a trusted CA fails (verification enforced)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom CA certificate configuration through `EVALHUB_CA_CERT_PATH` and `ca_cert_path`.
  * TLS certificate verification remains enabled when connecting to private or cluster endpoints.

* **Breaking Changes**
  * Removed the `--insecure` CLI option and `EVALHUB_INSECURE` environment variable.
  * Removed support for disabling TLS certificate verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->