### PR TITLE
refactor(sidecar): derive listen port from base_url, remove standalone port field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,8 @@ stop-service:
 # Sidecar (eval-runtime-sidecar) starter/stopper
 SIDECAR_PID_FILE ?= $(BIN_DIR)/sidecar.pid
 SIDECAR_LOG ?= $(BIN_DIR)/sidecar.log
-SIDECAR_PORT ?= 8081
-# Config dir containing sidecar_runtime_local.json (or minimal JSON is generated from SIDECAR_PORT)
-SIDECAR_CONFIG_DIR ?= config
+# Sidecar config JSON (port is derived from base_url in the file)
+SIDECAR_CONFIG_FILE ?= config/sidecar_runtime_local.json
 
 build-sidecar: $(BIN_DIR) ## Build only the sidecar binary
 	@echo "Building $(SIDECAR_BINARY_NAME) with ${LDFLAGS}"
@@ -117,10 +116,10 @@ build-mcp: $(BIN_DIR) ## Build the evalhub-mcp MCP server binary
 	@go build -race -ldflags "${LDFLAGS}" -o $(BIN_DIR)/$(MCP_BINARY_NAME) $(MCP_CMD_PATH)
 	@echo "Build complete: $(BIN_DIR)/$(MCP_BINARY_NAME)"
 
-start-sidecar: build-sidecar ## Run the sidecar in background (port $(SIDECAR_PORT), config from $(SIDECAR_CONFIG_DIR))
+start-sidecar: build-sidecar ## Run the sidecar in background (config from $(SIDECAR_CONFIG_FILE))
 	@rm -f "${SIDECAR_PID_FILE}" && true
-	@echo "Running $(SIDECAR_BINARY_NAME) on port $(SIDECAR_PORT) (config: $(SIDECAR_CONFIG_DIR))..."
-	@SIDECAR_PORT="$(SIDECAR_PORT)" ./scripts/start_sidecar.sh "${SIDECAR_PID_FILE}" "${BIN_DIR}/$(SIDECAR_BINARY_NAME)" "${SIDECAR_LOG}" "$(SIDECAR_PORT)" "$(SIDECAR_CONFIG_DIR)"
+	@echo "Running $(SIDECAR_BINARY_NAME) (config: $(SIDECAR_CONFIG_FILE))..."
+	@./scripts/start_sidecar.sh "${SIDECAR_PID_FILE}" "${BIN_DIR}/$(SIDECAR_BINARY_NAME)" "${SIDECAR_LOG}" "$(SIDECAR_CONFIG_FILE)"
 
 stop-sidecar: ## Stop the sidecar
 	-./scripts/stop_server.sh "${SIDECAR_PID_FILE}"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,7 +29,6 @@ env_mappings:
   EVALHUB_INSECURE_SKIP_VERIFY: sidecar.eval_hub.insecure_skip_verify
   EVALHUB_TOKEN_CACHE_TIMEOUT: sidecar.eval_hub.token_cache_timeout
   MLFLOW_TOKEN_CACHE_TIMEOUT: sidecar.mlflow.token_cache_timeout
-  SIDECAR_PORT: sidecar.port
   METRICS_PORT: prometheus.port
   METRICS_HOST: prometheus.host
   OTEL_METRIC_EXPORT_INTERVAL: otel.metric_export_interval
@@ -64,7 +63,6 @@ prometheus:
 
 sidecar:
   base_url: http://localhost:8080  # URL for adapter/runtime to call sidecar proxy (cluster mode)
-  port: 8080
   eval_hub:
     # TLS for outbound calls to eval-hub (sidecar -> eval-hub API).
     # On cluster: job pods inject EVALHUB_CA_CERT_PATH and EVALHUB_INSECURE_SKIP_VERIFY; sidecar reads

