### PR TITLE
chore(github): expand global CODEOWNERS fallback

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global fallback — all PRs need at least one approval
-* @ruivieira @julpayne @ppadashe-psp
+* @ruivieira @julpayne @ppadashe-psp @nbs-rh @gnaulak-redhat @scheruku-rh
 
 # Go service
 /cmd/ @ruivieira @julpayne @ppadashe-psp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global fallback — all PRs need at least one approval
-* @ruivieira @julpayne @ppadashe-psp @nbs-rh @gnaulak-redhat @scheruku-rh
+* @eval-hub/maintainers
 
 # Go service
 /cmd/ @ruivieira @julpayne @ppadashe-psp


### PR DESCRIPTION
## What and why

- Use the `@eval-hub/maintainers` team as the global CODEOWNERS fallback instead of listing individuals, so approval coverage stays in sync with team membership

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually