### PR TITLE
ci: skip dependency review workflow on forks

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   dependency-review:
+    if: github.repository == 'eval-hub/eval-hub'
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary
- Adds `if: github.repository == 'eval-hub/eval-hub'` to the dependency-review job so it only runs on the upstream repo
- Prevents unnecessary workflow failures and wasted Actions minutes on fork PRs

## Test plan
- [ ] Verify the workflow still triggers on PRs to eval-hub/eval-hub
- [ ] Confirm the workflow is skipped when a fork opens a PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Limited the dependency review workflow to the designated repository, ensuring it runs only in the intended project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->