### PR TITLE
chore: rename "Safety & Fairness" collection to "Safety and Fairness"

### DIFF
--- a/config/collections/safety-and-fairness-v1.yaml
+++ b/config/collections/safety-and-fairness-v1.yaml
@@ -1,5 +1,5 @@
 id: safety-and-fairness-v1
-name: Safety & Fairness
+name: Safety and Fairness
 category: safety
 description: Evaluates model safety, bias, and fairness across diverse scenarios.
 tags:

--- a/config/providers/inspect.yaml
+++ b/config/providers/inspect.yaml
@@ -339,7 +339,7 @@ benchmarks:
   # Task: inspect_evals/<name> | Uses --model flag (single model, no roles)
   # -----------------------------------------------------------------------
 
-  # Safety & alignment
+  # Safety and alignment
   - id: inspect/agentharm
     name: AgentHarm
     description: Evaluates whether AI agents can be induced to perform harmful actions across real-world tool-use scenarios.

--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -669,7 +669,7 @@ Feature: Collections Endpoint
     And there is a system collection with id "safety-and-fairness-v1"
     When I send a GET request to "/api/v1/evaluations/collections/safety-and-fairness-v1"
     Then the response code should be 200
-    And the response should contain "name" with value "Safety & Fairness"
+    And the response should contain "name" with value "Safety and Fairness"
 
   Scenario: Verify out of box collection retrieval - category - safety-and-fairness-v1
     Given the service is running


### PR DESCRIPTION
## What and why

This is for the UI team that have guidelines for names that include `no ampersand`.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Renamed the “Safety & Fairness” collection to “Safety and Fairness.”
  * Updated the standard inspection section heading to “Safety and alignment.”
* **Tests**
  * Updated collection retrieval checks to reflect the revised collection name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->