### PR TITLE
feat(k8s): set evaluation-status annotation on Job lifecycle transitions (RHAI-280)

### DIFF
--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -92,6 +92,7 @@ const (
 	labelKueueQueueNameKey           = "kueue.x-k8s.io/queue-name"
 	labelKueuePriorityClassKey       = "kueue.x-k8s.io/priority-class"
 	labelEvaluationPhaseKey          = "trustyai.opendatahub.io/evaluation-phase"
+	annotationEvaluationStatusKey    = "trustyai.opendatahub.io/evaluation-status"
 )
 
 var (

--- a/internal/eval_hub/runtimes/k8s/k8s_helper.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper.go
@@ -316,6 +316,31 @@ func (h *KubernetesHelper) EmitEvent(job *batchv1.Job, eventtype, reason, messag
 	return nil
 }
 
+// PatchJobStatusAnnotation patches the trustyai.opendatahub.io/evaluation-status annotation on a Job
+// with a JSON-encoded status payload. The annotation is best-effort; callers must not block on failures.
+func (h *KubernetesHelper) PatchJobStatusAnnotation(ctx context.Context, namespace, name string, payload map[string]any) error {
+	if namespace == "" || name == "" {
+		return fmt.Errorf("namespace and name are required")
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal annotation payload: %w", err)
+	}
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				annotationEvaluationStatusKey: string(data),
+			},
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshal patch: %w", err)
+	}
+	_, err = h.clientset.BatchV1().Jobs(namespace).Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	return err
+}
+
 // PatchJobPhaseLabel patches the trustyai.opendatahub.io/evaluation-phase label on a Job.
 // Patching metadata labels does not restart the Job or its Pods.
 func (h *KubernetesHelper) PatchJobPhaseLabel(ctx context.Context, namespace, name, phase string) error {

--- a/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_helper_test.go
@@ -203,3 +203,44 @@ func TestPatchJobPhaseLabelUpdatesLabel(t *testing.T) {
 		t.Fatalf("expected label value Running, got %q", got)
 	}
 }
+
+func TestPatchJobStatusAnnotationRequiresNamespaceAndName(t *testing.T) {
+	helper := &KubernetesHelper{}
+	if err := helper.PatchJobStatusAnnotation(context.Background(), "", "job", map[string]any{}); err == nil {
+		t.Fatal("expected error for missing namespace")
+	}
+	if err := helper.PatchJobStatusAnnotation(context.Background(), "default", "", map[string]any{}); err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestPatchJobStatusAnnotationSetsAnnotation(t *testing.T) {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "default"},
+	}
+	clientset := fake.NewSimpleClientset(job)
+	helper := &KubernetesHelper{clientset: clientset}
+
+	payload := map[string]any{
+		"phase":           "Running",
+		"evaluation_id":   "eval-123",
+		"benchmark_index": 0,
+	}
+	if err := helper.PatchJobStatusAnnotation(context.Background(), "default", "job-1", payload); err != nil {
+		t.Fatalf("PatchJobStatusAnnotation: %v", err)
+	}
+	updated, err := clientset.BatchV1().Jobs("default").Get(context.Background(), "job-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	got := updated.Annotations[annotationEvaluationStatusKey]
+	if got == "" {
+		t.Fatal("expected evaluation-status annotation to be set")
+	}
+	if !strings.Contains(got, "eval-123") {
+		t.Fatalf("expected evaluation_id in annotation, got: %s", got)
+	}
+	if !strings.Contains(got, "Running") {
+		t.Fatalf("expected phase in annotation, got: %s", got)
+	}
+}

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle.go
@@ -65,6 +65,19 @@ func (r *K8sRuntime) NotifyJobPhaseTransition(ctx context.Context, evaluation *a
 				"error", patchErr,
 			)
 		}
