### PR TITLE
ci: add pre-commit file hygiene checks to CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,46 @@
+name: Pre-commit file checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install pre-commit
+        run: uv pip install --system pre-commit
+
+      - name: Run file hygiene checks
+        run: |
+          pre-commit run end-of-file-fixer --all-files
+          pre-commit run trailing-whitespace --all-files
+          pre-commit run check-yaml --all-files
+          pre-commit run check-json --all-files
+          pre-commit run check-toml --all-files
+          pre-commit run check-merge-conflict --all-files
+          pre-commit run check-added-large-files --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,14 +33,19 @@ jobs:
           python-version: '3.12'
 
       - name: Install pre-commit
-        run: uv pip install --system pre-commit
+        run: uv pip install --system pre-commit==4.6.2
 
       - name: Run file hygiene checks
         run: |
-          pre-commit run end-of-file-fixer --all-files
-          pre-commit run trailing-whitespace --all-files
-          pre-commit run check-yaml --all-files
-          pre-commit run check-json --all-files
-          pre-commit run check-toml --all-files
-          pre-commit run check-merge-conflict --all-files
-          pre-commit run check-added-large-files --all-files
+          failed=0
+          for hook in \
+            end-of-file-fixer \
+            trailing-whitespace \
+            check-yaml \
+            check-json \
+            check-toml \
+            check-merge-conflict \
+            check-added-large-files; do
+            pre-commit run "$hook" --all-files || failed=1
+          done
+          exit "$failed"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.5
+    rev: v4.17.0
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1292,7 +1292,7 @@ Feature: Evaluation Jobs
     And the response should contain the value "{{env:TEST_DATA_PVC_MISSING_CLAIM_NAME|evalhub-offline-test-data-does-not-exist}}" at path "$.status.benchmarks[0].error_message.message"
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
-  
+
   @mlflow
   Scenario: Card generated for completed job with benchmarks
     Given the service is running
@@ -1310,7 +1310,7 @@ Feature: Evaluation Jobs
     And the MLflow artifact should contain the value "{{value:job_id}}" at path "$.metadata.evaluation_job_id"
     And the MLflow artifact should contain the value "{{env:MODEL_NAME|test}}" at path "$.context.model.name"
     And the MLflow artifact should contain "arc_easy"
-  
+
   @mlflow
   Scenario: Card generated for completed job with collection
     Given the service is running
@@ -1593,7 +1593,7 @@ Feature: Evaluation Jobs
     And the MLflow artifact should contain "results.benchmarks[0].error_message.message"
     And the MLflow artifact should contain "results.benchmarks[0].error_message.message_code"
     And the MLflow artifact should contain "results.benchmarks[0].error_message.message_origin"
-  
+
   @mlflow
   Scenario: EvalCard artifact is valid parseable JSON for failed job
     Given the service is running
@@ -1608,7 +1608,7 @@ Feature: Evaluation Jobs
     When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:experiment_id}}" and job "{{value:job_id}}"
     Then the MLflow artifact should exist
     And the MLflow artifact should be valid JSON
- 
+
   @mlflow
   Scenario: Card generated for job with no pass_criteria
     Given the service is running

--- a/tests/features/k8s_lifecycle_signals.feature
+++ b/tests/features/k8s_lifecycle_signals.feature
@@ -44,4 +44,3 @@ Feature: Kubernetes Lifecycle Signals
     And the evaluation Job should have label "trustyai.opendatahub.io/evaluation-phase" equal to "Failed"
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
-

--- a/tests/features/mcp.feature
+++ b/tests/features/mcp.feature
@@ -712,7 +712,7 @@ Feature: MCP Tools
     And the MCP response should contain the value "completed" at path "$.state"
     When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:mcp_job_id}}"
     Then the MLflow artifact should exist
- 
+
   @mlflow @cluster
   Scenario: MCP resource returns job with mlflow_run_id for completed job with evalcard
     Given the service is running


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow (`.github/workflows/pre-commit.yml`) that runs the lightweight file-hygiene hooks already defined in `.pre-commit-config.yaml` on every PR and push to `main`.
- Enforces **trailing newline** (`end-of-file-fixer`), **trailing whitespace**, YAML/JSON/TOML validity, merge-conflict markers, and large-file guards in CI — catching issues for contributors who have not installed pre-commit hooks locally.
- Follows existing workflow conventions: pinned action SHAs, `harden-runner`, `persist-credentials: false`, and `uv` for Python tooling.

## Test plan

- [x] Verify the new workflow runs successfully on this PR
- [x] Confirm `end-of-file-fixer` correctly flags files missing a trailing newline
- [x] Confirm `trailing-whitespace` correctly flags files with trailing whitespace


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated repository checks for formatting, syntax errors, merge conflicts, and oversized files on pull requests and pushes to the main branch.

* **Chores**
  * Updated the Commitizen validation hook.
  * Cleaned up whitespace and formatting in feature test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->