--- a/config/sidecar_runtime_local.json
+++ b/config/sidecar_runtime_local.json
@@ -1,8 +1,7 @@
 {
   "base_url": "http://localhost:8080",
   "eval_hub": {
-    "base_url": "http://localhost:8080",
-    "insecure_skip_verify": true
+    "base_url": "http://localhost:8080"
   },
   "mlflow": {
     "tracking_uri": "http://localhost:5000"

--- a/config/sidecar_runtime_local.json
+++ b/config/sidecar_runtime_local.json
@@ -1,8 +1,8 @@
 {
-  "port": 8080,
   "base_url": "http://localhost:8080",
   "eval_hub": {
-    "base_url": "http://localhost:8080"
+    "base_url": "http://localhost:8080",
+    "insecure_skip_verify": true
   },
   "mlflow": {
     "tracking_uri": "http://localhost:5000"

--- a/internal/eval_hub/config/loader.go
+++ b/internal/eval_hub/config/loader.go
@@ -410,6 +410,12 @@ func LoadConfig(logger *slog.Logger, version string, build string, buildDate str
 		return nil, err
 	}
 
+	if conf.Sidecar != nil {
+		if err := conf.Sidecar.ResolvePort(); err != nil {
+			return nil, err
+		}
+	}
+
 	// set the version, build, and build date
 	conf.Service.Version = version
 	conf.Service.Build = build

--- a/internal/eval_hub/config/loader_test.go
+++ b/internal/eval_hub/config/loader_test.go
@@ -215,6 +215,57 @@ secrets:
 		}
 	})
 
+	t.Run("sidecar ResolvePort called on load", func(t *testing.T) {
+		dir := t.TempDir()
+		content := `
+service:
+  port: 8080
+  termination_file: "/tmp/termination-log"
+database:
+  driver: sqlite
+  url: "file::memory:?mode=memory&cache=shared"
+sidecar:
+  base_url: "http://localhost:9090"
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := config.LoadConfig(logger, version, "local", time.Now().Format(time.RFC3339), "", dir)
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.Sidecar == nil {
+			t.Fatal("expected Sidecar config")
+		}
+		if cfg.Sidecar.Port != 9090 {
+			t.Fatalf("Sidecar.Port = %d, want 9090", cfg.Sidecar.Port)
+		}
+	})
+
+	t.Run("sidecar ResolvePort error propagated", func(t *testing.T) {
+		dir := t.TempDir()
+		content := `
+service:
+  port: 8080
+  termination_file: "/tmp/termination-log"
+database:
+  driver: sqlite
+  url: "file::memory:?mode=memory&cache=shared"
+sidecar:
+  base_url: "http://localhost"
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := config.LoadConfig(logger, version, "local", time.Now().Format(time.RFC3339), "", dir)
+		if err == nil {
+			t.Fatal("expected error for sidecar base_url without port")
+		}
+		if !strings.Contains(err.Error(), "explicit port") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
 	t.Run("loads providers from config dir", func(t *testing.T) {
 		_, err := config.LoadProviderConfigs(logger, testhelpers.NewValidator(t))
 		if err != nil {

--- a/internal/eval_hub/config/sidecar_config.go
+++ b/internal/eval_hub/config/sidecar_config.go
@@ -56,14 +56,14 @@ func (sc *SidecarConfig) ResolvePort() error {
 	if portStr == "" {
 		return fmt.Errorf("sidecar base URL %q must include an explicit port", sc.BaseURL)
 	}
-	port, err := strconv.Atoi(portStr)
+	port, err := strconv.ParseInt(portStr, 10, 32)
 	if err != nil {
 		return fmt.Errorf("invalid port in sidecar base URL %q: %w", sc.BaseURL, err)
 	}
 	if port < 1 || port > 65535 {
 		return fmt.Errorf("sidecar port %d out of range (1-65535)", port)
 	}
-	sc.Port = int32(port) // #nosec G115 -- range validated above (1-65535)
+	sc.Port = int32(port)
 	return nil
 }
 

--- a/internal/eval_hub/config/sidecar_config.go
+++ b/internal/eval_hub/config/sidecar_config.go
@@ -15,7 +15,7 @@ const (
 
 type SidecarConfig struct {
 	BaseURL          string                  `mapstructure:"base_url,omitempty" json:"base_url,omitempty"`
-	Port             int                     `mapstructure:"-" json:"-"` // derived from BaseURL by ResolvePort; never serialised
+	Port             int32                   `mapstructure:"-" json:"-"` // derived from BaseURL by ResolvePort; never serialised
 	EvalHub          *EvalHubClientConfig    `mapstructure:"eval_hub" json:"eval_hub,omitempty"`
 	MLFlow           *SidecarMLFlowConfig    `mapstructure:"mlflow,omitempty" json:"mlflow,omitempty"`
 	OCI              *SidecarOCIConfig       `mapstructure:"oci,omitempty" json:"oci,omitempty"`
@@ -35,6 +35,8 @@ func (sc *SidecarConfig) EffectiveBaseURL() string {
 // ResolvePort extracts the listen port from BaseURL and stores it in Port.
 // When BaseURL is empty both fields are left at their zero values; each
 // consumer module is responsible for falling back to the defaults.
+// A non-empty BaseURL must use http/https, include a hostname, and carry
+// an explicit port (required for Kubernetes probe/container port alignment).
 // Call once after loading config to fail fast on malformed URLs.
 func (sc *SidecarConfig) ResolvePort() error {
 	if sc.BaseURL == "" {
@@ -44,10 +46,15 @@ func (sc *SidecarConfig) ResolvePort() error {
 	if err != nil {
 		return fmt.Errorf("invalid sidecar base URL %q: %w", sc.BaseURL, err)
 	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("sidecar base URL %q must use http or https scheme", sc.BaseURL)
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("sidecar base URL %q must include a hostname", sc.BaseURL)
+	}
 	portStr := u.Port()
 	if portStr == "" {
-		sc.Port = DefaultSidecarPort
-		return nil
+		return fmt.Errorf("sidecar base URL %q must include an explicit port", sc.BaseURL)
 	}
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
@@ -56,7 +63,7 @@ func (sc *SidecarConfig) ResolvePort() error {
 	if port < 1 || port > 65535 {
 		return fmt.Errorf("sidecar port %d out of range (1-65535)", port)
 	}
-	sc.Port = port
+	sc.Port = int32(port) // #nosec G115 -- range validated above (1-65535)
 	return nil
 }
 

--- a/internal/eval_hub/config/sidecar_config.go
+++ b/internal/eval_hub/config/sidecar_config.go
@@ -2,18 +2,62 @@ package config
 
 import (
 	"crypto/tls"
+	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 )
 
+const (
+	DefaultSidecarPort    = 8080
+	DefaultSidecarBaseURL = "http://localhost:8080"
+)
+
 type SidecarConfig struct {
-	Port             int                     `mapstructure:"port,omitempty" json:"port,omitempty"`
 	BaseURL          string                  `mapstructure:"base_url,omitempty" json:"base_url,omitempty"`
+	Port             int                     `mapstructure:"-" json:"-"` // derived from BaseURL by ResolvePort; never serialised
 	EvalHub          *EvalHubClientConfig    `mapstructure:"eval_hub" json:"eval_hub,omitempty"`
 	MLFlow           *SidecarMLFlowConfig    `mapstructure:"mlflow,omitempty" json:"mlflow,omitempty"`
 	OCI              *SidecarOCIConfig       `mapstructure:"oci,omitempty" json:"oci,omitempty"`
 	Model            *SidecarModelConfig     `mapstructure:"model,omitempty" json:"model,omitempty"`
 	SidecarContainer *SidecarContainerConfig `mapstructure:"sidecar_container,omitempty" json:"sidecar_container,omitempty"`
 	OTEL             *OTELConfig             `mapstructure:"otel,omitempty" json:"otel,omitempty"`
+}
+
+// EffectiveBaseURL returns BaseURL if non-empty, otherwise DefaultSidecarBaseURL.
+func (sc *SidecarConfig) EffectiveBaseURL() string {
+	if sc.BaseURL != "" {
+		return sc.BaseURL
+	}
+	return DefaultSidecarBaseURL
+}
+
+// ResolvePort extracts the listen port from BaseURL and stores it in Port.
+// When BaseURL is empty both fields are left at their zero values; each
+// consumer module is responsible for falling back to the defaults.
+// Call once after loading config to fail fast on malformed URLs.
+func (sc *SidecarConfig) ResolvePort() error {
+	if sc.BaseURL == "" {
+		return nil
+	}
+	u, err := url.Parse(sc.BaseURL)
+	if err != nil {
+		return fmt.Errorf("invalid sidecar base URL %q: %w", sc.BaseURL, err)
+	}
+	portStr := u.Port()
+	if portStr == "" {
+		sc.Port = DefaultSidecarPort
+		return nil
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return fmt.Errorf("invalid port in sidecar base URL %q: %w", sc.BaseURL, err)
+	}
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("sidecar port %d out of range (1-65535)", port)
+	}
+	sc.Port = port
+	return nil
 }
 
 // SidecarModelConfig holds the model credential-injection proxy settings written into

--- a/internal/eval_hub/config/sidecar_config_test.go
+++ b/internal/eval_hub/config/sidecar_config_test.go
@@ -1,0 +1,45 @@
+package config
+
+import "testing"
+
+func TestResolvePort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		baseURL     string
+		wantPort    int
+		wantBaseURL string
+		wantErr     bool
+	}{
+		{"standard URL", "http://localhost:8080", 8080, "http://localhost:8080", false},
+		{"custom port", "http://localhost:9090", 9090, "http://localhost:9090", false},
+		{"https with port", "https://sidecar.example:8443", 8443, "https://sidecar.example:8443", false},
+		{"trailing slash", "http://localhost:8080/", 8080, "http://localhost:8080/", false},
+		{"no port uses default", "http://localhost", DefaultSidecarPort, "http://localhost", false},
+		{"empty URL is no-op", "", 0, "", false},
+		{"port out of range", "http://localhost:70000", 0, "", true},
+		{"invalid port string", "http://localhost:abc", 0, "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := &SidecarConfig{BaseURL: tc.baseURL}
+			err := sc.ResolvePort()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ResolvePort() with BaseURL %q: want error, got port %d", tc.baseURL, sc.Port)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolvePort() with BaseURL %q: unexpected error: %v", tc.baseURL, err)
+			}
+			if sc.Port != tc.wantPort {
+				t.Fatalf("ResolvePort() with BaseURL %q: got port %d, want %d", tc.baseURL, sc.Port, tc.wantPort)
+			}
+			if sc.BaseURL != tc.wantBaseURL {
+				t.Fatalf("ResolvePort() with BaseURL %q: got BaseURL %q, want %q", tc.baseURL, sc.BaseURL, tc.wantBaseURL)
+			}
+		})
+	}
+}

--- a/internal/eval_hub/config/sidecar_config_test.go
+++ b/internal/eval_hub/config/sidecar_config_test.go
@@ -8,7 +8,7 @@ func TestResolvePort(t *testing.T) {
 	tests := []struct {
 		name        string
 		baseURL     string
-		wantPort    int
+		wantPort    int32
 		wantBaseURL string
 		wantErr     bool
 	}{
@@ -16,8 +16,11 @@ func TestResolvePort(t *testing.T) {
 		{"custom port", "http://localhost:9090", 9090, "http://localhost:9090", false},
 		{"https with port", "https://sidecar.example:8443", 8443, "https://sidecar.example:8443", false},
 		{"trailing slash", "http://localhost:8080/", 8080, "http://localhost:8080/", false},
-		{"no port uses default", "http://localhost", DefaultSidecarPort, "http://localhost", false},
 		{"empty URL is no-op", "", 0, "", false},
+		{"no port is rejected", "http://localhost", 0, "", true},
+		{"ftp scheme rejected", "ftp://localhost:2121", 0, "", true},
+		{"opaque URL rejected", "localhost:9090", 0, "", true},
+		{"hostless URL rejected", "http://:8080", 0, "", true},
 		{"port out of range", "http://localhost:70000", 0, "", true},
 		{"invalid port string", "http://localhost:abc", 0, "", true},
 	}

--- a/internal/eval_hub/config/sidecar_config_test.go
+++ b/internal/eval_hub/config/sidecar_config_test.go
@@ -2,6 +2,24 @@ package config
 
 import "testing"
 
+func TestEffectiveBaseURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns BaseURL when set", func(t *testing.T) {
+		sc := &SidecarConfig{BaseURL: "https://sidecar.example:9443"}
+		if got := sc.EffectiveBaseURL(); got != "https://sidecar.example:9443" {
+			t.Fatalf("EffectiveBaseURL() = %q, want %q", got, "https://sidecar.example:9443")
+		}
+	})
+
+	t.Run("returns default when BaseURL empty", func(t *testing.T) {
+		sc := &SidecarConfig{}
+		if got := sc.EffectiveBaseURL(); got != DefaultSidecarBaseURL {
+			t.Fatalf("EffectiveBaseURL() = %q, want %q", got, DefaultSidecarBaseURL)
+		}
+	})
+}
+
 func TestResolvePort(t *testing.T) {
 	t.Parallel()
 
@@ -21,7 +39,9 @@ func TestResolvePort(t *testing.T) {
 		{"ftp scheme rejected", "ftp://localhost:2121", 0, "", true},
 		{"opaque URL rejected", "localhost:9090", 0, "", true},
 		{"hostless URL rejected", "http://:8080", 0, "", true},
+		{"port zero rejected", "http://localhost:0", 0, "", true},
 		{"port out of range", "http://localhost:70000", 0, "", true},
+		{"negative port rejected", "http://localhost:-1", 0, "", true},
 		{"invalid port string", "http://localhost:abc", 0, "", true},
 	}
 	for _, tc := range tests {

--- a/internal/eval_hub/handlers/sidecar_url_rewrite.go
+++ b/internal/eval_hub/handlers/sidecar_url_rewrite.go
@@ -12,10 +12,9 @@ import (
 )
 
 const (
-	evalHubInstanceNameEnv   = "EVALHUB_INSTANCE_NAME"
-	defaultEvalHubPort       = "8443"
-	defaultSidecarListenPort = 8080
-	inClusterNamespaceFile   = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	evalHubInstanceNameEnv = "EVALHUB_INSTANCE_NAME"
+	defaultEvalHubPort     = "8443"
+	inClusterNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 )
 
 var (
@@ -33,18 +32,10 @@ func (h *Handlers) rewriteSidecarURLsInBenchmarkStatus(event *api.BenchmarkStatu
 }
 
 func (h *Handlers) sidecarBaseURL() string {
-	port := defaultSidecarListenPort
-	baseURL := ""
-	if h.serviceConfig != nil && h.serviceConfig.Sidecar != nil {
-		if h.serviceConfig.Sidecar.Port != 0 {
-			port = h.serviceConfig.Sidecar.Port
-		}
-		baseURL = strings.TrimSpace(h.serviceConfig.Sidecar.BaseURL)
+	if h.serviceConfig == nil || h.serviceConfig.Sidecar == nil {
+		return config.DefaultSidecarBaseURL
 	}
-	if baseURL == "" {
-		baseURL = fmt.Sprintf("http://localhost:%d", port)
-	}
-	return baseURL
+	return h.serviceConfig.Sidecar.EffectiveBaseURL()
 }
 
 func (h *Handlers) sidecarURLTargets(job *api.EvaluationJobResource) api.SidecarURLTargets {

--- a/internal/eval_hub/handlers/sidecar_url_rewrite_test.go
+++ b/internal/eval_hub/handlers/sidecar_url_rewrite_test.go
@@ -14,9 +14,9 @@ func TestSidecarBaseURL(t *testing.T) {
 		t.Fatalf("default sidecarBaseURL = %q", got)
 	}
 
-	h.serviceConfig = &config.Config{Sidecar: &config.SidecarConfig{Port: 9090}}
+	h.serviceConfig = &config.Config{Sidecar: &config.SidecarConfig{BaseURL: "http://localhost:9090"}}
 	if got := h.sidecarBaseURL(); got != "http://localhost:9090" {
-		t.Fatalf("port-derived sidecarBaseURL = %q", got)
+		t.Fatalf("base_url-derived sidecarBaseURL = %q", got)
 	}
 
 	h.serviceConfig.Sidecar.BaseURL = "http://127.0.0.1:8080"

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -21,7 +21,6 @@ const (
 	defaultJobBackoffLimit = int32(0)
 	adapterContainerName   = "adapter"
 	sidecarContainerName   = "sidecar"
-	defaultSidecarPort     = int32(8080)
 	initContainerName      = "init"
 	jobSpecVolumeName      = "job-spec"
 	dataVolumeName         = "data"
@@ -173,14 +172,11 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 			VolumeMounts:    runtimeContainerVolumeMounts,
 		},
 	}
-	probePort := defaultSidecarPort
+	probePort := int32(config.DefaultSidecarPort)
 	if cfg.sidecarConfig != nil && cfg.sidecarConfig.Port != 0 {
-		p, err := sidecarPortFromInt(cfg.sidecarConfig.Port)
-		if err != nil {
-			return nil, fmt.Errorf("sidecar port: %w", err)
-		}
-		probePort = p
+		probePort = int32(cfg.sidecarConfig.Port)
 	}
+
 	// Sidecar is added as an init container with restartPolicy=Always to be
 	// promoted as a native sidecar container (KEP-753).
 	sidecarRestartPolicy := corev1.ContainerRestartPolicyAlways

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -174,7 +174,11 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 	}
 	probePort := int32(config.DefaultSidecarPort)
 	if cfg.sidecarConfig != nil && cfg.sidecarConfig.Port != 0 {
-		probePort = cfg.sidecarConfig.Port
+		p := cfg.sidecarConfig.Port
+		if p < 1 || p > 65535 {
+			return nil, fmt.Errorf("sidecar port %d out of range (1-65535)", p)
+		}
+		probePort = p
 	}
 
 	// Sidecar is added as an init container with restartPolicy=Always to be

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -174,7 +174,7 @@ func buildJob(cfg *jobConfig) (*batchv1.Job, error) {
 	}
 	probePort := int32(config.DefaultSidecarPort)
 	if cfg.sidecarConfig != nil && cfg.sidecarConfig.Port != 0 {
-		probePort = int32(cfg.sidecarConfig.Port)
+		probePort = cfg.sidecarConfig.Port
 	}
 
 	// Sidecar is added as an init container with restartPolicy=Always to be

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
@@ -11,26 +10,31 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestBuildJobRejectsInvalidSidecarPort(t *testing.T) {
+func TestBuildJobUsesJobConfigSidecarPort(t *testing.T) {
 	cfg := &jobConfig{
-		jobID:          "job-bad-port",
-		resourceGUID:   "guid-bp",
+		jobID:          "job-port",
+		resourceGUID:   "guid-port",
 		benchmarkIndex: 0,
 		namespace:      "default",
 		providerID:     "provider-1",
 		benchmarkID:    "bench-1",
 		adapterImage:   "adapter:latest",
-		sidecarConfig: &config.SidecarConfig{
-			Port: 70000,
-		},
+		sidecarConfig:  &config.SidecarConfig{BaseURL: "http://localhost:9090", Port: 9090},
 	}
 
-	_, err := buildJob(cfg)
-	if err == nil {
-		t.Fatal("buildJob() = nil, want sidecar port error")
+	job, err := buildJob(cfg)
+	if err != nil {
+		t.Fatalf("buildJob: %v", err)
 	}
-	if !strings.Contains(err.Error(), "sidecar port") {
-		t.Fatalf("buildJob() error = %v, want sidecar port error", err)
+	sidecar := findContainer(job.Spec.Template.Spec.InitContainers, sidecarContainerName)
+	if sidecar == nil {
+		t.Fatal("sidecar init container not found")
+	}
+	if sidecar.StartupProbe == nil || sidecar.StartupProbe.HTTPGet == nil {
+		t.Fatal("expected startup probe with HTTPGet")
+	}
+	if got := sidecar.StartupProbe.HTTPGet.Port.IntValue(); got != 9090 {
+		t.Fatalf("startup probe port = %d, want 9090", got)
 	}
 }
 
@@ -114,7 +118,6 @@ func TestBuildConfigMapSidecarConfigJSONContent(t *testing.T) {
 		jobSpec:        shared.JobSpec{},
 		resourceGUID:   "guid-123",
 		sidecarConfig: &config.SidecarConfig{
-			Port:    8081,
 			BaseURL: "http://localhost:8081",
 		},
 	}
@@ -126,8 +129,11 @@ func TestBuildConfigMapSidecarConfigJSONContent(t *testing.T) {
 	if err := json.Unmarshal([]byte(cm.Data[sidecarConfigFileName]), &m); err != nil {
 		t.Fatal(err)
 	}
-	if m["port"].(float64) != 8081 {
-		t.Fatalf("port: %v", m["port"])
+	if m["base_url"] != "http://localhost:8081" {
+		t.Fatalf("base_url: %v", m["base_url"])
+	}
+	if _, ok := m["port"]; ok {
+		t.Fatalf("sidecar_config.json should not contain 'port', got %v", m["port"])
 	}
 }
 

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -42,6 +42,26 @@ func TestBuildJobUsesJobConfigSidecarPort(t *testing.T) {
 	}
 }
 
+func TestBuildJobRejectsOutOfRangeSidecarPort(t *testing.T) {
+	for _, port := range []int32{-1, 65536} {
+		cfg := &jobConfig{
+			jobID:        "job-port-bad",
+			resourceGUID: "guid-port-bad",
+			namespace:    "default",
+			providerID:   "provider-1",
+			benchmarkID:  "bench-1",
+			adapterImage: "adapter:latest",
+			sidecarConfig: &config.SidecarConfig{
+				Port: port,
+			},
+		}
+		_, err := buildJob(cfg)
+		if err == nil {
+			t.Fatalf("expected error for sidecar port %d", port)
+		}
+	}
+}
+
 func findContainer(containers []corev1.Container, name string) *corev1.Container {
 	for i := range containers {
 		if containers[i].Name == name {

--- a/internal/eval_hub/runtimes/k8s/job_builders_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestBuildJobUsesJobConfigSidecarPort(t *testing.T) {
+	sc := &config.SidecarConfig{BaseURL: "http://localhost:9090"}
+	if err := sc.ResolvePort(); err != nil {
+		t.Fatalf("ResolvePort: %v", err)
+	}
 	cfg := &jobConfig{
 		jobID:          "job-port",
 		resourceGUID:   "guid-port",
@@ -19,7 +23,7 @@ func TestBuildJobUsesJobConfigSidecarPort(t *testing.T) {
 		providerID:     "provider-1",
 		benchmarkID:    "bench-1",
 		adapterImage:   "adapter:latest",
-		sidecarConfig:  &config.SidecarConfig{BaseURL: "http://localhost:9090", Port: 9090},
+		sidecarConfig:  sc,
 	}
 
 	job, err := buildJob(cfg)

--- a/internal/eval_hub/runtimes/k8s/job_config.go
+++ b/internal/eval_hub/runtimes/k8s/job_config.go
@@ -110,22 +110,10 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 		return nil, fmt.Errorf("model url and name are required")
 	}
 
-	port := defaultSidecarPort
-	sidecarBaseURL := ""
+	sidecarBaseURL := config.DefaultSidecarBaseURL
 	if serviceConfig != nil && serviceConfig.Sidecar != nil {
-		if serviceConfig.Sidecar.Port != 0 {
-			p, err := sidecarPortFromInt(serviceConfig.Sidecar.Port)
-			if err != nil {
-				return nil, fmt.Errorf("sidecar port: %w", err)
-			}
-			port = p
-		}
-		sidecarBaseURL = strings.TrimSpace(serviceConfig.Sidecar.BaseURL)
+		sidecarBaseURL = serviceConfig.Sidecar.EffectiveBaseURL()
 	}
-	if sidecarBaseURL == "" {
-		sidecarBaseURL = fmt.Sprintf("http://localhost:%d", port)
-	}
-
 	namespace := resolveNamespace(string(evaluation.Resource.Tenant))
 	spec, err := shared.BuildJobSpec(evaluation, provider.Resource.ID, benchmarkConfig, benchmarkIndex, &sidecarBaseURL)
 	if err != nil {

--- a/internal/eval_hub/runtimes/k8s/job_config_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_config_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
@@ -105,7 +104,7 @@ func TestBuildJobConfigDefaults(t *testing.T) {
 	}
 }
 
-func TestBuildJobConfigRejectsInvalidSidecarPort(t *testing.T) {
+func TestBuildJobConfigUsesBaseURL(t *testing.T) {
 	evaluation := &api.EvaluationJobResource{
 		Resource: api.EvaluationResource{
 			Resource: api.Resource{ID: "job-123"},
@@ -131,45 +130,7 @@ func TestBuildJobConfigRejectsInvalidSidecarPort(t *testing.T) {
 		},
 	}
 	serviceConfig := &config.Config{
-		Sidecar: &config.SidecarConfig{Port: 70000},
-	}
-
-	_, err := buildJobConfig(evaluation, provider, &evaluation.Benchmarks[0], 0, serviceConfig, nil)
-	if err == nil {
-		t.Fatal("buildJobConfig() = nil, want sidecar port error")
-	}
-	if !strings.Contains(err.Error(), "sidecar port") {
-		t.Fatalf("buildJobConfig() error = %v, want sidecar port error", err)
-	}
-}
-
-func TestBuildJobConfigUsesValidSidecarPort(t *testing.T) {
-	evaluation := &api.EvaluationJobResource{
-		Resource: api.EvaluationResource{
-			Resource: api.Resource{ID: "job-123"},
-		},
-		EvaluationJobConfig: api.EvaluationJobConfig{
-			Model: &api.ModelRef{
-				URL:  "http://model",
-				Name: "model",
-			},
-			Benchmarks: []api.EvaluationBenchmarkConfig{
-				{Ref: api.Ref{ID: "bench-1"}},
-			},
-		},
-	}
-	provider := &api.ProviderResource{
-		Resource: api.Resource{ID: "provider-1"},
-		ProviderConfig: api.ProviderConfig{
-			Runtime: &api.Runtime{
-				K8s: &api.K8sRuntime{
-					Image: "adapter:latest",
-				},
-			},
-		},
-	}
-	serviceConfig := &config.Config{
-		Sidecar: &config.SidecarConfig{Port: 9090},
+		Sidecar: &config.SidecarConfig{BaseURL: "http://localhost:9090"},
 	}
 
 	cfg, err := buildJobConfig(evaluation, provider, &evaluation.Benchmarks[0], 0, serviceConfig, nil)

--- a/internal/eval_hub/runtimes/k8s/job_env_resources.go
+++ b/internal/eval_hub/runtimes/k8s/job_env_resources.go
@@ -8,13 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func sidecarPortFromInt(port int) (int32, error) {
-	if port < 1 || port > 65535 {
-		return 0, fmt.Errorf("port %d out of range (1-65535)", port)
-	}
-	return int32(port), nil
-}
-
 func buildContainerCommand(entrypoint []string) []string {
 	if len(entrypoint) == 0 {
 		return nil

--- a/internal/eval_hub/runtimes/k8s/job_env_resources_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_env_resources_test.go
@@ -8,24 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestSidecarPortFromInt(t *testing.T) {
-	t.Parallel()
-
-	got, err := sidecarPortFromInt(8080)
-	if err != nil {
-		t.Fatalf("sidecarPortFromInt(8080) = %v, want nil error", err)
-	}
-	if got != 8080 {
-		t.Fatalf("sidecarPortFromInt(8080) = %d, want 8080", got)
-	}
-
-	for _, port := range []int{0, -1, 65536} {
-		if _, err := sidecarPortFromInt(port); err == nil {
-			t.Fatalf("sidecarPortFromInt(%d) = nil error, want out of range error", port)
-		}
-	}
-}
-
 func TestBuildJobAdapterImagePullPolicy(t *testing.T) {
 	base := &jobConfig{
 		jobID:          "job-pull",

--- a/internal/eval_hub/runtimes/k8s/k8s_helper.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper.go
@@ -328,7 +328,7 @@ func (h *KubernetesHelper) PatchJobPhaseLabel(ctx context.Context, namespace, na
 	patch := map[string]any{
 		"metadata": map[string]any{
 			"labels": map[string]string{
-				"trustyai.opendatahub.io/evaluation-phase": phase,
+				labelEvaluationPhaseKey: phase,
 			},
 		},
 	}

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
@@ -18,9 +18,7 @@ func sidecarForJobPod(cfg *config.Config, jc *jobConfig) (*config.SidecarConfig,
 	} else {
 		export = &config.SidecarConfig{}
 	}
-	if export.Port == 0 {
-		export.Port = int(defaultSidecarPort)
-	}
+	export.BaseURL = export.EffectiveBaseURL()
 
 	if jc != nil {
 		if jc.evalHubURL != "" {
@@ -85,7 +83,7 @@ func cloneSidecarConfig(sc *config.SidecarConfig) *config.SidecarConfig {
 	if sc == nil {
 		return nil
 	}
-	out := &config.SidecarConfig{Port: sc.Port, BaseURL: sc.BaseURL}
+	out := &config.SidecarConfig{BaseURL: sc.BaseURL, Port: sc.Port}
 	if sc.EvalHub != nil {
 		eh := *sc.EvalHub
 		out.EvalHub = &eh

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json_test.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json_test.go
@@ -47,7 +47,6 @@ func TestSidecarForJobPodIncludesOTEL(t *testing.T) {
 			ExporterType:     otel.ExporterTypeStdout,
 			ExporterInsecure: true,
 		},
-		Sidecar: &config.SidecarConfig{Port: 8080},
 	}
 	jc := &jobConfig{evalHubURL: "http://eval-hub:8080"}
 

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json_test.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json_test.go
@@ -39,6 +39,32 @@ func TestOtelConfigForJobPod(t *testing.T) {
 	})
 }
 
+func TestSidecarForJobPod_UsesEffectiveBaseURL(t *testing.T) {
+	t.Run("preserves explicit BaseURL from sidecar config", func(t *testing.T) {
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{BaseURL: "https://sidecar.example:9443"},
+		}
+		export, err := sidecarForJobPod(cfg, &jobConfig{evalHubURL: "http://eval-hub:8080"})
+		if err != nil {
+			t.Fatalf("sidecarForJobPod: %v", err)
+		}
+		if export.BaseURL != "https://sidecar.example:9443" {
+			t.Fatalf("BaseURL = %q, want %q", export.BaseURL, "https://sidecar.example:9443")
+		}
+	})
+
+	t.Run("falls back to default when BaseURL empty", func(t *testing.T) {
+		cfg := &config.Config{Sidecar: &config.SidecarConfig{}}
+		export, err := sidecarForJobPod(cfg, &jobConfig{evalHubURL: "http://eval-hub:8080"})
+		if err != nil {
+			t.Fatalf("sidecarForJobPod: %v", err)
+		}
+		if export.BaseURL != config.DefaultSidecarBaseURL {
+			t.Fatalf("BaseURL = %q, want default %q", export.BaseURL, config.DefaultSidecarBaseURL)
+		}
+	})
+}
+
 func TestSidecarForJobPodIncludesOTEL(t *testing.T) {
 	cfg := &config.Config{
 		OTEL: &config.OTELConfig{

--- a/internal/eval_runtime_sidecar/config/sidecar_runtime_config.go
+++ b/internal/eval_runtime_sidecar/config/sidecar_runtime_config.go
@@ -30,6 +30,12 @@ func LoadSidecarRuntimeConfig(sidecarJSONPath, version, build, buildDate string)
 	if err := json.Unmarshal(data, &sc); err != nil {
 		return nil, fmt.Errorf("parse sidecar config JSON: %w", err)
 	}
+	if sc.BaseURL == "" {
+		sc.BaseURL = config.DefaultSidecarBaseURL
+	}
+	if err := sc.ResolvePort(); err != nil {
+		return nil, err
+	}
 	if sc.EvalHub == nil {
 		sc.EvalHub = &config.EvalHubClientConfig{}
 	}

--- a/internal/eval_runtime_sidecar/config/sidecar_runtime_config_test.go
+++ b/internal/eval_runtime_sidecar/config/sidecar_runtime_config_test.go
@@ -10,7 +10,7 @@ func TestLoadSidecarRuntimeConfig(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sidecar_config.json")
 	json := `{
-  "port": 9090,
+  "base_url": "http://localhost:9090",
   "eval_hub": {
     "base_url": "https://hub.example:8443",
     "http_timeout": 5000000000
@@ -30,8 +30,8 @@ func TestLoadSidecarRuntimeConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSidecarRuntimeConfig: %v", err)
 	}
-	if cfg.Sidecar.Port != 9090 {
-		t.Fatalf("port %d", cfg.Sidecar.Port)
+	if cfg.Sidecar.BaseURL != "http://localhost:9090" {
+		t.Fatalf("base_url %s", cfg.Sidecar.BaseURL)
 	}
 	if cfg.Sidecar.EvalHub.BaseURL != "https://hub.example:8443" {
 		t.Fatalf("eval_hub: %+v", cfg.Sidecar.EvalHub)
@@ -56,12 +56,30 @@ func TestLoadSidecarRuntimeConfig_EmptyEvalHub(t *testing.T) {
 	}
 }
 
+func TestLoadSidecarRuntimeConfig_DefaultBaseURLAndPort(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar_config.json")
+	if err := os.WriteFile(path, []byte(`{"eval_hub":{"base_url":"https://hub.example"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadSidecarRuntimeConfig(path, "", "", "")
+	if err != nil {
+		t.Fatalf("LoadSidecarRuntimeConfig: %v", err)
+	}
+	if cfg.Sidecar.BaseURL != "http://localhost:8080" {
+		t.Fatalf("expected default base_url, got %q", cfg.Sidecar.BaseURL)
+	}
+	if cfg.Sidecar.Port != 8080 {
+		t.Fatalf("expected default port 8080, got %d", cfg.Sidecar.Port)
+	}
+}
+
 func TestLoadSidecarRuntimeConfig_OCISnakeCase(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sidecar_config.json")
 	// Snake_case keys as in /meta/sidecar_config.json on the pod
 	json := `{
-  "port": 8080,
+  "base_url": "http://localhost:8080",
   "eval_hub": { "base_url": "https://eval.example" },
   "oci": {
     "ca_cert_path": "/etc/certs/ca.pem",
@@ -90,7 +108,7 @@ func TestLoadSidecarRuntimeConfig_OTEL(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sidecar_config.json")
 	json := `{
-  "port": 8080,
+  "base_url": "http://localhost:8080",
   "eval_hub": { "base_url": "https://eval.example" },
   "otel": {
     "enabled": true,

--- a/internal/eval_runtime_sidecar/config/sidecar_runtime_config_test.go
+++ b/internal/eval_runtime_sidecar/config/sidecar_runtime_config_test.go
@@ -74,6 +74,18 @@ func TestLoadSidecarRuntimeConfig_DefaultBaseURLAndPort(t *testing.T) {
 	}
 }
 
+func TestLoadSidecarRuntimeConfig_InvalidBaseURL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar_config.json")
+	if err := os.WriteFile(path, []byte(`{"base_url":"http://localhost"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadSidecarRuntimeConfig(path, "", "", "")
+	if err == nil {
+		t.Fatal("expected error for base_url without explicit port")
+	}
+}
+
 func TestLoadSidecarRuntimeConfig_OCISnakeCase(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sidecar_config.json")

--- a/internal/eval_runtime_sidecar/proxy/http_client.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -69,6 +70,19 @@ func buildTLSConfig(caCertPath string, insecureSkipVerify bool, logger *slog.Log
 	return tlsConfig, nil
 }
 
+// schemeRequiresTLS returns true when the URL scheme is "https" or cannot be
+// determined (empty/unparseable), so callers default to the safer TLS path.
+func schemeRequiresTLS(rawURL string) bool {
+	if rawURL == "" {
+		return true
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return true
+	}
+	return u.Scheme == "https"
+}
+
 // NewHTTPClient creates an HTTP client for the eval-hub service from config.
 // Returns (nil, nil) when Sidecar.EvalHub is not configured.
 func NewEvalHubHTTPClient(config *config.Config, isOTELEnabled bool, logger *slog.Logger) (*http.Client, error) {
@@ -93,7 +107,7 @@ func NewEvalHubHTTPClient(config *config.Config, isOTELEnabled bool, logger *slo
 
 	var tlsConfig *tls.Config
 	var err error
-	if cfg != nil {
+	if cfg != nil && schemeRequiresTLS(cfg.BaseURL) {
 		tlsConfig, err = buildTLSConfig(caCertPath, insecureSkipVerify, logger, "EvalHub")
 		if err != nil {
 			return nil, err
@@ -120,9 +134,13 @@ func NewMLFlowHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logge
 	}
 
 	// TLS verification is always enabled for MLflow; use CACertPath for custom CAs.
-	tlsConfig, err := buildTLSConfig(mlflowConfig.CACertPath, false, logger, "MLflow")
-	if err != nil {
-		return nil, err
+	var tlsConfig *tls.Config
+	if schemeRequiresTLS(mlflowConfig.TrackingURI) {
+		var err error
+		tlsConfig, err = buildTLSConfig(mlflowConfig.CACertPath, false, logger, "MLflow")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	client := newHTTPClient(timeout, tlsConfig, isOTELEnabled, logger, "MLflow")
@@ -156,9 +174,17 @@ func NewModelHTTPClient(serviceConfig *config.Config, isOTELEnabled bool, logger
 	if mc != nil && mc.InsecureSkipVerify {
 		insecureSkipVerify = mc.InsecureSkipVerify
 	}
-	tlsConfig, err := buildTLSConfig(caCertPath, insecureSkipVerify, logger, "Model")
-	if err != nil {
-		return nil, err
+	targetURL := ""
+	if mc != nil {
+		targetURL = mc.URL
+	}
+	var tlsConfig *tls.Config
+	if schemeRequiresTLS(targetURL) {
+		var err error
+		tlsConfig, err = buildTLSConfig(caCertPath, insecureSkipVerify, logger, "Model")
+		if err != nil {
+			return nil, err
+		}
 	}
 	client := newHTTPClient(timeout, tlsConfig, isOTELEnabled, logger, "Model")
 	return client, nil

--- a/internal/eval_runtime_sidecar/proxy/http_client.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client.go
@@ -70,8 +70,8 @@ func buildTLSConfig(caCertPath string, insecureSkipVerify bool, logger *slog.Log
 	return tlsConfig, nil
 }
 
-// schemeRequiresTLS returns true when the URL scheme is "https" or cannot be
-// determined (empty/unparseable), so callers default to the safer TLS path.
+// schemeRequiresTLS returns false only for an explicit "http" scheme;
+// all other cases default to TLS. BaseURL scheme is validated by ResolvePort.
 func schemeRequiresTLS(rawURL string) bool {
 	if rawURL == "" {
 		return true
@@ -80,7 +80,7 @@ func schemeRequiresTLS(rawURL string) bool {
 	if err != nil {
 		return true
 	}
-	return u.Scheme == "https"
+	return u.Scheme != "http"
 }
 
 // NewHTTPClient creates an HTTP client for the eval-hub service from config.

--- a/internal/eval_runtime_sidecar/proxy/http_client_test.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client_test.go
@@ -17,6 +17,7 @@ func TestSchemeRequiresTLS(t *testing.T) {
 		{"empty defaults to true", "", true},
 		{"http does not require TLS", "http://localhost:8080", false},
 		{"https requires TLS", "https://evalhub.example.com", true},
+		{"no scheme defaults to true", "example.com", true},
 		{"unparseable defaults to true", "://bad", true},
 	}
 	for _, tc := range tests {
@@ -171,6 +172,136 @@ func TestNewMLFlowHTTPClient(t *testing.T) {
 			},
 		}
 		client, err := NewMLFlowHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+	})
+}
+
+func TestNewModelHTTPClient(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("returns nil when config is nil", func(t *testing.T) {
+		client, err := NewModelHTTPClient(nil, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client != nil {
+			t.Error("expected nil client when config is nil")
+		}
+	})
+
+	t.Run("returns nil when Sidecar is nil", func(t *testing.T) {
+		cfg := &config.Config{}
+		client, err := NewModelHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client != nil {
+			t.Error("expected nil client when Sidecar is nil")
+		}
+	})
+
+	t.Run("returns client with defaults when Model is nil", func(t *testing.T) {
+		cfg := &config.Config{Sidecar: &config.SidecarConfig{}}
+		client, err := NewModelHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+		if client.Timeout != DefaultHTTPTimeout {
+			t.Errorf("timeout = %v, want %v", client.Timeout, DefaultHTTPTimeout)
+		}
+	})
+
+	t.Run("http URL skips TLS config", func(t *testing.T) {
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				Model: &config.SidecarModelConfig{
+					URL: "http://localhost:8080",
+				},
+			},
+		}
+		client, err := NewModelHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+	})
+
+	t.Run("https URL with insecure_skip_verify", func(t *testing.T) {
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				Model: &config.SidecarModelConfig{
+					URL:                "https://model.example.com",
+					InsecureSkipVerify: true,
+				},
+			},
+		}
+		client, err := NewModelHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+	})
+}
+
+func TestNewOCIHTTPClient(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("returns nil when config is nil", func(t *testing.T) {
+		client, err := NewOCIHTTPClient(nil, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client != nil {
+			t.Error("expected nil client when config is nil")
+		}
+	})
+
+	t.Run("returns nil when Sidecar is nil", func(t *testing.T) {
+		cfg := &config.Config{}
+		client, err := NewOCIHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client != nil {
+			t.Error("expected nil client when Sidecar is nil")
+		}
+	})
+
+	t.Run("returns client with defaults when OCI is nil", func(t *testing.T) {
+		cfg := &config.Config{Sidecar: &config.SidecarConfig{}}
+		client, err := NewOCIHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+		if client.Timeout != DefaultHTTPTimeout {
+			t.Errorf("timeout = %v, want %v", client.Timeout, DefaultHTTPTimeout)
+		}
+	})
+
+	t.Run("uses custom timeout from OCI config", func(t *testing.T) {
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				OCI: &config.SidecarOCIConfig{
+					HTTPTimeout: 60_000_000_000,
+				},
+			},
+		}
+		client, err := NewOCIHTTPClient(cfg, false, logger)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/internal/eval_runtime_sidecar/proxy/http_client_test.go
+++ b/internal/eval_runtime_sidecar/proxy/http_client_test.go
@@ -7,6 +7,28 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 )
 
+func TestSchemeRequiresTLS(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		url    string
+		expect bool
+	}{
+		{"empty defaults to true", "", true},
+		{"http does not require TLS", "http://localhost:8080", false},
+		{"https requires TLS", "https://evalhub.example.com", true},
+		{"unparseable defaults to true", "://bad", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := schemeRequiresTLS(tc.url); got != tc.expect {
+				t.Errorf("schemeRequiresTLS(%q) = %v, want %v", tc.url, got, tc.expect)
+			}
+		})
+	}
+}
+
 func TestNewEvalHubHTTPClient(t *testing.T) {
 	logger := slog.Default()
 
@@ -48,6 +70,41 @@ func TestNewEvalHubHTTPClient(t *testing.T) {
 		}
 		if client.Timeout == 0 {
 			t.Error("expected non-zero timeout")
+		}
+	})
+
+	t.Run("http URL skips TLS config without insecure_skip_verify", func(t *testing.T) {
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				EvalHub: &config.EvalHubClientConfig{
+					BaseURL: "http://localhost:8080",
+				},
+			},
+		}
+		client, err := NewEvalHubHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+	})
+
+	t.Run("https URL with insecure_skip_verify does not require CA cert", func(t *testing.T) {
+		cfg := &config.Config{
+			Sidecar: &config.SidecarConfig{
+				EvalHub: &config.EvalHubClientConfig{
+					BaseURL:            "https://evalhub.example.com",
+					InsecureSkipVerify: true,
+				},
+			},
+		}
+		client, err := NewEvalHubHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
 		}
 	})
 }
@@ -104,6 +161,21 @@ func TestNewMLFlowHTTPClient(t *testing.T) {
 		}
 		if client.Timeout == 0 {
 			t.Error("expected non-zero timeout")
+		}
+	})
+
+	t.Run("http TrackingURI skips TLS config", func(t *testing.T) {
+		cfg := &config.Config{
+			MLFlow: &config.MLFlowConfig{
+				TrackingURI: "http://localhost:5000",
+			},
+		}
+		client, err := NewMLFlowHTTPClient(cfg, false, logger)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
 		}
 	})
 }

--- a/internal/eval_runtime_sidecar/server/server.go
+++ b/internal/eval_runtime_sidecar/server/server.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
@@ -24,37 +22,24 @@ type SidecarServer struct {
 
 // NewSidecarServer creates a new sidecar HTTP server with the given logger and config.
 func NewSidecarServer(logger *slog.Logger,
-	config *config.Config,
+	cfg *config.Config,
 ) (*SidecarServer, error) {
 
 	if logger == nil {
 		return nil, fmt.Errorf("logger is required for the server")
 	}
-	if config == nil {
+	if cfg == nil {
 		return nil, fmt.Errorf("service config is required for the sidecar server")
 	}
 
-	port := 8080
-
-	if config.Sidecar != nil {
-		if baseURL := strings.TrimSpace(config.Sidecar.BaseURL); baseURL != "" {
-			if strings.Contains(baseURL, ":") {
-				parts := strings.Split(baseURL, ":")
-				portStr := parts[len(parts)-1]
-				portInt, err := strconv.Atoi(portStr)
-				if err != nil {
-					logger.Warn("invalid port in base URL, using default port 8080", "error", err)
-				} else {
-					port = portInt
-				}
-			}
-		}
+	if cfg.Sidecar == nil {
+		return nil, fmt.Errorf("sidecar config is required")
 	}
 
 	return &SidecarServer{
-		port:   port,
+		port:   cfg.Sidecar.Port,
 		logger: logger,
-		config: config,
+		config: cfg,
 	}, nil
 }
 

--- a/internal/eval_runtime_sidecar/server/server.go
+++ b/internal/eval_runtime_sidecar/server/server.go
@@ -15,7 +15,7 @@ import (
 
 type SidecarServer struct {
 	httpServer *http.Server
-	port       int
+	port       int32
 	logger     *slog.Logger
 	config     *config.Config
 }
@@ -48,7 +48,7 @@ func (s *SidecarServer) isOTELEnabled() bool {
 }
 
 func (s *SidecarServer) GetPort() int {
-	return s.port
+	return int(s.port)
 }
 
 func (s *SidecarServer) setupRoutes() (http.Handler, error) {

--- a/internal/eval_runtime_sidecar/server/server_test.go
+++ b/internal/eval_runtime_sidecar/server/server_test.go
@@ -35,30 +35,23 @@ func TestNewSidecarServer(t *testing.T) {
 		}
 	})
 
-	t.Run("uses default port 8080 when Sidecar is nil", func(t *testing.T) {
+	t.Run("returns error when sidecar config is nil", func(t *testing.T) {
 		cfg := &config.Config{}
-		srv, err := sidecarServer.NewSidecarServer(logger, cfg)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		_, err := sidecarServer.NewSidecarServer(logger, cfg)
+		if err == nil {
+			t.Fatal("expected error when sidecar config is nil")
 		}
-		if srv.GetPort() != 8080 {
-			t.Errorf("expected port 8080, got %d", srv.GetPort())
-		}
-	})
-
-	t.Run("uses default port 8080 when Sidecar.Port is 0", func(t *testing.T) {
-		cfg := &config.Config{Sidecar: &config.SidecarConfig{}}
-		srv, err := sidecarServer.NewSidecarServer(logger, cfg)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if srv.GetPort() != 8080 {
-			t.Errorf("expected port 8080, got %d", srv.GetPort())
+		if err.Error() != "sidecar config is required" {
+			t.Errorf("unexpected error: %v", err)
 		}
 	})
 
-	t.Run("uses Sidecar.Port when set", func(t *testing.T) {
-		cfg := &config.Config{Sidecar: &config.SidecarConfig{BaseURL: "http://localhost:9090"}}
+	t.Run("uses port from Sidecar.BaseURL when set", func(t *testing.T) {
+		sc := &config.SidecarConfig{BaseURL: "http://localhost:9090"}
+		if err := sc.ResolvePort(); err != nil {
+			t.Fatal(err)
+		}
+		cfg := &config.Config{Sidecar: sc}
 		srv, err := sidecarServer.NewSidecarServer(logger, cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -71,7 +64,11 @@ func TestNewSidecarServer(t *testing.T) {
 
 func TestSidecarServer_GetPort(t *testing.T) {
 	logger := slog.Default()
-	cfg := &config.Config{Sidecar: &config.SidecarConfig{BaseURL: "http://localhost:3000"}}
+	sc := &config.SidecarConfig{BaseURL: "http://localhost:3000"}
+	if err := sc.ResolvePort(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Sidecar: sc}
 	srv, err := sidecarServer.NewSidecarServer(logger, cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -85,7 +82,7 @@ func TestSidecarServer_SetupRoutes(t *testing.T) {
 	logger := slog.Default()
 	cfg := &config.Config{
 		Sidecar: &config.SidecarConfig{
-			Port: 8080,
+			BaseURL: "http://localhost:8080",
 			EvalHub: &config.EvalHubClientConfig{
 				BaseURL:            "http://localhost:8080",
 				InsecureSkipVerify: true,
@@ -113,7 +110,7 @@ func TestSidecarServer_HealthEndpoint(t *testing.T) {
 	logger := slog.Default()
 	cfg := &config.Config{
 		Sidecar: &config.SidecarConfig{
-			Port: 8080,
+			BaseURL: "http://localhost:8080",
 			EvalHub: &config.EvalHubClientConfig{
 				BaseURL:            "http://localhost:8080",
 				InsecureSkipVerify: true,

--- a/scripts/start_sidecar.sh
+++ b/scripts/start_sidecar.sh
@@ -19,8 +19,10 @@ fi
 if [[ -f "${CONFIG_FILE}" ]]; then
   SIDECAR_JSON="${CONFIG_FILE}"
 else
-  TMP_JSON="/tmp/sidecar_runtime_$$.json"
-  printf '{"base_url":"http://localhost:8080","eval_hub":{"base_url":"http://localhost:8080"},"mlflow":{"tracking_uri":"http://localhost:5000"}}\n' > "${TMP_JSON}"
+  TMP_JSON="$(mktemp /tmp/sidecar_runtime_XXXXXX.json)" || { echo "Failed to create temp config"; exit 2; }
+  chmod 600 "${TMP_JSON}"
+  trap 'rm -f "${TMP_JSON}"' EXIT
+  printf '{"base_url":"http://localhost:8080","eval_hub":{"base_url":"http://localhost:8080"},"mlflow":{"tracking_uri":"http://localhost:5000"}}\n' > "${TMP_JSON}" || { echo "Failed to write temp config"; exit 2; }
   SIDECAR_JSON="${TMP_JSON}"
 fi
 "${EXE}" --sidecarconfig "${SIDECAR_JSON}" >> "${LOGFILE}" 2>&1 &

--- a/scripts/start_sidecar.sh
+++ b/scripts/start_sidecar.sh
@@ -1,33 +1,30 @@
 #!/bin/bash
 
 # Start the eval-runtime-sidecar in the background.
-# Usage: start_sidecar.sh <PID_FILE> <EXE> <LOGFILE> <SIDECAR_PORT> <CONFIG_DIR>
-# CONFIG_DIR defaults to repo config/; uses sidecar_runtime_local.json if present,
-# else writes a minimal JSON using SIDECAR_PORT.
+# Usage: start_sidecar.sh <PID_FILE> <EXE> <LOGFILE> <CONFIG_FILE>
+# CONFIG_FILE defaults to config/sidecar_runtime_local.json.
+# If the file does not exist a minimal fallback JSON is generated
+# (port is derived from base_url by the binary).
 
 PID_FILE="$1"
 EXE="$2"
 LOGFILE="$3"
-SIDECAR_PORT="$4"
-CONFIG_DIR="${5:-config}"
+CONFIG_FILE="${4:-config/sidecar_runtime_local.json}"
 
 if [[ ! -f "${EXE}" ]]; then
   echo "The sidecar executable ${EXE} does not exist"
   exit 2
 fi
 
-export SIDECAR_PORT="${SIDECAR_PORT}"
-SIDECAR_JSON="${CONFIG_DIR}/sidecar_runtime_local.json"
-if [[ -f "${SIDECAR_JSON}" ]]; then
-  :
+if [[ -f "${CONFIG_FILE}" ]]; then
+  SIDECAR_JSON="${CONFIG_FILE}"
 else
   TMP_JSON="/tmp/sidecar_runtime_$$.json"
-  PORT="${SIDECAR_PORT:-8080}"
-  printf '{"port":%s,"base_url":"http://localhost:%s","eval_hub":{"base_url":"http://localhost:8080"},"mlflow":{"tracking_uri":"http://localhost:5000"}}\n' "${PORT}" "${PORT}" > "${TMP_JSON}"
+  printf '{"base_url":"http://localhost:8080","eval_hub":{"base_url":"http://localhost:8080"},"mlflow":{"tracking_uri":"http://localhost:5000"}}\n' > "${TMP_JSON}"
   SIDECAR_JSON="${TMP_JSON}"
 fi
 "${EXE}" --sidecarconfig "${SIDECAR_JSON}" >> "${LOGFILE}" 2>&1 &
 SERVICE_PID=$!
 echo "${SERVICE_PID}" > "${PID_FILE}"
 sleep 2
-echo "Started the sidecar with PID ${SERVICE_PID} (port ${SIDECAR_PORT}, config ${CONFIG_DIR}), PID file ${PID_FILE}, log ${LOGFILE}"
+echo "Started the sidecar with PID ${SERVICE_PID} (config ${SIDECAR_JSON}), PID file ${PID_FILE}, log ${LOGFILE}"


### PR DESCRIPTION


## What and why
Sidecar does not use "port" information , it only uses "base_url" information from where it extracts the port information also. The eval-hub server still have "port" fields in the config + in the generated job.json . This needs to be cleaned up.

Changes:
Replace the standalone sidecar.port config field with port derivation from base_url via SidecarConfig.ResolvePort(). This eliminates a redundant config knob that could drift out of sync with the URL and simplifies the Makefile, start script, and sidecar server initialization.

- Add ResolvePort() to extract port from base_url at config load time
- Add EffectiveBaseURL() to DRY the fallback-to-default pattern across three call sites (handlers, job_config, sidecar_config_json)
- Remove sidecarPortFromInt helper and SIDECAR_PORT env var mapping
- Simplify start_sidecar.sh to accept a config file path directly
- Update all tests to use base_url instead of port


Closes # NA

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

sidecar-config.json generated wihtout "port" now. Evaluation completed successfully
<img width="873" height="206" alt="Screenshot 2026-08-07 at 4 11 02 PM" src="https://github.com/user-attachments/assets/30528dda-d72a-4c93-917c-4ff98bad9ea5" />
<img width="892" height="779" alt="Screenshot 2026-08-07 at 4 09 11 PM" src="https://github.com/user-attachments/assets/a6e0c195-8e00-4a27-836a-29662282d815" />

sidecar started without "port" locally, without requiring insecure_verify 
<img width="1148" height="662" alt="Screenshot 2026-08-07 at 4 13 28 PM" src="https://github.com/user-attachments/assets/ef7aa19b-b1fb-4318-8c89-596650a3be5a" />


## Breaking changes
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Sidecar setup now uses a single configuration file and derives its port from the configured base URL.
  * Added localhost defaults and support for custom HTTP/HTTPS URLs and ports.
  * Kubernetes jobs and startup probes now use the resolved sidecar port consistently.

* **Bug Fixes**
  * Improved validation and error reporting for invalid sidecar URLs and ports.
  * HTTP connections no longer receive unnecessary TLS configuration.

* **Developer Experience**
  * Sidecar startup logging now displays the configuration file path.
  * Simplified startup options and fallback configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->