+		statusPayload := map[string]any{
+			"phase":           phase,
+			"timestamp":       time.Now().UTC().Format(time.RFC3339),
+			"evaluation_id":   evaluation.Resource.ID,
+			"benchmark_index": benchmarkIndex,
+		}
+		if annotErr := r.helper.PatchJobStatusAnnotation(signalCtx, namespace, job.Name, statusPayload); annotErr != nil {
+			r.logger.WarnContext(signalCtx, "lifecycle signal: patch status annotation failed",
+				"job_name", job.Name,
+				"phase", phase,
+				"error", annotErr,
+			)
+		}
 		messageFmt := "benchmark %d phase transition: %s"
 		if emitErr := r.helper.EmitEvent(job, eventtype, reason, messageFmt, benchmarkIndex, phase); emitErr != nil {
 			r.logger.WarnContext(signalCtx, "lifecycle signal: emit event failed",

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle_test.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime_lifecycle_test.go
@@ -79,6 +79,9 @@ func TestNotifyJobPhaseTransitionPatchesLabel(t *testing.T) {
 	if got := updated.Labels[labelEvaluationPhaseKey]; got != "Running" {
 		t.Fatalf("expected label value Running, got %q", got)
 	}
+	if got := updated.Annotations[annotationEvaluationStatusKey]; got == "" {
+		t.Fatal("expected evaluation-status annotation to be set")
+	}
 }
 
 func TestNotifyJobPhaseTransitionEmitsEvent(t *testing.T) {
@@ -193,8 +196,8 @@ func TestNotifyJobPhaseTransitionPatchLabelError(t *testing.T) {
 		helper: NewKubernetesHelperWithRecorder(clientset, fakeRecorder),
 	}
 	rt.NotifyJobPhaseTransition(context.Background(), evaluation, 0, api.StateRunning)
-	if patchCalled != 1 {
-		t.Fatalf("expected patch to be called once, got %d", patchCalled)
+	if patchCalled != 2 {
+		t.Fatalf("expected patch to be called twice (phase label + status annotation), got %d", patchCalled)
 	}
 	select {
 	case msg := <-fakeRecorder.Events:
@@ -233,6 +236,9 @@ func TestNotifyJobPhaseTransitionFailedState(t *testing.T) {
 	}
 	if got := updated.Labels[labelEvaluationPhaseKey]; got != "Failed" {
 		t.Fatalf("expected label value Failed, got %q", got)
+	}
+	if got := updated.Annotations[annotationEvaluationStatusKey]; got == "" {
+		t.Fatal("expected evaluation-status annotation to be set for Failed state")
 	}
 
 	select {


### PR DESCRIPTION
## What and why

Extends the Kubernetes-native evaluation lifecycle signals feature (RHAISTRAT-1923) with the P1 `evaluation-status` annotation.

`NotifyJobPhaseTransition` already patches the `trustyai.opendatahub.io/evaluation-phase` label and emits a Kubernetes Event on each lifecycle transition. This PR adds a second, structured signal: the `trustyai.opendatahub.io/evaluation-status` annotation, which carries a JSON payload containing the phase, RFC3339 timestamp, evaluation ID, and benchmark index.

The annotation is intended for consumers that need machine-readable structured state without parsing Event messages (e.g. policy controllers that want to read the evaluation ID or timestamp alongside the outcome) without querying the EvalHub API.

Both operations remain best-effort: annotation patch failures are logged at warn level and do not block the evaluation job lifecycle or the Event emission that follows.

Relates to https://redhat.atlassian.net/browse/RHAISTRAT-1923 (P1 item)

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

Unit tests added in `k8s_helper_test.go`:
- `TestPatchJobStatusAnnotationRequiresNamespaceAndName`: guards against missing namespace/name
- `TestPatchJobStatusAnnotationSetsAnnotation`: verifies the JSON payload is written and contains the expected fields

`k8s_runtime_lifecycle_test.go` extended:
- `TestNotifyJobPhaseTransitionPatchesLabel` asserts the annotation is set alongside the phase label on a Running transition
- `TestNotifyJobPhaseTransitionFailedState` asserts the annotation is set for a Failed transition
- `TestNotifyJobPhaseTransitionPatchLabelError` patch-call count updated from 1 -> 2 (label patch + annotation patch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes evaluation jobs now record phase, timestamp, evaluation ID, and benchmark information in their status.
  * Status updates are applied without interrupting evaluation event processing if an update fails.

* **Bug Fixes**
  * Improved handling and validation of job status updates, including namespace and job name checks.

* **Tests**
  * Added coverage for successful status updates, required field validation, payload preservation, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->