### PR TITLE
chore(skills): add release-notes skill for OpenSSF releases

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -35,6 +35,21 @@ Git history and `gh` PR lists are **inputs only**. The published body must be a
 curated summary. GitHub `--generate-notes` alone is **not** sufficient output
 for this skill.
 
+## OpenSSF allowed implementations (may)
+
+> The release notes MAY be implemented in a variety of ways. Many projects
+> provide them in a file named "NEWS", "CHANGELOG", or "ChangeLog", optionally
+> with extensions such as ".txt", ".md", or ".html". Historically the term
+> "change log" meant a log of every change, but to meet these criteria what is
+> needed is a human-readable summary. The release notes MAY instead be provided
+> by version control system mechanisms such as the GitHub Releases workflow.
+
+**EvalHub choice:** publish curated notes via the **GitHub Releases** body for
+each tagged release (`vX.Y.Z`). Do not add a `NEWS` / `CHANGELOG` file unless
+the user explicitly asks for that as an additional channel. Either approach is
+valid under OpenSSF as long as the content is a human-readable summary (not a
+raw change log of every commit).
+
 ## How to invoke
 
 **Cursor:** Ask e.g. “Generate release notes for v1.0.0 using the release-notes

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: release-notes
+description: >
+  Draft human-readable GitHub release notes for a given version or tag.
+  Summarizes major changes and upgrade impact from merged PRs and conventional
+  commits (never raw git log). Use when writing release notes, preparing a
+  GitHub release, satisfying OpenSSF release-notes requirements, or when the
+  user asks to generate notes for a tag like v1.0.0.
+allowed-tools:
+  - Read
+  - Edit
+  - Bash(git *)
+  - Bash(gh *)
+  - Bash(grep *)
+  - Bash(jq *)
+  - Bash(sort *)
+  - Bash(sed *)
+  - Bash(cat *)
+---
+
+# Release Notes Skill
+
+Draft **human-readable** release notes for an EvalHub GitHub release so users can
+decide whether to upgrade and what the upgrade impact will be.
+
+## OpenSSF requirement (must satisfy)
+
+> The project MUST provide, in each release, release notes that are a
+> human-readable summary of major changes in that release to help users
+> determine if they should upgrade and what the upgrade impact will be. The
+> release notes MUST NOT be the raw output of a version control log (e.g., the
+> "git log" command results are not release notes).
+
+Git history and `gh` PR lists are **inputs only**. The published body must be a
+curated summary. GitHub `--generate-notes` alone is **not** sufficient output
+for this skill.
+
+## How to invoke
+
+**Cursor:** Ask e.g. “Generate release notes for v1.0.0 using the release-notes
+skill”. Optionally attach `@.claude/skills/release-notes/SKILL.md`.
+
+**Claude Code:** `/release-notes` or ask naturally (e.g. “Draft release notes
+for the next tag”).
+
+## Procedure
+
+Follow these steps **in order**. Do not skip steps.
+
+### Step 1 — Resolve the target version
+
+Accept an explicit tag/version from the user (e.g. `v1.0.0` or `1.0.0`).
+
+If none is given:
+
+1. Read `VERSION` (unprefixed SemVer, e.g. `1.0.0`).
+2. Use that as the target; the GitHub tag form is `v` + version (e.g. `v1.0.0`).
+
+Normalize:
+
+- **Version:** `X.Y.Z` (no `v`)
+- **Tag:** `vX.Y.Z`
+
+Confirm the tag exists locally or on the remote (`git fetch --tags` if needed):
+
+```bash
+git rev-parse --verify "refs/tags/vX.Y.Z^{}"
+```
+
+If the tag does not exist yet, still draft notes for the range
+`previous_tag..HEAD` (or `previous_tag..main`) and say the release is not
+published.
+
+### Step 2 — Find the previous release tag
+
+```bash
+git tag --list 'v*' --sort=-v:refname
+```
+
+Pick the highest SemVer tag **strictly older** than the target. If none,
+treat the range as the full history to the target (first release) and say so.
+
+### Step 3 — Collect change inputs (not the notes)
+
+Gather material between `previous_tag` and `target_tag` (or `HEAD`):
+
+**Merged PRs** (preferred):
+
+```bash
+gh pr list --state merged --limit 200 \
+  --search "merged:>=YYYY-MM-DD" \
+  --json number,title,labels,mergedAt,author,body
+```
+
+Prefer filtering by merge time of the previous tag when possible:
+
+```bash
+git log -1 --format=%cI previous_tag
+```
+
+**Conventional commits** (supplement; do not dump raw):
+
+```bash
+git log previous_tag..target_tag --pretty=format:'%s' --no-merges
+```
+
+Group by type prefix (`feat`, `fix`, `perf`, `refactor`, `docs`, `build`,
+`chore`, `ci`, `test`, `bump`, `revert`, `style`). Ignore noise-only chores
+unless they affect users (deps with CVE fixes, Go bumps, image tags).
+
+Also skim:
+
+- `COMPATIBILITY.md` — what counts as breaking / upgrade impact
+- Notable version-bump or dependency PRs in the range
+
+### Step 4 — Draft the notes
+
+Write notes using the structure in [template.md](template.md).
+
+Rules:
+
+1. **Lead with a short summary** (2–4 sentences): what this release is for and
+   who should care.
+2. **Always include an Upgrade impact** section (even if “No breaking changes;
+   safe to upgrade for most users”).
+3. Call out **breaking changes**, API/OpenAPI changes, config/env changes,
+   image tag policy changes, and required client/SDK alignment.
+4. Prefer **user-facing** language over internal refactors. Link important PRs
+   as `(#NNN)`.
+5. Omit empty sections rather than leaving placeholders.
+6. **Never** paste `git log` / full commit SHA lists / unedited
+   `--generate-notes` output as the release body.
+
+### Step 5 — Present for human review
+
+Show the full markdown body to the user. Ask whether to:
+
+- **A.** Only keep the draft (copy/paste later), or
+- **B.** Apply it to GitHub.
+
+Do **not** publish or overwrite a release body without explicit confirmation.
+
+### Step 6 — Apply to GitHub (only if confirmed)
+
+If the release **exists**:
+
+```bash
+gh release edit "vX.Y.Z" --notes-file /tmp/evalhub-release-notes.md
+```
+
+If the release **does not exist** and the user wants a **draft**:
+
+```bash
+gh release create "vX.Y.Z" --draft --title "vX.Y.Z" \
+  --notes-file /tmp/evalhub-release-notes.md
+```
+
+Do not attach binaries here unless the user asks; MCP/asset releases are handled
+by `.github/workflows/release-mcp.yml`.
+
+If CI already created a release with auto-generated notes, **replace** the body
+with the curated notes (after confirmation). Leaving only `--generate-notes`
+output does not meet this skill’s OpenSSF bar.
+
+### Step 7 — Report
+
+Summarize:
+
+- Target version / tag and previous tag
+- Whether the GitHub release was updated, left as draft, or draft-only in chat
+- Any gaps (missing PR bodies, first release, unclear breaking changes)
+
+## Commit / PR when adding skill-only changes
+
+If this work is only documentation/skill files, use:
+
+```text
+chore(skills): add release-notes skill for OpenSSF-compliant GitHub releases
+```

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -69,22 +69,27 @@ Accept an explicit tag/version from the user (e.g. `v1.0.0` or `1.0.0`).
 If none is given:
 
 1. Read `VERSION` (unprefixed SemVer, e.g. `1.0.0`).
