### PR TITLE
fix(storage): serialize system resource reloads and bulk-delete safely

### DIFF
--- a/internal/eval_hub/abstractions/storage.go
+++ b/internal/eval_hub/abstractions/storage.go
@@ -96,6 +96,8 @@ type Storage interface {
 
 	// LoadSystemResources reloads system-owned providers and collections into
 	// the database. Existing system resources are deleted and replaced.
+	// CreatedAt is preserved for existing IDs; UpdatedAt is preserved only when
+	// the serialized config is unchanged.
 	LoadSystemResources(systemCollections map[string]api.CollectionResource, systemProviders map[string]api.ProviderResource) error
 
 	// Close the storage connection

--- a/internal/eval_hub/config/watcher.go
+++ b/internal/eval_hub/config/watcher.go
@@ -21,6 +21,11 @@ type Watcher struct {
 	storage   abstractions.Storage
 	configDir string
 	debounce  time.Duration
+
+	// reloadMu serializes reload() so overlapping debounced callbacks cannot
+	// run LoadSystemResources concurrently. A second reload that starts while
+	// the first is still running waits, then re-reads configs from disk.
+	reloadMu sync.Mutex
 }
 
 // NewWatcher creates a config watcher that monitors the given config directory
@@ -144,7 +149,11 @@ func isRelevantEvent(event fsnotify.Event) bool {
 
 // reload re-reads provider and collection configs from disk and updates
 // the storage layer. Errors are logged but do not stop the watcher.
+// Concurrent reload invocations are serialized so only one runs at a time.
 func (w *Watcher) reload() {
+	w.reloadMu.Lock()
+	defer w.reloadMu.Unlock()
+
 	w.logger.Info("Reloading system providers and collections")
 
 	providerConfigs, providerErr := LoadProviderConfigs(w.logger, w.validate, w.configDir)

--- a/internal/eval_hub/config/watcher.go
+++ b/internal/eval_hub/config/watcher.go
@@ -25,6 +25,8 @@ type Watcher struct {
 	// reloadMu serializes reload() so overlapping debounced callbacks cannot
 	// run LoadSystemResources concurrently. A second reload that starts while
 	// the first is still running waits, then re-reads configs from disk.
+	// This is in addition to the storage-level systemResourcesMu which guards
+	// LoadSystemResources itself against any direct callers.
 	reloadMu sync.Mutex
 }
 

--- a/internal/eval_hub/config/watcher_test.go
+++ b/internal/eval_hub/config/watcher_test.go
@@ -144,6 +144,91 @@ func TestWatcher_DebouncesMutipleEvents(t *testing.T) {
 	}
 }
 
+func TestWatcher_SerializesOverlappingReloads(t *testing.T) {
+	logger := logging.FallbackLogger()
+	store := &blockingMockStorage{entered: make(chan struct{}, 1), release: make(chan struct{})}
+	validate := testhelpers.NewValidator(t)
+	w := NewWatcher(logger, validate, store, t.TempDir())
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		w.reload()
+	}()
+
+	select {
+	case <-store.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first reload to enter LoadSystemResources")
+	}
+
+	secondStarted := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		close(secondStarted)
+		w.reload()
+	}()
+	<-secondStarted
+	// Give the second reload a chance to race past the mutex if serialization is broken.
+	time.Sleep(100 * time.Millisecond)
+	if store.getInFlight() != 1 {
+		t.Fatalf("expected exactly one in-flight LoadSystemResources while first holds lock, got %d", store.getInFlight())
+	}
+	if store.getLoadCalls() != 1 {
+		t.Fatalf("expected second reload to wait on mutex, loadCalls=%d", store.getLoadCalls())
+	}
+
+	close(store.release)
+	wg.Wait()
+	if store.getLoadCalls() != 2 {
+		t.Fatalf("expected both reloads to complete, loadCalls=%d", store.getLoadCalls())
+	}
+	if store.getInFlight() != 0 {
+		t.Fatalf("expected no in-flight loads after completion, got %d", store.getInFlight())
+	}
+}
+
+// blockingMockStorage blocks inside LoadSystemResources until release is closed.
+type blockingMockStorage struct {
+	abstractions.Storage
+	mu        sync.Mutex
+	loadCalls int
+	inFlight  int
+	entered   chan struct{}
+	release   chan struct{}
+}
+
+func (m *blockingMockStorage) LoadSystemResources(_ map[string]api.CollectionResource, _ map[string]api.ProviderResource) error {
+	m.mu.Lock()
+	m.loadCalls++
+	m.inFlight++
+	m.mu.Unlock()
+
+	select {
+	case m.entered <- struct{}{}:
+	default:
+	}
+	<-m.release
+
+	m.mu.Lock()
+	m.inFlight--
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *blockingMockStorage) getLoadCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.loadCalls
+}
+
+func (m *blockingMockStorage) getInFlight() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.inFlight
+}
+
 func TestWatcher_StopsOnContextCancel(t *testing.T) {
 	dir := t.TempDir()
 	provDir := filepath.Join(dir, "providers")

--- a/internal/eval_hub/config/watcher_test.go
+++ b/internal/eval_hub/config/watcher_test.go
@@ -146,7 +146,11 @@ func TestWatcher_DebouncesMutipleEvents(t *testing.T) {
 
 func TestWatcher_SerializesOverlappingReloads(t *testing.T) {
 	logger := logging.FallbackLogger()
-	store := &blockingMockStorage{entered: make(chan struct{}, 1), release: make(chan struct{})}
+	store := &blockingMockStorage{
+		entered:  make(chan struct{}, 1),
+		proceed:  make(chan struct{}),
+		released: make(chan struct{}),
+	}
 	validate := testhelpers.NewValidator(t)
 	w := NewWatcher(logger, validate, store, t.TempDir())
 
@@ -157,29 +161,54 @@ func TestWatcher_SerializesOverlappingReloads(t *testing.T) {
 		w.reload()
 	}()
 
+	// Wait until the first reload is inside LoadSystemResources.
 	select {
 	case <-store.entered:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for first reload to enter LoadSystemResources")
 	}
 
-	secondStarted := make(chan struct{})
+	// Launch a second reload that must block on the watcher mutex.
+	secondBlocked := make(chan struct{})
 	go func() {
 		defer wg.Done()
-		close(secondStarted)
+		close(secondBlocked)
 		w.reload()
 	}()
-	<-secondStarted
-	// Give the second reload a chance to race past the mutex if serialization is broken.
-	time.Sleep(100 * time.Millisecond)
+	<-secondBlocked
+
+	// Wait until the second goroutine is actually parked on reloadMu.
+	// We know it's blocked when the watcher mutex has a waiter: the first
+	// reload still holds it and the second goroutine has started but
+	// hasn't entered LoadSystemResources.
+	deadline := time.After(2 * time.Second)
+	for store.getLoadCalls() < 1 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for first load call")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
 	if store.getInFlight() != 1 {
 		t.Fatalf("expected exactly one in-flight LoadSystemResources while first holds lock, got %d", store.getInFlight())
 	}
-	if store.getLoadCalls() != 1 {
-		t.Fatalf("expected second reload to wait on mutex, loadCalls=%d", store.getLoadCalls())
+
+	// Release the first reload.
+	store.proceed <- struct{}{}
+	<-store.released
+
+	// The second reload should now enter LoadSystemResources.
+	select {
+	case <-store.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second reload to enter LoadSystemResources")
 	}
 
-	close(store.release)
+	// Release the second reload.
+	store.proceed <- struct{}{}
+	<-store.released
+
 	wg.Wait()
 	if store.getLoadCalls() != 2 {
 		t.Fatalf("expected both reloads to complete, loadCalls=%d", store.getLoadCalls())
@@ -189,14 +218,17 @@ func TestWatcher_SerializesOverlappingReloads(t *testing.T) {
 	}
 }
 
-// blockingMockStorage blocks inside LoadSystemResources until release is closed.
+// blockingMockStorage blocks inside LoadSystemResources until a value is sent
+// on proceed, then signals released. Each call signals entered so the test can
+// observe exactly when LoadSystemResources is executing.
 type blockingMockStorage struct {
 	abstractions.Storage
 	mu        sync.Mutex
 	loadCalls int
 	inFlight  int
 	entered   chan struct{}
-	release   chan struct{}
+	proceed   chan struct{}
+	released  chan struct{}
 }
 
 func (m *blockingMockStorage) LoadSystemResources(_ map[string]api.CollectionResource, _ map[string]api.ProviderResource) error {
@@ -205,15 +237,14 @@ func (m *blockingMockStorage) LoadSystemResources(_ map[string]api.CollectionRes
 	m.inFlight++
 	m.mu.Unlock()
 
-	select {
-	case m.entered <- struct{}{}:
-	default:
-	}
-	<-m.release
+	m.entered <- struct{}{}
+	<-m.proceed
 
 	m.mu.Lock()
 	m.inFlight--
 	m.mu.Unlock()
+
+	m.released <- struct{}{}
 	return nil
 }
 

--- a/internal/eval_hub/storage/sql/collections.go
+++ b/internal/eval_hub/storage/sql/collections.go
@@ -21,6 +21,12 @@ func (s *sqlStorage) CreateCollection(collection *api.CollectionResource) error 
 }
 
 func (s *sqlStorage) createCollectionTxn(txn *sql.Tx, collection *api.CollectionResource) error {
+	if collection.Resource.CreatedAt.IsZero() {
+		collection.Resource.CreatedAt = time.Now()
+	}
+	if collection.Resource.UpdatedAt.IsZero() {
+		collection.Resource.UpdatedAt = collection.Resource.CreatedAt
+	}
 	collectionJSON, err := s.createCollectionEntity(collection)
 	if err != nil {
 		return serviceerrors.NewServiceError(messages.InternalServerError, "Error", err)

--- a/internal/eval_hub/storage/sql/postgres/statements.go
+++ b/internal/eval_hub/storage/sql/postgres/statements.go
@@ -14,9 +14,9 @@ import (
 const (
 	INSERT_EVALUATION_STATEMENT = `INSERT INTO evaluations (id, tenant_id, owner, status, experiment_id, entity) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id;`
 
-	INSERT_COLLECTION_STATEMENT = `INSERT INTO collections (id, tenant_id, owner, entity) VALUES ($1, $2, $3, $4) RETURNING id;`
+	INSERT_COLLECTION_STATEMENT = `INSERT INTO collections (id, tenant_id, owner, created_at, updated_at, entity) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id;`
 
-	INSERT_PROVIDER_STATEMENT = `INSERT INTO providers (id, tenant_id, owner, entity) VALUES ($1, $2, $3, $4) RETURNING id;`
+	INSERT_PROVIDER_STATEMENT = `INSERT INTO providers (id, tenant_id, owner, created_at, updated_at, entity) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id;`
 
 	TABLES_SCHEMA = `
 CREATE TABLE IF NOT EXISTS evaluations (
@@ -180,6 +180,10 @@ func (s *postgresStatementsFactory) CreateDeleteEntityStatement(tenant api.Tenan
 	return fmt.Sprintf(`DELETE FROM %s WHERE id = $1;`, tableName), []any{id}
 }
 
+func (s *postgresStatementsFactory) CreateDeleteSystemEntitiesStatement(tableName string) (string, []any) {
+	return fmt.Sprintf(`DELETE FROM %s WHERE owner = $1;`, tableName), []any{abstractions.OwnerSystem}
+}
+
 func (s *postgresStatementsFactory) CreateUpdateEntityStatement(tenant api.Tenant, tableName, id string, entityJSON string, status *api.OverallState) (string, []any) {
 	// UPDATE "evaluations" SET "status" = ?, "entity" = ?, "updated_at" = CURRENT_TIMESTAMP WHERE "id" = ?;
 	switch tableName {
@@ -197,7 +201,7 @@ func (s *postgresStatementsFactory) CreateUpdateEntityStatement(tenant api.Tenan
 }
 
 func (s *postgresStatementsFactory) CreateProviderAddEntityStatement(provider *api.ProviderResource, entity string) (string, []any) {
-	return INSERT_PROVIDER_STATEMENT, []any{provider.Resource.ID, provider.Resource.Tenant, provider.Resource.Owner, entity}
+	return INSERT_PROVIDER_STATEMENT, []any{provider.Resource.ID, provider.Resource.Tenant, provider.Resource.Owner, provider.Resource.CreatedAt, provider.Resource.UpdatedAt, entity}
 }
 
 func (s *postgresStatementsFactory) getWhereStatement(tenant api.Tenant, id string, index int) (string, []any) {
@@ -226,7 +230,7 @@ func (s *postgresStatementsFactory) CreateProviderGetEntityStatement(query *shar
 }
 
 func (s *postgresStatementsFactory) CreateCollectionAddEntityStatement(collection *api.CollectionResource, entity string) (string, []any) {
-	return INSERT_COLLECTION_STATEMENT, []any{collection.Resource.ID, collection.Resource.Tenant, collection.Resource.Owner, entity}
+	return INSERT_COLLECTION_STATEMENT, []any{collection.Resource.ID, collection.Resource.Tenant, collection.Resource.Owner, collection.Resource.CreatedAt, collection.Resource.UpdatedAt, entity}
 }
 
 func (s *postgresStatementsFactory) CreateCollectionGetEntityStatement(query *shared.EntityQuery) (string, []any, []any) {

--- a/internal/eval_hub/storage/sql/postgres/statements_test.go
+++ b/internal/eval_hub/storage/sql/postgres/statements_test.go
@@ -1,0 +1,76 @@
+package postgres
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/storage/sql/shared"
+	"github.com/eval-hub/eval-hub/pkg/api"
+)
+
+func TestCreateDeleteSystemEntitiesStatement(t *testing.T) {
+	f := NewStatementsFactory(slog.Default())
+	stmt, args := f.CreateDeleteSystemEntitiesStatement(shared.TABLE_PROVIDERS)
+	if !strings.Contains(stmt, "DELETE FROM providers") {
+		t.Fatalf("unexpected statement: %s", stmt)
+	}
+	if !strings.Contains(stmt, "owner = $1") {
+		t.Fatalf("expected owner placeholder $1, got: %s", stmt)
+	}
+	if len(args) != 1 || args[0] != abstractions.OwnerSystem {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+}
+
+func TestCreateProviderAddEntityStatementIncludesTimestamps(t *testing.T) {
+	f := NewStatementsFactory(slog.Default())
+	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	updated := time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC)
+	provider := &api.ProviderResource{
+		Resource: api.Resource{
+			ID:        "p1",
+			Tenant:    "t1",
+			Owner:     "system",
+			CreatedAt: created,
+			UpdatedAt: updated,
+		},
+	}
+	stmt, args := f.CreateProviderAddEntityStatement(provider, `{"name":"n"}`)
+	if !strings.Contains(stmt, "created_at") || !strings.Contains(stmt, "updated_at") {
+		t.Fatalf("expected created_at/updated_at columns in: %s", stmt)
+	}
+	if len(args) != 6 {
+		t.Fatalf("expected 6 args, got %d: %#v", len(args), args)
+	}
+	if args[3] != created || args[4] != updated {
+		t.Fatalf("timestamp args mismatch: %#v", args)
+	}
+}
+
+func TestCreateCollectionAddEntityStatementIncludesTimestamps(t *testing.T) {
+	f := NewStatementsFactory(slog.Default())
+	created := time.Date(2024, 3, 4, 5, 6, 7, 0, time.UTC)
+	updated := time.Date(2024, 4, 5, 6, 7, 8, 0, time.UTC)
+	collection := &api.CollectionResource{
+		Resource: api.Resource{
+			ID:        "c1",
+			Tenant:    "t1",
+			Owner:     "system",
+			CreatedAt: created,
+			UpdatedAt: updated,
+		},
+	}
+	stmt, args := f.CreateCollectionAddEntityStatement(collection, `{"name":"n"}`)
+	if !strings.Contains(stmt, "created_at") || !strings.Contains(stmt, "updated_at") {
+		t.Fatalf("expected created_at/updated_at columns in: %s", stmt)
+	}
+	if len(args) != 6 {
+		t.Fatalf("expected 6 args, got %d: %#v", len(args), args)
+	}
+	if args[3] != created || args[4] != updated {
+		t.Fatalf("timestamp args mismatch: %#v", args)
+	}
+}

--- a/internal/eval_hub/storage/sql/providers.go
+++ b/internal/eval_hub/storage/sql/providers.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"database/sql"
 	"encoding/json"
+	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
@@ -17,6 +18,12 @@ func (s *sqlStorage) CreateProvider(provider *api.ProviderResource) error {
 }
 
 func (s *sqlStorage) createProviderTxn(txn *sql.Tx, provider *api.ProviderResource) error {
+	if provider.Resource.CreatedAt.IsZero() {
+		provider.Resource.CreatedAt = time.Now()
+	}
+	if provider.Resource.UpdatedAt.IsZero() {
+		provider.Resource.UpdatedAt = provider.Resource.CreatedAt
+	}
 	providerJSON, err := s.createProviderEntity(provider)
 	if err != nil {
 		return se.NewServiceError(messages.InternalServerError, "Error", err)

--- a/internal/eval_hub/storage/sql/shared/statements.go
+++ b/internal/eval_hub/storage/sql/shared/statements.go
@@ -33,5 +33,7 @@ type SQLStatementsFactory interface {
 	CreateListEntitiesStatement(tenant api.Tenant, tableName string, limit, offset int, filter map[string]any) (string, []any)
 	ScanRowForEntity(tenant api.Tenant, ableName string, rows *sql.Rows, query *EntityQuery) error
 	CreateDeleteEntityStatement(tenant api.Tenant, tableName string, id string) (string, []any)
+	// CreateDeleteSystemEntitiesStatement deletes all owner=system rows in tableName.
+	CreateDeleteSystemEntitiesStatement(tableName string) (string, []any)
 	CreateUpdateEntityStatement(tenant api.Tenant, tableName, id string, entityJSON string, status *api.OverallState) (string, []any)
 }

--- a/internal/eval_hub/storage/sql/sql.go
+++ b/internal/eval_hub/storage/sql/sql.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	// import the postgres driver - "pgx"
@@ -46,6 +47,9 @@ type sqlStorage struct {
 	owner             api.User
 	maxArgLength      int
 	isolationLevel    sql.IsolationLevel
+	// systemResourcesMu serializes LoadSystemResources across With* clones that
+	// share the same DB pool (pointer is copied, not the mutex value).
+	systemResourcesMu *sync.Mutex
 }
 
 func NewStorage(
@@ -158,6 +162,7 @@ func NewStorage(
 		ctx:               context.Background(),
 		maxArgLength:      512,
 		isolationLevel:    isolationLevel,
+		systemResourcesMu: &sync.Mutex{},
 	}
 
 	// ping the database to verify the DSN provided by the user is valid and the server is accessible
@@ -359,6 +364,7 @@ func (s *sqlStorage) WithLogger(logger *slog.Logger) abstractions.Storage {
 		owner:             s.owner,
 		maxArgLength:      s.maxArgLength,
 		isolationLevel:    s.isolationLevel,
+		systemResourcesMu: s.systemResourcesMu,
 	}
 }
 
@@ -373,6 +379,7 @@ func (s *sqlStorage) WithContext(ctx context.Context) abstractions.Storage {
 		owner:             s.owner,
 		maxArgLength:      s.maxArgLength,
 		isolationLevel:    s.isolationLevel,
+		systemResourcesMu: s.systemResourcesMu,
 	}
 }
 
@@ -387,6 +394,7 @@ func (s *sqlStorage) WithTenant(tenant api.Tenant) abstractions.Storage {
 		owner:             s.owner,
 		maxArgLength:      s.maxArgLength,
 		isolationLevel:    s.isolationLevel,
+		systemResourcesMu: s.systemResourcesMu,
 	}
 }
 
@@ -401,5 +409,6 @@ func (s *sqlStorage) WithOwner(owner api.User) abstractions.Storage {
 		owner:             owner,
 		maxArgLength:      s.maxArgLength,
 		isolationLevel:    s.isolationLevel,
+		systemResourcesMu: s.systemResourcesMu,
 	}
 }

--- a/internal/eval_hub/storage/sql/sqlite/statements.go
+++ b/internal/eval_hub/storage/sql/sqlite/statements.go
@@ -14,9 +14,9 @@ import (
 const (
 	INSERT_EVALUATION_STATEMENT = `INSERT INTO evaluations (id, tenant_id, owner, status, experiment_id, entity) VALUES (?, ?, ?, ?, ?, ?);`
 
-	INSERT_COLLECTION_STATEMENT = `INSERT INTO collections (id, tenant_id, owner, entity) VALUES (?, ?, ?, ?);`
+	INSERT_COLLECTION_STATEMENT = `INSERT INTO collections (id, tenant_id, owner, created_at, updated_at, entity) VALUES (?, ?, ?, ?, ?, ?);`
 
-	INSERT_PROVIDER_STATEMENT = `INSERT INTO providers (id, tenant_id, owner, entity) VALUES (?, ?, ?, ?);`
+	INSERT_PROVIDER_STATEMENT = `INSERT INTO providers (id, tenant_id, owner, created_at, updated_at, entity) VALUES (?, ?, ?, ?, ?, ?);`
 
 	TABLES_SCHEMA = `
 CREATE TABLE IF NOT EXISTS evaluations (
@@ -185,6 +185,10 @@ func (s *sqliteStatementsFactory) CreateDeleteEntityStatement(tenant api.Tenant,
 	return fmt.Sprintf(`DELETE FROM %s WHERE id = ?;`, tableName), []any{id}
 }
 
+func (s *sqliteStatementsFactory) CreateDeleteSystemEntitiesStatement(tableName string) (string, []any) {
+	return fmt.Sprintf(`DELETE FROM %s WHERE owner = ?;`, tableName), []any{abstractions.OwnerSystem}
+}
+
 func (s *sqliteStatementsFactory) CreateUpdateEntityStatement(tenant api.Tenant, tableName, id string, entityJSON string, status *api.OverallState) (string, []any) {
 	// these WHERE statements are okay because we can only update user resources
 	switch tableName {
@@ -202,7 +206,7 @@ func (s *sqliteStatementsFactory) CreateUpdateEntityStatement(tenant api.Tenant,
 }
 
 func (s *sqliteStatementsFactory) CreateProviderAddEntityStatement(provider *api.ProviderResource, entity string) (string, []any) {
-	return INSERT_PROVIDER_STATEMENT, []any{provider.Resource.ID, provider.Resource.Tenant, provider.Resource.Owner, entity}
+	return INSERT_PROVIDER_STATEMENT, []any{provider.Resource.ID, provider.Resource.Tenant, provider.Resource.Owner, provider.Resource.CreatedAt, provider.Resource.UpdatedAt, entity}
 }
 
 func (s *sqliteStatementsFactory) getWhereStatement(tenant api.Tenant, id string) (string, []any) {
@@ -230,7 +234,7 @@ func (s *sqliteStatementsFactory) CreateProviderGetEntityStatement(query *shared
 }
 
 func (s *sqliteStatementsFactory) CreateCollectionAddEntityStatement(collection *api.CollectionResource, entity string) (string, []any) {
-	return INSERT_COLLECTION_STATEMENT, []any{collection.Resource.ID, collection.Resource.Tenant, collection.Resource.Owner, entity}
+	return INSERT_COLLECTION_STATEMENT, []any{collection.Resource.ID, collection.Resource.Tenant, collection.Resource.Owner, collection.Resource.CreatedAt, collection.Resource.UpdatedAt, entity}
 }
 
 func (s *sqliteStatementsFactory) CreateCollectionGetEntityStatement(query *shared.EntityQuery) (string, []any, []any) {

--- a/internal/eval_hub/storage/sql/sqlite/statements_test.go
+++ b/internal/eval_hub/storage/sql/sqlite/statements_test.go
@@ -1,0 +1,48 @@
+package sqlite
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/storage/sql/shared"
+	"github.com/eval-hub/eval-hub/pkg/api"
+)
+
+func TestCreateDeleteSystemEntitiesStatement(t *testing.T) {
+	f := NewStatementsFactory(slog.Default())
+	stmt, args := f.CreateDeleteSystemEntitiesStatement(shared.TABLE_COLLECTIONS)
+	if !strings.Contains(stmt, "DELETE FROM collections") {
+		t.Fatalf("unexpected statement: %s", stmt)
+	}
+	if !strings.Contains(stmt, "owner = ?") {
+		t.Fatalf("expected owner placeholder ?, got: %s", stmt)
+	}
+	if len(args) != 1 || args[0] != abstractions.OwnerSystem {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+}
+
+func TestCreateProviderAddEntityStatementIncludesTimestamps(t *testing.T) {
+	f := NewStatementsFactory(slog.Default())
+	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	updated := time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC)
+	provider := &api.ProviderResource{
+		Resource: api.Resource{
+			ID:        "p1",
+			Tenant:    "t1",
+			Owner:     "system",
+			CreatedAt: created,
+			UpdatedAt: updated,
+		},
+	}
+	stmt, args := f.CreateProviderAddEntityStatement(provider, `{"name":"n"}`)
+	if !strings.Contains(stmt, "created_at") || !strings.Contains(stmt, "updated_at") {
+		t.Fatalf("expected created_at/updated_at columns in: %s", stmt)
+	}
+	if len(args) != 6 || args[3] != created || args[4] != updated {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+}

--- a/internal/eval_hub/storage/sql/system_resources.go
+++ b/internal/eval_hub/storage/sql/system_resources.go
@@ -8,54 +8,48 @@ import (
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/serviceerrors"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/storage/sql/shared"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
+
+const systemResourceListPageSize = 200
 
 // LoadSystemResources reloads system-owned providers and collections into the
 // database. It deletes all existing system resources and inserts the new ones,
 // preserving CreatedAt/UpdatedAt timestamps for resources that already existed.
+//
+// Concurrent calls are serialized via systemResourcesMu so overlapping config
+// watcher reloads cannot interleave delete/insert work.
 func (s *sqlStorage) LoadSystemResources(systemCollections map[string]api.CollectionResource, systemProviders map[string]api.ProviderResource) error {
+	s.systemResourcesMu.Lock()
+	defer s.systemResourcesMu.Unlock()
+
 	s.logger.Info("Loading system resources")
 
 	return s.withTransaction("load-system-resources", "system", func(txn *sql.Tx) error {
-		// we take the simplest approach here:
-		// 1. delete all existing system resources
-		// 2. insert the new system resources
-		// Both steps always run so that orphaned records are removed when
+		// Full replace of the desired system set:
+		// 1. snapshot existing system resources (for timestamps + change logging)
+		// 2. delete all system-owned rows in one statement (avoids offset/delete races)
+		// 3. insert the new system resources
+		// Both delete and insert always run so orphaned records are removed when
 		// config files are deleted (empty maps mean "no system resources").
 		{
+			existingCollections, err := s.listAllSystemCollections(txn)
+			if err != nil {
+				return serviceerrors.WithRollback(err)
+			}
+
+			deleteStmt, deleteArgs := s.statementsFactory.CreateDeleteSystemEntitiesStatement(shared.TABLE_COLLECTIONS)
+			if _, err := s.exec(txn, deleteStmt, deleteArgs...); err != nil {
+				return serviceerrors.WithRollback(err)
+			}
+
 			var deletedCollections []string
 			var updatedCollections []string
 			var addedCollections []string
-			existingCollections := make(map[string]api.CollectionResource)
-			cont := true
-			offset := 0
-			for cont {
-				// as we filter with an empty tenant we will only get the system collections
-				filter := abstractions.QueryFilter{
-					Limit:  200,
-					Offset: offset,
-					Params: map[string]any{},
-				}
-				collections, err := s.getCollectionsTransactional(txn, &filter)
-				if err != nil {
-					return serviceerrors.WithRollback(err)
-				}
-				for _, collection := range collections.Items {
-					// double check that this is a system collection
-					if collection.Resource.IsSystemResource() {
-						err := s.deleteCollectionTxn(txn, collection.Resource.ID)
-						if err != nil {
-							return serviceerrors.WithRollback(err)
-						}
-						deletedCollections = append(deletedCollections, collection.Resource.ID)
-						existingCollections[collection.Resource.ID] = collection
-					}
-				}
-				if collections.TotalCount < filter.Limit {
-					cont = false
-				} else {
-					offset += filter.Limit
+			for id := range existingCollections {
+				if _, ok := systemCollections[id]; !ok {
+					deletedCollections = append(deletedCollections, id)
 				}
 			}
 			for _, collection := range systemCollections {
@@ -76,50 +70,34 @@ func (s *sqlStorage) LoadSystemResources(systemCollections map[string]api.Collec
 				if err != nil {
 					return serviceerrors.WithRollback(err)
 				}
-				if slices.Contains(deletedCollections, collection.Resource.ID) {
+				if _, ok := existingCollections[collection.Resource.ID]; ok {
 					updatedCollections = append(updatedCollections, collection.Resource.ID)
-					deletedCollections = slices.DeleteFunc(deletedCollections, func(id string) bool {
-						return id == collection.Resource.ID
-					})
 				} else {
 					addedCollections = append(addedCollections, collection.Resource.ID)
 				}
 			}
+			slices.Sort(deletedCollections)
+			slices.Sort(updatedCollections)
+			slices.Sort(addedCollections)
 			s.logger.Info("Loaded system collections", "added", strings.Join(addedCollections, ","), "updated", strings.Join(updatedCollections, ","), "deleted", strings.Join(deletedCollections, ","))
 		}
 		{
+			existingProviders, err := s.listAllSystemProviders(txn)
+			if err != nil {
+				return serviceerrors.WithRollback(err)
+			}
+
+			deleteStmt, deleteArgs := s.statementsFactory.CreateDeleteSystemEntitiesStatement(shared.TABLE_PROVIDERS)
+			if _, err := s.exec(txn, deleteStmt, deleteArgs...); err != nil {
+				return serviceerrors.WithRollback(err)
+			}
+
 			var deletedProviders []string
 			var updatedProviders []string
 			var addedProviders []string
-			existingProviders := make(map[string]api.ProviderResource)
-			cont := true
-			offset := 0
-			for cont {
-				// as we filter with an empty tenant we will only get the system providers
-				filter := abstractions.QueryFilter{
-					Limit:  200,
-					Offset: offset,
-					Params: map[string]any{},
-				}
-				providers, err := s.getProvidersTransactional(txn, &filter)
-				if err != nil {
-					return serviceerrors.WithRollback(err)
-				}
-				for _, provider := range providers.Items {
-					// double check that this is a system provider
-					if provider.Resource.IsSystemResource() {
-						err := s.deleteProviderTxn(txn, provider.Resource.ID)
-						if err != nil {
-							return serviceerrors.WithRollback(err)
-						}
-						deletedProviders = append(deletedProviders, provider.Resource.ID)
-						existingProviders[provider.Resource.ID] = provider
-					}
-				}
-				if providers.TotalCount < filter.Limit {
-					cont = false
-				} else {
-					offset += filter.Limit
+			for id := range existingProviders {
+				if _, ok := systemProviders[id]; !ok {
+					deletedProviders = append(deletedProviders, id)
 				}
 			}
 			for _, provider := range systemProviders {
@@ -140,18 +118,66 @@ func (s *sqlStorage) LoadSystemResources(systemCollections map[string]api.Collec
 				if err != nil {
 					return serviceerrors.WithRollback(err)
 				}
-				if slices.Contains(deletedProviders, provider.Resource.ID) {
+				if _, ok := existingProviders[provider.Resource.ID]; ok {
 					updatedProviders = append(updatedProviders, provider.Resource.ID)
-					deletedProviders = slices.DeleteFunc(deletedProviders, func(id string) bool {
-						return id == provider.Resource.ID
-					})
 				} else {
 					addedProviders = append(addedProviders, provider.Resource.ID)
 				}
 			}
+			slices.Sort(deletedProviders)
+			slices.Sort(updatedProviders)
+			slices.Sort(addedProviders)
 			s.logger.Info("Loaded system providers", "added", strings.Join(addedProviders, ","), "updated", strings.Join(updatedProviders, ","), "deleted", strings.Join(deletedProviders, ","))
 		}
 		s.logger.Info("Loaded system resources")
 		return nil
 	})
+}
+
+func (s *sqlStorage) listAllSystemCollections(txn *sql.Tx) (map[string]api.CollectionResource, error) {
+	existing := make(map[string]api.CollectionResource)
+	offset := 0
+	for {
+		filter := abstractions.QueryFilter{
+			Limit:  systemResourceListPageSize,
+			Offset: offset,
+			Params: map[string]any{"scope": abstractions.ScopeSystem},
+		}
+		collections, err := s.getCollectionsTransactional(txn, &filter)
+		if err != nil {
+			return nil, err
+		}
+		for _, collection := range collections.Items {
+			existing[collection.Resource.ID] = collection
+		}
+		if len(collections.Items) < filter.Limit {
+			break
+		}
+		offset += filter.Limit
+	}
+	return existing, nil
+}
+
+func (s *sqlStorage) listAllSystemProviders(txn *sql.Tx) (map[string]api.ProviderResource, error) {
+	existing := make(map[string]api.ProviderResource)
+	offset := 0
+	for {
+		filter := abstractions.QueryFilter{
+			Limit:  systemResourceListPageSize,
+			Offset: offset,
+			Params: map[string]any{"scope": abstractions.ScopeSystem},
+		}
+		providers, err := s.getProvidersTransactional(txn, &filter)
+		if err != nil {
+			return nil, err
+		}
+		for _, provider := range providers.Items {
+			existing[provider.Resource.ID] = provider
+		}
+		if len(providers.Items) < filter.Limit {
+			break
+		}
+		offset += filter.Limit
+	}
+	return existing, nil
 }

--- a/internal/eval_hub/storage/sql/system_resources.go
+++ b/internal/eval_hub/storage/sql/system_resources.go
@@ -1,7 +1,9 @@
 package sql
 
 import (
+	"bytes"
 	"database/sql"
+	"encoding/json"
 	"slices"
 	"strings"
 	"time"
@@ -15,8 +17,10 @@ import (
 const systemResourceListPageSize = 200
 
 // LoadSystemResources reloads system-owned providers and collections into the
-// database. It deletes all existing system resources and inserts the new ones,
-// preserving CreatedAt/UpdatedAt timestamps for resources that already existed.
+// database. It deletes all existing system resources and inserts the new ones.
+// CreatedAt is preserved for IDs that already existed. UpdatedAt is preserved
+// only when the serialized config matches the snapshot; otherwise it is set to
+// the current time so consumers can detect definition changes.
 //
 // Concurrent calls are serialized via systemResourcesMu so overlapping config
 // watcher reloads cannot interleave delete/insert work.
@@ -52,16 +56,21 @@ func (s *sqlStorage) LoadSystemResources(systemCollections map[string]api.Collec
 					deletedCollections = append(deletedCollections, id)
 				}
 			}
+			now := time.Now()
 			for _, collection := range systemCollections {
 				// make sure that these are set
 				collection.Resource.Tenant = ""
 				collection.Resource.Owner = "system"
 				if existingCollection, ok := existingCollections[collection.Resource.ID]; ok {
 					collection.Resource.CreatedAt = existingCollection.Resource.CreatedAt
-					collection.Resource.UpdatedAt = existingCollection.Resource.UpdatedAt
+					if systemCollectionConfigEqual(existingCollection, collection) {
+						collection.Resource.UpdatedAt = existingCollection.Resource.UpdatedAt
+					} else {
+						collection.Resource.UpdatedAt = now
+					}
 				}
 				if collection.Resource.CreatedAt.IsZero() {
-					collection.Resource.CreatedAt = time.Now()
+					collection.Resource.CreatedAt = now
 				}
 				if collection.Resource.UpdatedAt.IsZero() {
 					collection.Resource.UpdatedAt = collection.Resource.CreatedAt
@@ -100,16 +109,21 @@ func (s *sqlStorage) LoadSystemResources(systemCollections map[string]api.Collec
 					deletedProviders = append(deletedProviders, id)
 				}
 			}
+			now := time.Now()
 			for _, provider := range systemProviders {
 				// make sure that these are set
 				provider.Resource.Tenant = ""
 				provider.Resource.Owner = "system"
 				if existingProvider, ok := existingProviders[provider.Resource.ID]; ok {
 					provider.Resource.CreatedAt = existingProvider.Resource.CreatedAt
-					provider.Resource.UpdatedAt = existingProvider.Resource.UpdatedAt
+					if systemProviderConfigEqual(existingProvider, provider) {
+						provider.Resource.UpdatedAt = existingProvider.Resource.UpdatedAt
+					} else {
+						provider.Resource.UpdatedAt = now
+					}
 				}
 				if provider.Resource.CreatedAt.IsZero() {
-					provider.Resource.CreatedAt = time.Now()
+					provider.Resource.CreatedAt = now
 				}
 				if provider.Resource.UpdatedAt.IsZero() {
 					provider.Resource.UpdatedAt = provider.Resource.CreatedAt
@@ -132,6 +146,24 @@ func (s *sqlStorage) LoadSystemResources(systemCollections map[string]api.Collec
 		s.logger.Info("Loaded system resources")
 		return nil
 	})
+}
+
+func systemProviderConfigEqual(existing, next api.ProviderResource) bool {
+	a, errA := json.Marshal(existing.ProviderConfig)
+	b, errB := json.Marshal(next.ProviderConfig)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
+}
+
+func systemCollectionConfigEqual(existing, next api.CollectionResource) bool {
+	a, errA := json.Marshal(existing.CollectionConfig)
+	b, errB := json.Marshal(next.CollectionConfig)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 func (s *sqlStorage) listAllSystemCollections(txn *sql.Tx) (map[string]api.CollectionResource, error) {

--- a/internal/eval_hub/storage/sql/system_resources_test.go
+++ b/internal/eval_hub/storage/sql/system_resources_test.go
@@ -1,0 +1,200 @@
+package sql_test
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
+	"github.com/eval-hub/eval-hub/pkg/api"
+)
+
+func TestLoadSystemResources_ReplacesLargeSystemSetAndPreservesTenantProviders(t *testing.T) {
+	store, err := getTestStorage(t, "sqlite", getDBName())
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	const systemCount = 250 // exceeds the previous 200-row pagination page size
+	initialSystem := make(map[string]api.ProviderResource, systemCount)
+	for i := range systemCount {
+		id := fmt.Sprintf("sys-provider-%03d", i)
+		initialSystem[id] = api.ProviderResource{
+			Resource: api.Resource{ID: id, Owner: "system"},
+			ProviderConfig: api.ProviderConfig{
+				Name:        id,
+				Description: "system provider",
+			},
+		}
+	}
+	if err := store.LoadSystemResources(nil, initialSystem); err != nil {
+		t.Fatalf("initial LoadSystemResources: %v", err)
+	}
+
+	tenant := api.Tenant("tenant-keep")
+	tenantStore := store.WithTenant(tenant)
+	tenantProvider := &api.ProviderResource{
+		Resource: api.Resource{
+			ID:        "tenant-provider-1",
+			Tenant:    tenant,
+			CreatedAt: time.Now(),
+		},
+		ProviderConfig: api.ProviderConfig{
+			Name:        "Tenant Provider",
+			Description: "must survive system reload",
+		},
+	}
+	if err := tenantStore.CreateProvider(tenantProvider); err != nil {
+		t.Fatalf("CreateProvider tenant: %v", err)
+	}
+
+	// Keep only the second half of system providers so orphans must be deleted.
+	kept := make(map[string]api.ProviderResource, systemCount/2)
+	for i := systemCount / 2; i < systemCount; i++ {
+		id := fmt.Sprintf("sys-provider-%03d", i)
+		kept[id] = initialSystem[id]
+	}
+	if err := store.LoadSystemResources(nil, kept); err != nil {
+		t.Fatalf("reload LoadSystemResources: %v", err)
+	}
+
+	systemListed, err := store.GetProviders(&abstractions.QueryFilter{
+		Limit:  1000,
+		Params: map[string]any{"scope": abstractions.ScopeSystem},
+	})
+	if err != nil {
+		t.Fatalf("GetProviders system: %v", err)
+	}
+	if systemListed.TotalCount != len(kept) {
+		t.Fatalf("expected %d system providers after reload, got total_count=%d items=%d",
+			len(kept), systemListed.TotalCount, len(systemListed.Items))
+	}
+	for _, p := range systemListed.Items {
+		if _, ok := kept[p.Resource.ID]; !ok {
+			t.Fatalf("unexpected system provider still present: %s", p.Resource.ID)
+		}
+	}
+
+	gotTenant, err := tenantStore.GetProvider("tenant-provider-1")
+	if err != nil {
+		t.Fatalf("tenant provider should remain after system reload: %v", err)
+	}
+	if gotTenant.Name != "Tenant Provider" {
+		t.Fatalf("tenant provider name changed: %s", gotTenant.Name)
+	}
+
+	_, err = store.GetProvider("sys-provider-000")
+	if err == nil {
+		t.Fatal("expected orphaned system provider sys-provider-000 to be deleted")
+	}
+}
+
+func TestLoadSystemResources_PreservesTimestampsOnUpdate(t *testing.T) {
+	store, err := getTestStorage(t, "sqlite", getDBName())
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	initial := map[string]api.ProviderResource{
+		"sys-a": {
+			Resource:       api.Resource{ID: "sys-a", Owner: "system"},
+			ProviderConfig: api.ProviderConfig{Name: "A", Description: "first"},
+		},
+	}
+	if err := store.LoadSystemResources(nil, initial); err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+
+	before, err := store.GetProvider("sys-a")
+	if err != nil {
+		t.Fatalf("GetProvider before reload: %v", err)
+	}
+	if before.Resource.CreatedAt.IsZero() || before.Resource.UpdatedAt.IsZero() {
+		t.Fatal("expected non-zero timestamps after initial load")
+	}
+
+	reloaded := map[string]api.ProviderResource{
+		"sys-a": {
+			Resource:       api.Resource{ID: "sys-a", Owner: "system"},
+			ProviderConfig: api.ProviderConfig{Name: "A-updated", Description: "second"},
+		},
+	}
+	if err := store.LoadSystemResources(nil, reloaded); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	got, err := store.GetProvider("sys-a")
+	if err != nil {
+		t.Fatalf("GetProvider: %v", err)
+	}
+	if !got.Resource.CreatedAt.Equal(before.Resource.CreatedAt) {
+		t.Fatalf("CreatedAt not preserved: got %v want %v", got.Resource.CreatedAt, before.Resource.CreatedAt)
+	}
+	if !got.Resource.UpdatedAt.Equal(before.Resource.UpdatedAt) {
+		t.Fatalf("UpdatedAt not preserved: got %v want %v", got.Resource.UpdatedAt, before.Resource.UpdatedAt)
+	}
+	if got.Name != "A-updated" {
+		t.Fatalf("expected updated name, got %s", got.Name)
+	}
+}
+
+func TestLoadSystemResources_SerializesConcurrentCalls(t *testing.T) {
+	store, err := getTestStorage(t, "sqlite", getDBName())
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	var failures atomic.Int32
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			providers := map[string]api.ProviderResource{
+				"shared-sys": {
+					Resource: api.Resource{ID: "shared-sys", Owner: "system"},
+					ProviderConfig: api.ProviderConfig{
+						Name:        fmt.Sprintf("name-%d", i),
+						Description: "concurrent reload",
+					},
+				},
+				fmt.Sprintf("only-%d", i): {
+					Resource: api.Resource{ID: fmt.Sprintf("only-%d", i), Owner: "system"},
+					ProviderConfig: api.ProviderConfig{
+						Name:        fmt.Sprintf("only-%d", i),
+						Description: "per-goroutine",
+					},
+				},
+			}
+			if err := store.LoadSystemResources(nil, providers); err != nil {
+				failures.Add(1)
+				t.Errorf("LoadSystemResources goroutine %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if failures.Load() != 0 {
+		t.Fatalf("%d concurrent LoadSystemResources calls failed", failures.Load())
+	}
+
+	systemListed, err := store.GetProviders(&abstractions.QueryFilter{
+		Limit:  100,
+		Params: map[string]any{"scope": abstractions.ScopeSystem},
+	})
+	if err != nil {
+		t.Fatalf("GetProviders: %v", err)
+	}
+	// Last writer wins: exactly one full desired set should remain (2 providers).
+	if systemListed.TotalCount != 2 {
+		t.Fatalf("expected 2 system providers after serialized concurrent reloads, got %d", systemListed.TotalCount)
+	}
+	if _, err := store.GetProvider("shared-sys"); err != nil {
+		t.Fatalf("shared-sys missing after concurrent reloads: %v", err)
+	}
+}

--- a/internal/eval_hub/storage/sql/system_resources_test.go
+++ b/internal/eval_hub/storage/sql/system_resources_test.go
@@ -11,6 +11,23 @@ import (
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
+func testSystemCollection(id, name, description string) api.CollectionResource {
+	return api.CollectionResource{
+		Resource: api.Resource{ID: id, Owner: "system"},
+		CollectionConfig: api.CollectionConfig{
+			Name:        name,
+			Description: description,
+			Category:    "test",
+			Benchmarks: []api.CollectionBenchmarkConfig{
+				{
+					Ref:        api.Ref{ID: "bench-1"},
+					ProviderID: "provider-1",
+				},
+			},
+		},
+	}
+}
+
 func TestLoadSystemResources_ReplacesLargeSystemSetAndPreservesTenantProviders(t *testing.T) {
 	store, err := getTestStorage(t, "sqlite", getDBName())
 	if err != nil {
@@ -92,53 +109,177 @@ func TestLoadSystemResources_ReplacesLargeSystemSetAndPreservesTenantProviders(t
 	}
 }
 
-func TestLoadSystemResources_PreservesTimestampsOnUpdate(t *testing.T) {
+func TestLoadSystemResources_ReplacesLargeSystemCollections(t *testing.T) {
 	store, err := getTestStorage(t, "sqlite", getDBName())
 	if err != nil {
 		t.Fatalf("Failed to create storage: %v", err)
 	}
 	t.Cleanup(func() { _ = store.Close() })
 
-	initial := map[string]api.ProviderResource{
+	const systemCount = 250
+	initial := make(map[string]api.CollectionResource, systemCount)
+	for i := range systemCount {
+		id := fmt.Sprintf("sys-collection-%03d", i)
+		initial[id] = testSystemCollection(id, id, "system collection")
+	}
+	if err := store.LoadSystemResources(initial, nil); err != nil {
+		t.Fatalf("initial LoadSystemResources: %v", err)
+	}
+
+	tenant := api.Tenant("tenant-keep")
+	tenantStore := store.WithTenant(tenant)
+	tenantCollection := &api.CollectionResource{
+		Resource: api.Resource{
+			ID:        "tenant-collection-1",
+			Tenant:    tenant,
+			CreatedAt: time.Now(),
+		},
+		CollectionConfig: api.CollectionConfig{
+			Name:        "Tenant Collection",
+			Description: "must survive system reload",
+			Category:    "test",
+			Benchmarks: []api.CollectionBenchmarkConfig{
+				{Ref: api.Ref{ID: "bench-1"}, ProviderID: "provider-1"},
+			},
+		},
+	}
+	if err := tenantStore.CreateCollection(tenantCollection); err != nil {
+		t.Fatalf("CreateCollection tenant: %v", err)
+	}
+
+	kept := make(map[string]api.CollectionResource, systemCount/2)
+	for i := systemCount / 2; i < systemCount; i++ {
+		id := fmt.Sprintf("sys-collection-%03d", i)
+		kept[id] = initial[id]
+	}
+	if err := store.LoadSystemResources(kept, nil); err != nil {
+		t.Fatalf("reload LoadSystemResources: %v", err)
+	}
+
+	systemListed, err := store.GetCollections(&abstractions.QueryFilter{
+		Limit:  1000,
+		Params: map[string]any{"scope": abstractions.ScopeSystem},
+	})
+	if err != nil {
+		t.Fatalf("GetCollections system: %v", err)
+	}
+	if systemListed.TotalCount != len(kept) {
+		t.Fatalf("expected %d system collections after reload, got total_count=%d items=%d",
+			len(kept), systemListed.TotalCount, len(systemListed.Items))
+	}
+
+	gotTenant, err := tenantStore.GetCollection("tenant-collection-1")
+	if err != nil {
+		t.Fatalf("tenant collection should remain after system reload: %v", err)
+	}
+	if gotTenant.Name != "Tenant Collection" {
+		t.Fatalf("tenant collection name changed: %s", gotTenant.Name)
+	}
+
+	_, err = store.GetCollection("sys-collection-000")
+	if err == nil {
+		t.Fatal("expected orphaned system collection sys-collection-000 to be deleted")
+	}
+}
+
+func TestLoadSystemResources_TimestampsOnContentChangeAndUnchangedReload(t *testing.T) {
+	store, err := getTestStorage(t, "sqlite", getDBName())
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	initialProviders := map[string]api.ProviderResource{
 		"sys-a": {
 			Resource:       api.Resource{ID: "sys-a", Owner: "system"},
 			ProviderConfig: api.ProviderConfig{Name: "A", Description: "first"},
 		},
 	}
-	if err := store.LoadSystemResources(nil, initial); err != nil {
+	initialCollections := map[string]api.CollectionResource{
+		"sys-c": testSystemCollection("sys-c", "C", "first"),
+	}
+	if err := store.LoadSystemResources(initialCollections, initialProviders); err != nil {
 		t.Fatalf("initial load: %v", err)
 	}
 
-	before, err := store.GetProvider("sys-a")
+	beforeProvider, err := store.GetProvider("sys-a")
 	if err != nil {
 		t.Fatalf("GetProvider before reload: %v", err)
 	}
-	if before.Resource.CreatedAt.IsZero() || before.Resource.UpdatedAt.IsZero() {
-		t.Fatal("expected non-zero timestamps after initial load")
+	beforeCollection, err := store.GetCollection("sys-c")
+	if err != nil {
+		t.Fatalf("GetCollection before reload: %v", err)
 	}
 
-	reloaded := map[string]api.ProviderResource{
+	time.Sleep(5 * time.Millisecond)
+
+	// Unchanged content should preserve both timestamps.
+	if err := store.LoadSystemResources(initialCollections, initialProviders); err != nil {
+		t.Fatalf("unchanged reload: %v", err)
+	}
+	unchangedProvider, err := store.GetProvider("sys-a")
+	if err != nil {
+		t.Fatalf("GetProvider after unchanged reload: %v", err)
+	}
+	if !unchangedProvider.Resource.CreatedAt.Equal(beforeProvider.Resource.CreatedAt) {
+		t.Fatalf("provider CreatedAt changed on identical reload")
+	}
+	if !unchangedProvider.Resource.UpdatedAt.Equal(beforeProvider.Resource.UpdatedAt) {
+		t.Fatalf("provider UpdatedAt changed on identical reload: got %v want %v",
+			unchangedProvider.Resource.UpdatedAt, beforeProvider.Resource.UpdatedAt)
+	}
+	unchangedCollection, err := store.GetCollection("sys-c")
+	if err != nil {
+		t.Fatalf("GetCollection after unchanged reload: %v", err)
+	}
+	if !unchangedCollection.Resource.UpdatedAt.Equal(beforeCollection.Resource.UpdatedAt) {
+		t.Fatalf("collection UpdatedAt changed on identical reload")
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	changedProviders := map[string]api.ProviderResource{
 		"sys-a": {
 			Resource:       api.Resource{ID: "sys-a", Owner: "system"},
 			ProviderConfig: api.ProviderConfig{Name: "A-updated", Description: "second"},
 		},
 	}
-	if err := store.LoadSystemResources(nil, reloaded); err != nil {
-		t.Fatalf("reload: %v", err)
+	changedCollections := map[string]api.CollectionResource{
+		"sys-c": testSystemCollection("sys-c", "C-updated", "second"),
+	}
+	if err := store.LoadSystemResources(changedCollections, changedProviders); err != nil {
+		t.Fatalf("content-change reload: %v", err)
 	}
 
-	got, err := store.GetProvider("sys-a")
+	gotProvider, err := store.GetProvider("sys-a")
 	if err != nil {
-		t.Fatalf("GetProvider: %v", err)
+		t.Fatalf("GetProvider after content change: %v", err)
 	}
-	if !got.Resource.CreatedAt.Equal(before.Resource.CreatedAt) {
-		t.Fatalf("CreatedAt not preserved: got %v want %v", got.Resource.CreatedAt, before.Resource.CreatedAt)
+	if gotProvider.Name != "A-updated" {
+		t.Fatalf("expected updated provider name, got %s", gotProvider.Name)
 	}
-	if !got.Resource.UpdatedAt.Equal(before.Resource.UpdatedAt) {
-		t.Fatalf("UpdatedAt not preserved: got %v want %v", got.Resource.UpdatedAt, before.Resource.UpdatedAt)
+	if !gotProvider.Resource.CreatedAt.Equal(beforeProvider.Resource.CreatedAt) {
+		t.Fatalf("provider CreatedAt not preserved: got %v want %v",
+			gotProvider.Resource.CreatedAt, beforeProvider.Resource.CreatedAt)
 	}
-	if got.Name != "A-updated" {
-		t.Fatalf("expected updated name, got %s", got.Name)
+	if !gotProvider.Resource.UpdatedAt.After(beforeProvider.Resource.UpdatedAt) {
+		t.Fatalf("provider UpdatedAt should advance on content change: got %v want after %v",
+			gotProvider.Resource.UpdatedAt, beforeProvider.Resource.UpdatedAt)
+	}
+
+	gotCollection, err := store.GetCollection("sys-c")
+	if err != nil {
+		t.Fatalf("GetCollection after content change: %v", err)
+	}
+	if gotCollection.Name != "C-updated" {
+		t.Fatalf("expected updated collection name, got %s", gotCollection.Name)
+	}
+	if !gotCollection.Resource.CreatedAt.Equal(beforeCollection.Resource.CreatedAt) {
+		t.Fatalf("collection CreatedAt not preserved")
+	}
+	if !gotCollection.Resource.UpdatedAt.After(beforeCollection.Resource.UpdatedAt) {
+		t.Fatalf("collection UpdatedAt should advance on content change: got %v want after %v",
+			gotCollection.Resource.UpdatedAt, beforeCollection.Resource.UpdatedAt)
 	}
 }
 
@@ -196,5 +337,56 @@ func TestLoadSystemResources_SerializesConcurrentCalls(t *testing.T) {
 	}
 	if _, err := store.GetProvider("shared-sys"); err != nil {
 		t.Fatalf("shared-sys missing after concurrent reloads: %v", err)
+	}
+}
+
+func TestCreateProviderAndCollection_DefaultTimestamps(t *testing.T) {
+	store, err := getTestStorage(t, "sqlite", getDBName())
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	tenant := api.Tenant("tenant-ts")
+	store = store.WithTenant(tenant)
+
+	provider := &api.ProviderResource{
+		Resource: api.Resource{ID: "p-ts", Tenant: tenant, Owner: "user"},
+		ProviderConfig: api.ProviderConfig{
+			Name:        "P",
+			Description: "timestamps defaulted",
+		},
+	}
+	if err := store.CreateProvider(provider); err != nil {
+		t.Fatalf("CreateProvider: %v", err)
+	}
+	gotProvider, err := store.GetProvider("p-ts")
+	if err != nil {
+		t.Fatalf("GetProvider: %v", err)
+	}
+	if gotProvider.Resource.CreatedAt.IsZero() || gotProvider.Resource.UpdatedAt.IsZero() {
+		t.Fatal("expected CreateProvider to populate timestamps")
+	}
+
+	collection := &api.CollectionResource{
+		Resource: api.Resource{ID: "c-ts", Tenant: tenant, Owner: "user"},
+		CollectionConfig: api.CollectionConfig{
+			Name:        "C",
+			Description: "timestamps defaulted",
+			Category:    "test",
+			Benchmarks: []api.CollectionBenchmarkConfig{
+				{Ref: api.Ref{ID: "bench-1"}, ProviderID: "provider-1"},
+			},
+		},
+	}
+	if err := store.CreateCollection(collection); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	gotCollection, err := store.GetCollection("c-ts")
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if gotCollection.Resource.CreatedAt.IsZero() || gotCollection.Resource.UpdatedAt.IsZero() {
+		t.Fatal("expected CreateCollection to populate timestamps")
 	}
 }


### PR DESCRIPTION
## Summary
- Serialize `LoadSystemResources` and config-watcher reloads so overlapping reloads cannot interleave delete/insert work.
- Replace paginated delete-while-scanning with a single `DELETE ... WHERE owner = 'system'`, after snapshotting existing system rows for timestamps and change logging (fixes skipped rows when total ≥ 200).
- Persist `created_at` / `updated_at` on provider/collection inserts so reload timestamp preservation actually sticks in the DB.

## Test plan
- [x] `go test ./internal/eval_hub/storage/sql/ ./internal/eval_hub/config/ -count=1`
- [x] New tests cover large system sets (>200), tenant provider survival, timestamp preservation, concurrent `LoadSystemResources`, and watcher reload serialization
- [ ] Confirm config-watcher still reloads after editing a provider YAML under `config/providers/`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when configuration reloads happen concurrently.
  * Prevented overlapping reloads from conflicting, ensuring the latest configuration is applied consistently.
  * Preserved resource creation and update timestamps during synchronization.
  * Removed obsolete system-managed resources while retaining tenant-owned resources.
* **Tests**
  * Added coverage for concurrent reloads, large resource sets, timestamp preservation, and replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->