### PR TITLE
test(fvt): wait longer for missing-PVC job to fail

### DIFF
--- a/tests/features/README.md
+++ b/tests/features/README.md
@@ -93,7 +93,7 @@ When running in local server mode, the tests will:
 | `@hardware_profile` | Hardware profile API and Kubernetes Job adapter resource tests in `evaluation_jobs.feature`; require pipeline env vars (see below). |
 | `@metrics` | Prometheus `/metrics` scrape tests in `metrics.feature`; in cluster/remote mode require `METRICS_URL` (see below). |
 | `@logs` | Evaluation job log collection scenarios in `evaluation_local_jobs.feature` and `evaluation_jobs.feature` |
-| `@pvc` | Evaluation jobs that mount offline test data from a PersistentVolumeClaim (`evaluation_jobs.feature`). Defaults: claim `evalhub-offline-test-data`, `sub_path` `staging`. Override with `TEST_DATA_PVC_CLAIM_NAME` / `TEST_DATA_PVC_SUB_PATH`. Missing-PVC negative case uses `TEST_DATA_PVC_MISSING_CLAIM_NAME` (default `evalhub-offline-test-data-does-not-exist`) and waits up to 2m30s for operator failure sync. Opt in with `GODOG_TAGS="@pvc"`. |
+| `@pvc` | Evaluation jobs that mount offline test data from a PersistentVolumeClaim (`evaluation_jobs.feature`). Defaults: claim `evalhub-offline-test-data`, `sub_path` `staging`. Override with `TEST_DATA_PVC_CLAIM_NAME` / `TEST_DATA_PVC_SUB_PATH`. Missing-PVC negative case uses `TEST_DATA_PVC_MISSING_CLAIM_NAME` (default `evalhub-offline-test-data-does-not-exist`) and waits up to 5m for operator failure sync. Opt in with `GODOG_TAGS="@pvc"`. |
 | `@gha-wheel-sanity` | Local-runtime wheel validation scenario run by `scripts/gha_wheel_sanity_test.sh` during GHA wheel checks |
 
 ### Metrics tests (`@metrics`)

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1267,13 +1267,14 @@ Feature: Evaluation Jobs
     And the response should contain the value "request_validation_failed" at path "$.message_code"
     And the response should contain the value "s3 and pvc are mutually exclusive" at path "$.message"
 
-  # Requires trustyai-service-operator eval-job failure reconciler (unschedulable PVC → FAILED after ~2m grace).
+  # Requires trustyai-service-operator eval-job failure reconciler (unschedulable PVC → FAILED after scheduling grace).
+  # Wait deadline must exceed that grace period with margin.
   # Default missing claim: evalhub-offline-test-data-does-not-exist (override with TEST_DATA_PVC_MISSING_CLAIM_NAME).
   @pvc
   @negative
   Scenario: Evaluation job with missing PVC fails after scheduling grace
     Given the service is running
-    And I set the wait deadline to "2m30s"
+    And I set the wait deadline to "5m"
     And I set the wait interval to "10s"
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_pvc_missing.json"
     Then the response code should be 202


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->
- The missing-PVC test was timing out at 2m30s because TrustyAI needs a bit longer before it marks the job failed.
- Increased the wait to 5m so the test can finish reliably.

Closes #  https://redhat.atlassian.net/browse/RHOAIENG-80941

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated evaluation job failure coverage for unschedulable persistent storage.
  * Extended the expected wait deadline from 2 minutes 30 seconds to 5 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->