-2. Use that as the target; the GitHub tag form is `v` + version (e.g. `v1.0.0`).
+2. Use that as the target.
 
-Normalize:
+**Validate before any shell interpolation.** The supplied value (user input or
+`VERSION`) MUST match `^v?[0-9]+\.[0-9]+\.[0-9]+$`. Reject anything else and
+stop; do not interpolate unvalidated strings into Git or `gh` commands.
 
-- **Version:** `X.Y.Z` (no `v`)
-- **Tag:** `vX.Y.Z`
+Normalize a valid value to the canonical tag form:
+
+- **Tag (`target_tag`):** `vX.Y.Z` (always with a leading `v`)
+- **Version:** `X.Y.Z` (no `v`; strip a leading `v` if present)
+
+Use only `target_tag` in all Git/`gh` commands below.
 
 Confirm the tag exists locally or on the remote (`git fetch --tags` if needed):
 
 ```bash
-git rev-parse --verify "refs/tags/vX.Y.Z^{}"
+git rev-parse --verify "refs/tags/${target_tag}^{}"
 ```
 
-If the tag does not exist yet, still draft notes for the range
-`previous_tag..HEAD` (or `previous_tag..main`) and say the release is not
-published.
+If the tag does not exist yet, still draft notes using the ranges in Step 2–3
+(with `HEAD` or `main` as the upper bound) and say the release is not published.
 
 ### Step 2 — Find the previous release tag
 
