### PR TITLE
fix: multi-benchmark sidecar 502 from shared model URL

### DIFF
--- a/internal/eval_hub/runtimes/shared/jobspec.go
+++ b/internal/eval_hub/runtimes/shared/jobspec.go
@@ -51,7 +51,7 @@ func BuildJobSpec(
 		ProviderID:     providerID,
 		BenchmarkID:    benchmarkConfig.ID,
 		BenchmarkIndex: benchmarkIndex,
-		Model:          evaluation.Model,
+		Model:          cloneModelRef(evaluation.Model),
 		NumExamples:    numExamples,
 		Parameters:     benchmarkParams,
 		CallbackURL:    callbackURL,
@@ -69,6 +69,24 @@ func BuildJobSpec(
 	}
 
 	return &spec, nil
+}
+
+// cloneModelRef returns a copy isolated from evaluation.Model so runtime code can
+// rewrite jobSpec.Model.URL (sidecar localhost) without mutating the job's model URL
+// used when creating later benchmarks in the same evaluation.
+func cloneModelRef(m *api.ModelRef) *api.ModelRef {
+	if m == nil {
+		return nil
+	}
+	out := *m
+	if m.Auth != nil {
+		auth := *m.Auth
+		out.Auth = &auth
+	}
+	if len(m.Parameters) > 0 {
+		out.Parameters = CopyParams(m.Parameters)
+	}
+	return &out
 }
 
 // CopyParams creates a shallow copy of a parameters map.

--- a/internal/eval_hub/runtimes/shared/jobspec_test.go
+++ b/internal/eval_hub/runtimes/shared/jobspec_test.go
@@ -195,6 +195,52 @@ func TestBuildJobSpec_ModelNotAliasedToEvaluation(t *testing.T) {
 	}
 }
 
+func TestBuildJobSpec_NilModel(t *testing.T) {
+	eval := baseEvaluation()
+	eval.Model = nil
+
+	spec, err := shared.BuildJobSpec(eval, "provider-1", &eval.Benchmarks[0], 0, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if spec.Model != nil {
+		t.Fatalf("expected nil Model, got %v", spec.Model)
+	}
+}
+
+func TestBuildJobSpec_ModelAuthNotAliased(t *testing.T) {
+	eval := baseEvaluation()
+	eval.Model.Auth = &api.ModelAuth{SecretRef: "model-token"}
+	spec, err := shared.BuildJobSpec(eval, "provider-1", &eval.Benchmarks[0], 0, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if spec.Model.Auth == eval.Model.Auth {
+		t.Fatal("expected job spec model auth to be a copy, not the same pointer as evaluation.Model.Auth")
+	}
+	spec.Model.Auth.SecretRef = "mutated"
+	if eval.Model.Auth.SecretRef != "model-token" {
+		t.Fatalf("mutating job spec model auth should not change evaluation.Model.Auth, got %q", eval.Model.Auth.SecretRef)
+	}
+}
+
+func TestBuildJobSpec_ModelParametersNotAliased(t *testing.T) {
+	eval := baseEvaluation()
+	eval.Model.Parameters = map[string]any{"temperature": 0.7}
+	spec, err := shared.BuildJobSpec(eval, "provider-1", &eval.Benchmarks[0], 0, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	spec.Model.Parameters["temperature"] = 1.0
+	if eval.Model.Parameters["temperature"] != 0.7 {
+		t.Fatalf("mutating job spec model parameters should not change evaluation.Model.Parameters, got %v", eval.Model.Parameters["temperature"])
+	}
+	spec.Model.Parameters["new_key"] = "value"
+	if _, exists := eval.Model.Parameters["new_key"]; exists {
+		t.Fatal("mutating job spec model parameters map should not affect evaluation.Model.Parameters")
+	}
+}
+
 func TestBuildJobSpecJSONNilCallbackURL(t *testing.T) {
 	eval := baseEvaluation()
 

--- a/internal/eval_hub/runtimes/shared/jobspec_test.go
+++ b/internal/eval_hub/runtimes/shared/jobspec_test.go
@@ -180,6 +180,21 @@ func TestBuildJobSpecJSONHappyPath(t *testing.T) {
 	}
 }
 
+func TestBuildJobSpec_ModelNotAliasedToEvaluation(t *testing.T) {
+	eval := baseEvaluation()
+	spec, err := shared.BuildJobSpec(eval, "provider-1", &eval.Benchmarks[0], 0, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if spec.Model == eval.Model {
+		t.Fatal("expected job spec model to be a copy, not the same pointer as evaluation.Model")
+	}
+	spec.Model.URL = "http://localhost:8080/v1"
+	if eval.Model.URL != "http://model.example" {
+		t.Fatalf("mutating job spec model URL should not change evaluation.Model.URL, got %q", eval.Model.URL)
+	}
+}
+
 func TestBuildJobSpecJSONNilCallbackURL(t *testing.T) {
 	eval := baseEvaluation()
 


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->
When creating resources for benchmark 0, the K8s runtime rewrites `jobSpec.Model.URL` to the sidecar (`http://localhost:8080/...`) so adapters call the sidecar proxy. Because `jobSpec.Model` pointed at the same `*ModelRef` as `evaluation.Model`, that rewrite also changed `evaluation.Model.URL`. 
For benchmark 1+, `modelTargetURL` was read from the corrupted URL, so `sidecar_config.json` pointed the proxy at itself → 502.

Changes:

- Fix multi-benchmark evaluation jobs where the second (and later) benchmark pods failed with 502 errors because the sidecar model proxy targeted `localhost` instead of the real model endpoint.
- `BuildJobSpec` now clones `evaluation.Model` into the per-benchmark job spec so K8s runtime can rewrite `jobSpec.Model.URL` to the sidecar address without mutating `evaluation.Model.URL`.
- Preserves the original model URL for subsequent benchmarks when `buildJobConfig` reads `modelTargetURL` and writes `sidecar_config.json`.


Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation job creation to prevent model configuration changes from unintentionally affecting the original evaluation.
  * Preserved correct behavior when model, authentication, or parameter data is absent.

* **Tests**
  * Added coverage for isolated model configuration, nested authentication and parameters, and nil model handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->