@@ -92,31 +97,64 @@ published.
 git tag --list 'v*' --sort=-v:refname
 ```
 
-Pick the highest SemVer tag **strictly older** than the target. If none,
-treat the range as the full history to the target (first release) and say so.
+Pick the highest SemVer tag **strictly older** than `target_tag`. Store it as
+`previous_tag`.
+
+**If a previous tag exists** — use ranges `previous_tag..target_tag` (or
+`previous_tag..HEAD` / `previous_tag..main` when the target tag is not
+published yet).
+
+**If none (first release)** — there is no `previous_tag`. Do **not** invent or
+reference an undefined `previous_tag`. Use the first-release branch:
+
+- Commit range: `target_tag` (or `HEAD` / `main` if the tag is not published)
+- PR time window: from the repository’s earliest commit date through the
+  target tag’s (or `HEAD`’s) committer date
+- State clearly that this is the first release
 
 ### Step 3 — Collect change inputs (not the notes)
 
-Gather material between `previous_tag` and `target_tag` (or `HEAD`):
+Gather material for the range from Step 2.
 
-**Merged PRs** (preferred):
+**Merged PRs** (preferred) — derive both merge-time bounds from tags (or the
+first-release upper bound only):
 
 ```bash
-gh pr list --state merged --limit 200 \
-  --search "merged:>=YYYY-MM-DD" \
+# Upper bound (always): committer date of target_tag, or HEAD if unpublished
+upper_ref="$target_tag"   # use HEAD if the target tag is not published yet
+upper_date=$(git log -1 --format=%cI "$upper_ref")
+
+# Lower bound (previous-release path only; omit for first release)
+lower_date=$(git log -1 --format=%cI "$previous_tag")
+```
+
+Search with both bounds when `previous_tag` exists; for a first release use
+only `merged:<=${upper_date}`. Read up to **1000** matching PRs
+(`--limit 1000`). If the result count equals that limit, split the date window
+and merge pages until every matching PR is collected:
+
+```bash
+# previous-release path (both bounds); drop merged:>=… for first release
+gh pr list --state merged --limit 1000 \
+  --search "merged:>=${lower_date} merged:<=${upper_date}" \
   --json number,title,labels,mergedAt,author,body
 ```
 
-Prefer filtering by merge time of the previous tag when possible:
-
-```bash
-git log -1 --format=%cI previous_tag
-```
+**Verify before drafting:** every collected PR’s `mergedAt` MUST fall within
+the intended window (strictly after `previous_tag` when present, and on or
+before `upper_ref`). Confirm each PR’s merge commit is reachable in
+`previous_tag..target_tag` (or the first-release range). Drop any PR outside
+that window.
 
 **Conventional commits** (supplement; do not dump raw):
 
 ```bash
-git log previous_tag..target_tag --pretty=format:'%s' --no-merges
+# previous-release path
+git log "${previous_tag}..${target_tag}" --pretty=format:'%s' --no-merges
+
+# first-release path (no previous_tag)
+git log "${target_tag}" --pretty=format:'%s' --no-merges
+# or, if target tag unpublished: git log HEAD --pretty=format:'%s' --no-merges
 ```
 
 Group by type prefix (`feat`, `fix`, `perf`, `refactor`, `docs`, `build`,
@@ -157,16 +195,26 @@ Do **not** publish or overwrite a release body without explicit confirmation.
 
 ### Step 6 — Apply to GitHub (only if confirmed)
 
+Use the validated `target_tag` (e.g. `v1.0.0`) in every command.
+
 If the release **exists**:
 
 ```bash
-gh release edit "vX.Y.Z" --notes-file /tmp/evalhub-release-notes.md
+gh release edit "${target_tag}" --notes-file /tmp/evalhub-release-notes.md
+```
+
+If the release **does not exist** and the user confirmed **publication** (not a
+draft):
+
+```bash
+gh release create "${target_tag}" --title "${target_tag}" \
+  --notes-file /tmp/evalhub-release-notes.md
 ```
 
 If the release **does not exist** and the user wants a **draft**:
 
 ```bash
-gh release create "vX.Y.Z" --draft --title "vX.Y.Z" \
+gh release create "${target_tag}" --draft --title "${target_tag}" \
   --notes-file /tmp/evalhub-release-notes.md
 ```
 
@@ -187,8 +235,23 @@ Summarize:
 
 ## Commit / PR when adding skill-only changes
 
-If this work is only documentation/skill files, use:
+If this work is only documentation/skill files, commit with `git commit -s`
+(DCO sign-off). Do **not** add a `Signed-off-by` line yourself; `-s` appends it
+from the author’s configured `user.name` and `user.email`.
+
+Use a Conventional Commits subject (example for the initial skill; adapt the
+subject for later skill-only edits):
 
 ```text
 chore(skills): add release-notes skill for OpenSSF-compliant GitHub releases
 ```
+
+Append **one** approved AI attribution trailer at the end of the commit message
+body (after the subject and any description), for example:
+
+```text
+Assisted-by: Cursor
+```
+
+or `Made-with: Cursor` / `Generated with: Claude Code` as appropriate. Do not
+stack multiple attribution trailers.

--- a/.claude/skills/release-notes/template.md
+++ b/.claude/skills/release-notes/template.md
@@ -1,0 +1,52 @@
+# Release notes template
+
+Use this shape for the GitHub release body. Drop sections with nothing useful to say.
+Do not leave `TBD` placeholders in a published release.
+
+```markdown
+## Summary
+
+<!-- 2–4 sentences: what shipped and why a user might upgrade -->
+
+## Upgrade impact
+
+<!-- Required. Be explicit. Examples:
+- No breaking changes expected for API clients on /api/v1.
+- Breaking: <what changed>, <who is affected>, <what to do>.
+- Config/env: <new or removed keys>.
+- Images: pin to <version> tag; see COMPATIBILITY.md.
+- Align eval-hub-sdk only if this release documents a required client bump.
+-->
+
+## Breaking changes
+
+<!-- Omit entire section if none. List each break with mitigation. -->
+
+## Highlights
+
+<!-- Major user-facing features / changes. Link PRs: (#123) -->
+
+## Bug fixes
+
+<!-- User-visible fixes only -->
+
+## Dependencies and security
+
+<!-- Notable dependency bumps, CVE fixes, Go/toolchain bumps -->
+
+## Documentation
+
+<!-- Significant docs/OpenAPI changes worth calling out -->
+
+## Contributors
+
+<!-- Optional: thank non-bot contributors for this range -->
+```
+
+## Tone
+
+- Write for operators and API consumers, not for commit archaeology.
+- Prefer concrete upgrade steps over vague “various improvements”.
+- When unsure whether something breaks clients, check `COMPATIBILITY.md` and
+  OpenAPI diffs in the range; if still unsure, flag it under Upgrade impact as
+  “verify before upgrading” rather than omitting it.

--- a/.gitignore
+++ b/.gitignore
@@ -252,6 +252,10 @@ mlflow.log
 !.claude/skills/golang-version-update/
 .claude/skills/golang-version-update/*
 !.claude/skills/golang-version-update/SKILL.md
+!.claude/skills/release-notes/
+.claude/skills/release-notes/*
+!.claude/skills/release-notes/SKILL.md
+!.claude/skills/release-notes/template.md
 
 .agentready/
 

--- a/.gitignore
+++ b/.gitignore
@@ -252,10 +252,6 @@ mlflow.log
 !.claude/skills/golang-version-update/
 .claude/skills/golang-version-update/*
 !.claude/skills/golang-version-update/SKILL.md
-!.claude/skills/release-notes/
-.claude/skills/release-notes/*
-!.claude/skills/release-notes/SKILL.md
-!.claude/skills/release-notes/template.md
 
 .agentready/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,10 @@ When updating the project version, edit these four source files:
 
 Then run `make documentation` to regenerate the bundled docs. Do **not** hand-edit the generated files under `docs/` (`openapi.yaml`, `openapi.json`, `openapi-internal.yaml`, `openapi-internal.json`, `index*.html`).
 
+For each GitHub release, publish curated release notes (human-readable summary and
+upgrade impact — not raw `git log`). Use the `release-notes` skill at
+`.claude/skills/release-notes/SKILL.md` (see also `CLAUDE.md`).
+
 ### Dependencies
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Each GitHub release must include human-readable release notes (OpenSSF): a summa
 of major changes and upgrade impact — **not** raw `git log` or unedited
 `--generate-notes` output.
 
+OpenSSF allows several delivery mechanisms (e.g. `NEWS` / `CHANGELOG` files, or
+version-control release UIs). This project uses the **GitHub Releases** workflow
+as the primary channel.
+
 Use the project skill [`.claude/skills/release-notes/SKILL.md`](.claude/skills/release-notes/SKILL.md)
 to draft and (after confirmation) apply notes for a given tag/version.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,37 @@
 
 @AGENTS.md
 
+## Release notes
+
+Each GitHub release must include human-readable release notes (OpenSSF): a summary
+of major changes and upgrade impact — **not** raw `git log` or unedited
+`--generate-notes` output.
+
+Use the project skill [`.claude/skills/release-notes/SKILL.md`](.claude/skills/release-notes/SKILL.md)
+to draft and (after confirmation) apply notes for a given tag/version.
+
+##### Run from Cursor
+
+In Agent chat, ask for example:
+
+- “Generate release notes for v1.0.0 using the release-notes skill”
+- “Draft OpenSSF-compliant release notes for the next release”
+
+Optionally attach `@.claude/skills/release-notes/SKILL.md`.
+
+##### Run from Claude Code terminal
+
+```text
+/release-notes
+```
+
+Or ask naturally (e.g. “Draft release notes for v1.0.0”).
+
+##### After the skill runs
+
+Expect a curated markdown body with Summary and Upgrade impact. The skill must
+not publish or overwrite a GitHub release body without explicit confirmation.
+
 ## CVE fixing
 
 ### Instructions for CVE fixing


### PR DESCRIPTION
## Summary
- Adds a project Claude/Cursor skill (`.claude/skills/release-notes/`) that drafts human-readable GitHub release notes with an explicit **Upgrade impact** section, using merged PRs and conventional commits as inputs only.
- Documents how to invoke the skill from Cursor and Claude Code in `CLAUDE.md` / `AGENTS.md`.
- Whitelists the skill files in `.gitignore` (same pattern as `golang-version-update`).

This supports the OpenSSF requirement that each release include curated notes (not raw `git log` / unedited `--generate-notes` output).

## Test plan
- [ ] Invoke the skill for an existing tag (e.g. `v1.0.0`) and confirm the draft includes Summary + Upgrade impact and is not a raw commit dump
- [ ] Confirm the skill asks for confirmation before `gh release edit` / draft create
- [ ] Optionally attach `@.claude/skills/release-notes/SKILL.md` in Cursor and verify the procedure is followed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a standardized process for creating clear, human-readable release notes.
  * Introduced a release-note template covering summaries, upgrade impact, breaking changes, highlights, bug fixes, security, documentation, and contributors.
  * Added guidance for preparing OpenSSF-compliant notes and documenting compatibility considerations.
  * Clarified review and explicit confirmation requirements for publishing or updating GitHub releases.
  * Updated contributor guidance to support consistent release preparation and release-note automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->