### PR TITLE
feat(local): support sidecar proxy in local runtime mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,7 @@ When running locally:
 - **No `evalhub-config` ConfigMap** on job pods; proxy targets and TLS live in JSON (`eval_hub.base_url`, `mlflow.tracking_uri`, `mlflow.token_path`, CA paths, optional `eval_hub.token`).
 - Termination message path is **fixed in the sidecar binary** (`/data/termination-log`).
 - Local dev: `config/sidecar_runtime_local.json` or `make start-sidecar`.
+- Local mode (since v0.0.2): `make start-sidecar SIDECAR_CONFIG_FILE=config/sidecar_local_mode.json` — starts the sidecar with `local_mode: true` on port 8082, skipping OCI/MLflow proxy initialization and SA token auth.
 
 #### Request identity (kube-rbac-proxy)
 

--- a/cmd/eval_runtime_sidecar/main.go
+++ b/cmd/eval_runtime_sidecar/main.go
@@ -51,6 +51,9 @@ func main() {
 	if err != nil {
 		startUpFailed(terminationFilePath(), err, "Failed to load sidecar config", logger)
 	}
+	if svcConfig.Sidecar == nil {
+		startUpFailed(terminationFilePath(), fmt.Errorf("sidecar section missing from config"), "Invalid sidecar config", logger)
+	}
 
 	var otelShutdown func(context.Context) error
 	if svcConfig.IsOTELEnabled() {
@@ -76,6 +79,7 @@ func main() {
 		"version", version,
 		"build", build,
 		"build_date", buildDate,
+		"local_mode", svcConfig.Sidecar.LocalMode,
 		"mlflow_tracking", svcConfig.MLFlow != nil && svcConfig.MLFlow.TrackingURI != "",
 		"otel", svcConfig.IsOTELEnabled(),
 	)

--- a/config/sidecar_local_mode.json
+++ b/config/sidecar_local_mode.json
@@ -1,0 +1,11 @@
+{
+  "base_url": "http://localhost:8082",
+  "local_mode": true,
+  "local": {
+    "job_cache_sweep_interval": "1h30m",
+    "job_cache_entry_ttl": "2h"
+  },
+  "eval_hub": {
+    "base_url": "http://localhost:8080"
+  }
+}

--- a/internal/eval_hub/config/sidecar_config.go
+++ b/internal/eval_hub/config/sidecar_config.go
@@ -2,11 +2,31 @@ package config
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
 	"time"
 )
+
+// Duration wraps time.Duration with human-readable JSON unmarshalling (e.g. "5m", "2h").
+type Duration struct {
+	time.Duration
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	var err error
+	d.Duration, err = time.ParseDuration(s)
+	return err
+}
 
 const (
 	DefaultSidecarPort    = 8080
@@ -15,6 +35,7 @@ const (
 
 type SidecarConfig struct {
 	LocalMode        bool                    `mapstructure:"local_mode,omitempty" json:"local_mode,omitempty"`
+	Local            *LocalConfig            `mapstructure:"local,omitempty" json:"local,omitempty"`
 	BaseURL          string                  `mapstructure:"base_url,omitempty" json:"base_url,omitempty"`
 	Port             int32                   `mapstructure:"-" json:"-"` // derived from BaseURL by ResolvePort; never serialised
 	EvalHub          *EvalHubClientConfig    `mapstructure:"eval_hub" json:"eval_hub,omitempty"`
@@ -24,6 +45,13 @@ type SidecarConfig struct {
 	InitContainer    *InitContainerConfig    `mapstructure:"init_container,omitempty" json:"init_container,omitempty"`
 	SidecarContainer *SidecarContainerConfig `mapstructure:"sidecar_container,omitempty" json:"sidecar_container,omitempty"`
 	OTEL             *OTELConfig             `mapstructure:"otel,omitempty" json:"otel,omitempty"`
+}
+
+// LocalConfig holds local-mode-only tuning knobs. Ignored when LocalMode is false.
+// All fields are optional; zero values fall back to defaults.
+type LocalConfig struct {
+	JobCacheSweepInterval Duration `mapstructure:"job_cache_sweep_interval,omitempty" json:"job_cache_sweep_interval,omitempty"`
+	JobCacheEntryTTL      Duration `mapstructure:"job_cache_entry_ttl,omitempty" json:"job_cache_entry_ttl,omitempty"`
 }
 
 // InitContainerConfig holds metadata written by eval-hub for the init container phase.

--- a/internal/eval_hub/runtimes/local/local_runtime.go
+++ b/internal/eval_hub/runtimes/local/local_runtime.go
@@ -281,6 +281,7 @@ func (r *LocalRuntime) runBenchmark(
 	// Set environment variables
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("EVALHUB_JOB_SPEC_PATH=%s", absJobSpecPath),
+		"EVALHUB_MODE=local",
 	)
 	for _, envVar := range provider.Runtime.Local.Env {
 		if envVar.Name != "" {

--- a/internal/eval_hub/runtimes/local/local_runtime_test.go
+++ b/internal/eval_hub/runtimes/local/local_runtime_test.go
@@ -345,8 +345,8 @@ func TestRunEvaluationJobPassesEnvVar(t *testing.T) {
 	outputFile := filepath.Join(dirName, "env_output.txt")
 	sentinelPath := filepath.Join(dirName, "done")
 
-	// Command writes EVALHUB_JOB_SPEC_PATH and TEST_VAR to output file
-	command := fmt.Sprintf("sh -c 'echo $EVALHUB_JOB_SPEC_PATH > %s && echo $TEST_VAR >> %s && touch %s'", outputFile, outputFile, sentinelPath)
+	// Command writes EVALHUB_JOB_SPEC_PATH, TEST_VAR, and EVALHUB_MODE to output file
+	command := fmt.Sprintf("sh -c 'echo $EVALHUB_JOB_SPEC_PATH > %s && echo $TEST_VAR >> %s && echo $EVALHUB_MODE >> %s && touch %s'", outputFile, outputFile, outputFile, sentinelPath)
 	providers := sampleLocalProviders(providerID, command)
 
 	rt := &LocalRuntime{
@@ -382,16 +382,19 @@ func TestRunEvaluationJobPassesEnvVar(t *testing.T) {
 		t.Fatal("expected env output, got empty file")
 	}
 
-	// Parse the two lines
+	// Parse the three lines
 	lines := strings.Split(output, "\n")
-	if len(lines) < 2 {
-		t.Fatalf("expected at least 2 lines in env output, got %d: %q", len(lines), output)
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 lines in env output, got %d: %q", len(lines), output)
 	}
 	if lines[0] != absExpectedPath {
 		t.Fatalf("expected EVALHUB_JOB_SPEC_PATH=%q, got %q", absExpectedPath, lines[0])
 	}
 	if lines[1] != "test_value" {
 		t.Fatalf("expected TEST_VAR=%q, got %q", "test_value", lines[1])
+	}
+	if lines[2] != "local" {
+		t.Fatalf("EVALHUB_MODE = %q, want local", lines[2])
 	}
 }
 

--- a/internal/eval_hub/runtimes/shared/sidecar_job_info.go
+++ b/internal/eval_hub/runtimes/shared/sidecar_job_info.go
@@ -55,7 +55,7 @@ func RewriteModelURLForLocalSidecar(sidecarBaseURL, jobID, modelURL string) (str
 	if sidecar.Host == "" {
 		return "", fmt.Errorf("invalid sidecar base URL %q: missing host", sidecarBaseURL)
 	}
-	model, err := url.Parse(strings.TrimSuffix(modelURL, "/"))
+	model, err := url.Parse(modelURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid model URL %q: %w", modelURL, err)
 	}

--- a/internal/eval_hub/runtimes/shared/sidecar_job_info_test.go
+++ b/internal/eval_hub/runtimes/shared/sidecar_job_info_test.go
@@ -130,7 +130,14 @@ func TestRewriteModelURLForLocalSidecar(t *testing.T) {
 			sidecarBaseURL: "http://localhost:8082",
 			jobID:          "job-abc",
 			modelURL:       "https://model-serving.example.com/v1/",
-			want:           "http://localhost:8082/model/job-abc/v1",
+			want:           "http://localhost:8082/model/job-abc/v1/",
+		},
+		{
+			name:           "model URL host only with trailing slash",
+			sidecarBaseURL: "http://localhost:8082",
+			jobID:          "job-abc",
+			modelURL:       "https://model-serving.example.com/",
+			want:           "http://localhost:8082/model/job-abc/",
 		},
 		{
 			name:           "model URL with query string",

--- a/internal/eval_runtime_sidecar/config/sidecar_runtime_config_test.go
+++ b/internal/eval_runtime_sidecar/config/sidecar_runtime_config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestLoadSidecarRuntimeConfig(t *testing.T) {
@@ -114,6 +115,100 @@ func TestLoadSidecarRuntimeConfig_OCISnakeCase(t *testing.T) {
 	if cfg.Sidecar.OCI.HTTPTimeout != 30_000_000_000 {
 		t.Errorf("oci.http_timeout = %v", cfg.Sidecar.OCI.HTTPTimeout)
 	}
+}
+
+func TestLoadSidecarRuntimeConfig_LocalMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar_config.json")
+
+	t.Run("local_mode true", func(t *testing.T) {
+		json := `{
+  "base_url": "http://localhost:8082",
+  "local_mode": true,
+  "eval_hub": { "base_url": "http://localhost:8080" }
+}`
+		if err := os.WriteFile(path, []byte(json), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadSidecarRuntimeConfig(path, "v1", "b1", "d1")
+		if err != nil {
+			t.Fatalf("LoadSidecarRuntimeConfig: %v", err)
+		}
+		if !cfg.Sidecar.LocalMode {
+			t.Fatal("expected LocalMode true")
+		}
+		if cfg.Sidecar.Port != 8082 {
+			t.Fatalf("expected port 8082, got %d", cfg.Sidecar.Port)
+		}
+	})
+
+	t.Run("local_mode defaults to false", func(t *testing.T) {
+		json := `{
+  "base_url": "http://localhost:8080",
+  "eval_hub": { "base_url": "http://localhost:8080" }
+}`
+		if err := os.WriteFile(path, []byte(json), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadSidecarRuntimeConfig(path, "v1", "b1", "d1")
+		if err != nil {
+			t.Fatalf("LoadSidecarRuntimeConfig: %v", err)
+		}
+		if cfg.Sidecar.LocalMode {
+			t.Fatal("expected LocalMode false by default")
+		}
+	})
+}
+
+func TestLoadSidecarRuntimeConfig_LocalConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar_config.json")
+
+	t.Run("parses local block with custom values", func(t *testing.T) {
+		json := `{
+  "base_url": "http://localhost:8082",
+  "local_mode": true,
+  "local": {
+    "job_cache_sweep_interval": "1h30m",
+    "job_cache_entry_ttl": "2h"
+  },
+  "eval_hub": { "base_url": "http://localhost:8080" }
+}`
+		if err := os.WriteFile(path, []byte(json), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadSidecarRuntimeConfig(path, "v1", "b1", "d1")
+		if err != nil {
+			t.Fatalf("LoadSidecarRuntimeConfig: %v", err)
+		}
+		if cfg.Sidecar.Local == nil {
+			t.Fatal("expected Local config")
+		}
+		if cfg.Sidecar.Local.JobCacheSweepInterval.Duration != 90*time.Minute {
+			t.Errorf("sweep interval = %v, want 1h30m", cfg.Sidecar.Local.JobCacheSweepInterval)
+		}
+		if cfg.Sidecar.Local.JobCacheEntryTTL.Duration != 2*time.Hour {
+			t.Errorf("entry TTL = %v, want 2h", cfg.Sidecar.Local.JobCacheEntryTTL)
+		}
+	})
+
+	t.Run("local block nil when omitted", func(t *testing.T) {
+		json := `{
+  "base_url": "http://localhost:8082",
+  "local_mode": true,
+  "eval_hub": { "base_url": "http://localhost:8080" }
+}`
+		if err := os.WriteFile(path, []byte(json), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadSidecarRuntimeConfig(path, "v1", "b1", "d1")
+		if err != nil {
+			t.Fatalf("LoadSidecarRuntimeConfig: %v", err)
+		}
+		if cfg.Sidecar.Local != nil {
+			t.Errorf("expected Local nil when omitted, got %+v", cfg.Sidecar.Local)
+		}
+	})
 }
 
 func TestLoadSidecarRuntimeConfig_OTEL(t *testing.T) {

--- a/internal/eval_runtime_sidecar/handlers/handlers.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -31,7 +32,7 @@ type Handlers struct {
 	ociProxy         *httputil.ReverseProxy
 	ociTokenProducer *proxy.OCITokenProducer // created once at startup for OCI auth
 	ociRepository    string                  // from job spec; used to route requests to /registry/{ociRepository}
-	modelProxy       *httputil.ReverseProxy  // model credential-injection proxy; nil when not configured
+	modelProxy       *httputil.ReverseProxy  // k8s: credential-injection proxy; local: per-job routing proxy
 
 	// gitSHA is the commit SHA from .git-metadata (isGitJob only). Best-effort load in New();
 	// if still empty, tryLoadGitSHA retries on each events POST until success, then the value
@@ -43,30 +44,44 @@ type Handlers struct {
 }
 
 // New creates handlers and builds reverse proxies for eval-hub, MLflow, OCI, and optionally model.
-func New(config *config.Config, logger *slog.Logger) (*Handlers, error) {
-	evalHubProxy, err := newEvalhubProxy(config, logger)
+// The ctx parameter controls the lifetime of background goroutines (e.g. local mode cache sweep).
+func New(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*Handlers, error) {
+	evalHubProxy, err := newEvalhubProxy(cfg, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	mlflowProxy, err := newMlflowProxy(config, logger)
-	if err != nil {
-		return nil, err
+	var mlflowProxy *httputil.ReverseProxy
+	var ociProxy *httputil.ReverseProxy
+	var ociTokenProducer *proxy.OCITokenProducer
+	var ociRepository string
+	if !cfg.Sidecar.LocalMode {
+		mlflowProxy, err = newMlflowProxy(cfg, logger)
+		if err != nil {
+			return nil, err
+		}
+		ociProxy, ociTokenProducer, ociRepository, err = newOciProxy(cfg, logger)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		logger.Info("Local mode: skipping MLflow and OCI proxy initialization")
 	}
 
-	ociProxy, ociTokenProducer, ociRepository, err := newOciProxy(config, logger)
-	if err != nil {
-		return nil, err
-	}
-
-	modelProxy, err := newModelProxy(config, logger)
-	if err != nil {
-		return nil, err
+	var modelProxy *httputil.ReverseProxy
+	if cfg.Sidecar.LocalMode {
+		modelProxy = newLocalModelProxy(ctx, cfg.Sidecar.Local, logger)
+		logger.Info("Local model proxy enabled with per-job routing")
+	} else {
+		modelProxy, err = newModelProxy(cfg, logger)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	h := &Handlers{
 		logger:           logger,
-		serviceConfig:    config,
+		serviceConfig:    cfg,
 		evalHubProxy:     evalHubProxy,
 		mlflowProxy:      mlflowProxy,
 		ociProxy:         ociProxy,
@@ -262,12 +277,13 @@ func (h *Handlers) parseProxyCall(r *http.Request) (*httputil.ReverseProxy, *pro
 	case strings.HasPrefix(r.RequestURI, "/api/v1/evaluations/"):
 		ehClientConfig := h.serviceConfig.Sidecar.EvalHub
 		if ehClientConfig != nil {
-			return h.evalHubProxy, &proxy.AuthTokenInput{
-				TargetEndpoint:    "eval-hub",
-				AuthTokenPath:     ServiceAccountAuthFileDefault,
-				AuthToken:         ehClientConfig.Token,
-				TokenCacheTimeout: ehClientConfig.TokenCacheTimeout,
-			}, nil
+			input := proxy.AuthTokenInput{TargetEndpoint: "eval-hub"}
+			if !h.serviceConfig.Sidecar.LocalMode {
+				input.AuthTokenPath = ServiceAccountAuthFileDefault
+				input.AuthToken = ehClientConfig.Token
+				input.TokenCacheTimeout = ehClientConfig.TokenCacheTimeout
+			}
+			return h.evalHubProxy, &input, nil
 		}
 		return nil, nil, fmt.Errorf("eval-hub proxy is not configured")
 
@@ -297,10 +313,6 @@ func (h *Handlers) parseProxyCall(r *http.Request) (*httputil.ReverseProxy, *pro
 		}
 		return nil, nil, fmt.Errorf("oci proxy is not configured")
 	default:
-		// Model credential-injection proxy is the catch-all: when configured, any request
-		// not matched by the specific prefixes above is forwarded to the model target URL.
-		// The model proxy's Rewrite function performs ref-token substitution and dynamic URL
-		// routing; it does not use AuthTokenInput, so an empty value is returned.
 		if h.modelProxy != nil {
 			return h.modelProxy, &proxy.AuthTokenInput{}, nil
 		}

--- a/internal/eval_runtime_sidecar/handlers/handlers_test.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/eval_runtime_sidecar/proxy"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
@@ -47,7 +49,7 @@ func TestNew(t *testing.T) {
 				},
 			},
 		}
-		_, err := New(cfg, logger)
+		_, err := New(context.Background(), cfg, logger)
 		if err == nil {
 			t.Fatal("expected error when eval_hub.base_url is not set")
 		}
@@ -66,7 +68,7 @@ func TestNew(t *testing.T) {
 			},
 			MLFlow: &config.MLFlowConfig{TrackingURI: "http://localhost:5000"},
 		}
-		h, err := New(cfg, logger)
+		h, err := New(context.Background(), cfg, logger)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -96,6 +98,136 @@ func TestHandlers_HandleHealth(t *testing.T) {
 	}
 }
 
+func TestNew_LocalMode(t *testing.T) {
+	logger := slog.Default()
+	cfg := &config.Config{
+		Sidecar: &config.SidecarConfig{
+			BaseURL:   "http://localhost:8082",
+			LocalMode: true,
+			EvalHub: &config.EvalHubClientConfig{
+				BaseURL: "http://localhost:8080",
+			},
+		},
+	}
+	h, err := New(context.Background(), cfg, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !h.serviceConfig.Sidecar.LocalMode {
+		t.Error("expected LocalMode true")
+	}
+	if h.mlflowProxy != nil {
+		t.Error("expected mlflowProxy nil in local mode")
+	}
+	if h.ociProxy != nil {
+		t.Error("expected ociProxy nil in local mode")
+	}
+	if h.modelProxy == nil {
+		t.Error("expected modelProxy non-nil in local mode")
+	}
+}
+
+func TestHandleProxyCall_LocalMode_ModelRouting(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var receivedPath, receivedAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	jobsDir := t.TempDir()
+	authDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(authDir, "api-key"), []byte("sk-test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	jobID := "test-job-42"
+	jobDir := filepath.Join(jobsDir, jobID)
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jobInfo := `{"model": {"url": "` + upstream.URL + `", "auth_secret_mount_path": "` + authDir + `"}}`
+	if err := os.WriteFile(filepath.Join(jobDir, "sidecar-job-info.json"), []byte(jobInfo), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Sidecar: &config.SidecarConfig{
+			BaseURL:   "http://localhost:8082",
+			LocalMode: true,
+			EvalHub: &config.EvalHubClientConfig{
+				BaseURL: "http://localhost:8080",
+			},
+		},
+	}
+	h, err := New(context.Background(), cfg, logger)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	// Override the local model proxy to point at our temp dir.
+	cache := proxy.NewJobInfoCache(jobsDir, proxy.DefaultJobCacheTTL, logger)
+	h.modelProxy = proxy.NewLocalModelReverseProxy(cache, logger)
+
+	t.Run("routes /model/<job-id>/path to upstream with prefix stripped", func(t *testing.T) {
+		receivedPath = ""
+		req := httptest.NewRequest(http.MethodPost, "/model/"+jobID+"/v1/chat/completions", nil)
+		rw := httptest.NewRecorder()
+		h.HandleProxyCall(rw, req)
+
+		if rw.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200; body = %s", rw.Code, rw.Body.String())
+		}
+		if receivedPath != "/v1/chat/completions" {
+			t.Errorf("upstream path = %q, want /v1/chat/completions", receivedPath)
+		}
+	})
+
+	t.Run("forwards request without injecting auth when adapter sends none", func(t *testing.T) {
+		receivedAuth = ""
+		req := httptest.NewRequest(http.MethodGet, "/model/"+jobID+"/v1/models", nil)
+		rw := httptest.NewRecorder()
+		h.HandleProxyCall(rw, req)
+
+		if receivedAuth != "" {
+			t.Errorf("upstream auth = %q, want empty (sidecar must not inject credentials in local mode)", receivedAuth)
+		}
+	})
+
+	t.Run("unknown job returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/model/nonexistent/v1/models", nil)
+		rw := httptest.NewRecorder()
+		h.HandleProxyCall(rw, req)
+
+		if rw.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want 404", rw.Code)
+		}
+	})
+
+	t.Run("non-model path in local mode returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/some/random/path", nil)
+		rw := httptest.NewRecorder()
+		h.HandleProxyCall(rw, req)
+
+		if rw.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", rw.Code)
+		}
+	})
+
+	t.Run("eval-hub path still routes correctly in local mode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/evaluations/jobs", nil)
+		rw := httptest.NewRecorder()
+		h.HandleProxyCall(rw, req)
+		// Should route to eval-hub proxy (will get connection error, not 400)
+		if rw.Code == http.StatusBadRequest && strings.Contains(rw.Body.String(), "unknown proxy call") {
+			t.Error("eval-hub path should not be treated as unknown proxy call in local mode")
+		}
+	})
+}
+
 func TestHandlers_HandleProxyCall(t *testing.T) {
 	logger := slog.Default()
 	cfg := &config.Config{
@@ -107,7 +239,7 @@ func TestHandlers_HandleProxyCall(t *testing.T) {
 		},
 		MLFlow: &config.MLFlowConfig{TrackingURI: "http://localhost:5000"},
 	}
-	h, err := New(cfg, logger)
+	h, err := New(context.Background(), cfg, logger)
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}
@@ -210,7 +342,7 @@ func TestHandlers_HandleProxyCall(t *testing.T) {
 				},
 			},
 		}
-		hNoMLFlow, err := New(cfgNoMLFlow, logger)
+		hNoMLFlow, err := New(context.Background(), cfgNoMLFlow, logger)
 		if err != nil {
 			t.Fatalf("New() error: %v", err)
 		}
@@ -538,7 +670,7 @@ func TestHandleProxyCall_GitSHAInjectedOnEventsPost(t *testing.T) {
 			InitContainer: &config.InitContainerConfig{IsGitJob: true},
 		},
 	}
-	h, err := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h, err := New(context.Background(), cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}

--- a/internal/eval_runtime_sidecar/handlers/model.go
+++ b/internal/eval_runtime_sidecar/handlers/model.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http/httputil"
@@ -43,4 +44,25 @@ func newModelProxy(config *config.Config, logger *slog.Logger) (*httputil.Revers
 	rp := proxy.NewModelReverseProxy(target, modelHTTPClient, logger, secretMountPath, ServiceAccountAuthFileDefault)
 	logger.Info("Model proxy enabled", "url", targetURL)
 	return rp, nil
+}
+
+// newLocalModelProxy creates a reverse proxy for local mode that routes /model/<job-id>/<path>
+// requests to per-job upstream model URLs using a TTL cache of sidecar-job-info.json files.
+// A background sweep goroutine is started and will exit when ctx is cancelled.
+func newLocalModelProxy(ctx context.Context, localCfg *config.LocalConfig, logger *slog.Logger) *httputil.ReverseProxy {
+	ttl := proxy.DefaultJobCacheTTL
+	sweepInterval := proxy.DefaultJobCacheSweepInterval
+	if localCfg != nil {
+		if localCfg.JobCacheEntryTTL.Duration > 0 {
+			ttl = localCfg.JobCacheEntryTTL.Duration
+		}
+		if localCfg.JobCacheSweepInterval.Duration > 0 {
+			sweepInterval = localCfg.JobCacheSweepInterval.Duration
+		}
+	}
+
+	cache := proxy.NewJobInfoCache("", ttl, logger)
+	cache.StartSweep(ctx, sweepInterval)
+	logger.Info("Job cache sweep started", "sweep_interval", sweepInterval, "entry_ttl", ttl)
+	return proxy.NewLocalModelReverseProxy(cache, logger)
 }

--- a/internal/eval_runtime_sidecar/proxy/job_cache.go
+++ b/internal/eval_runtime_sidecar/proxy/job_cache.go
@@ -1,0 +1,175 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/runtimes/shared"
+)
+
+const (
+	DefaultJobCacheTTL           = 2 * time.Hour
+	DefaultJobCacheSweepInterval = 90 * time.Minute
+	DefaultJobsDir               = "/tmp/evalhub-jobs"
+)
+
+type jobCacheEntry struct {
+	target     *url.URL
+	httpClient *http.Client
+	cleanAfter time.Time
+}
+
+// JobInfoCache maps job-id to resolved proxy state with a per-entry TTL.
+// Entries are lazy-loaded from the filesystem on first access and refreshed
+// after the TTL expires.
+type JobInfoCache struct {
+	mu      sync.RWMutex
+	entries map[string]*jobCacheEntry
+	ttl     time.Duration
+	jobsDir string
+	now     func() time.Time
+	logger  *slog.Logger
+}
+
+// NewJobInfoCache creates a job info cache that reads sidecar-job-info.json
+// files from jobsDir (defaults to /tmp/evalhub-jobs).
+func NewJobInfoCache(jobsDir string, ttl time.Duration, logger *slog.Logger) *JobInfoCache {
+	if jobsDir == "" {
+		jobsDir = DefaultJobsDir
+	}
+	if ttl <= 0 {
+		ttl = DefaultJobCacheTTL
+	}
+	return &JobInfoCache{
+		entries: make(map[string]*jobCacheEntry),
+		ttl:     ttl,
+		jobsDir: jobsDir,
+		now:     time.Now,
+		logger:  logger,
+	}
+}
+
+// Get returns the parsed target URL and per-job HTTP client for the given job-id.
+// Loads from the filesystem on cache miss. Cached entries are served
+// indefinitely; cleanAfter is only a hint for future passive sweep.
+func (c *JobInfoCache) Get(jobID string) (*url.URL, *http.Client, error) {
+	c.mu.RLock()
+	if entry, ok := c.entries[jobID]; ok {
+		c.mu.RUnlock()
+		return entry.target, entry.httpClient, nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry, ok := c.entries[jobID]; ok {
+		return entry.target, entry.httpClient, nil
+	}
+
+	entry, err := c.loadEntry(jobID)
+	if err != nil {
+		return nil, nil, err
+	}
+	entry.cleanAfter = c.now().Add(c.ttl)
+	c.entries[jobID] = entry
+	c.logger.Info("Loaded job info into cache", "job_id", jobID, "target", entry.target.String())
+	return entry.target, entry.httpClient, nil
+}
+
+func (c *JobInfoCache) loadEntry(jobID string) (*jobCacheEntry, error) {
+	if strings.ContainsAny(jobID, "/\\") {
+		return nil, fmt.Errorf("invalid job-id %q", jobID)
+	}
+
+	infoPath := filepath.Join(c.jobsDir, jobID, shared.SidecarJobInfoFileName)
+	data, err := os.ReadFile(infoPath) // #nosec G304 -- job-id validated above, path constructed from known base
+	if err != nil {
+		return nil, fmt.Errorf("job info not found for %q: %w", jobID, err)
+	}
+
+	var info shared.SidecarJobInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, fmt.Errorf("invalid job info JSON for %q: %w", jobID, err)
+	}
+	if info.Model == nil || strings.TrimSpace(info.Model.URL) == "" {
+		return nil, fmt.Errorf("job info for %q is missing model URL", jobID)
+	}
+
+	target, err := url.Parse(strings.TrimSuffix(strings.TrimSpace(info.Model.URL), "/"))
+	if err != nil || !target.IsAbs() || target.Host == "" {
+		return nil, fmt.Errorf("invalid model URL %q in job info for %q", info.Model.URL, jobID)
+	}
+
+	timeout := DefaultHTTPTimeout
+	if info.Model.HTTPTimeout > 0 {
+		timeout = info.Model.HTTPTimeout
+	}
+
+	caCertPath := ""
+	if mountPath := strings.TrimSpace(info.Model.AuthSecretMountPath); mountPath != "" {
+		candidate := filepath.Join(mountPath, "ca_cert")
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			caCertPath = candidate
+		}
+	}
+
+	label := "Job-" + jobID
+	var tlsCfg *tls.Config
+	if schemeRequiresTLS(info.Model.URL) {
+		var tlsErr error
+		tlsCfg, tlsErr = buildTLSConfig(caCertPath, info.Model.InsecureSkipVerify, c.logger, label)
+		if tlsErr != nil {
+			return nil, fmt.Errorf("TLS config for job %q: %w", jobID, tlsErr)
+		}
+	}
+	httpClient := newHTTPClient(timeout, tlsCfg, false, c.logger, label)
+
+	return &jobCacheEntry{
+		target:     target,
+		httpClient: httpClient,
+	}, nil
+}
+
+// StartSweep launches a background goroutine that periodically removes expired
+// cache entries. It returns immediately. The goroutine exits when ctx is cancelled.
+func (c *JobInfoCache) StartSweep(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = DefaultJobCacheSweepInterval
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.sweep()
+			}
+		}
+	}()
+}
+
+func (c *JobInfoCache) sweep() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	for jobID, entry := range c.entries {
+		if now.After(entry.cleanAfter) {
+			delete(c.entries, jobID)
+			c.logger.Info("Swept expired job cache entry", "job_id", jobID)
+		}
+	}
+}

--- a/internal/eval_runtime_sidecar/proxy/job_cache_test.go
+++ b/internal/eval_runtime_sidecar/proxy/job_cache_test.go
@@ -1,0 +1,390 @@
+package proxy
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eval-hub/eval-hub/internal/eval_hub/runtimes/shared"
+)
+
+func TestJobInfoCache_Get(t *testing.T) {
+	t.Parallel()
+	logger := slog.Default()
+
+	t.Run("loads job info from filesystem", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		jobID := "job-abc-123"
+		writeJobInfo(t, jobsDir, jobID, `{
+			"model": {
+				"url": "https://model.example.com/v1",
+				"auth_secret_mount_path": "/home/user/creds"
+			}
+		}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		target, _, err := cache.Get(jobID)
+		if err != nil {
+			t.Fatalf("Get() error: %v", err)
+		}
+		if target.Host != "model.example.com" {
+			t.Errorf("target host = %q, want %q", target.Host, "model.example.com")
+		}
+	})
+
+	t.Run("returns cached entry on second call", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		jobID := "job-cached"
+		writeJobInfo(t, jobsDir, jobID, `{
+			"model": {"url": "https://model.example.com:8443/v1"}
+		}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		target1, _, err := cache.Get(jobID)
+		if err != nil {
+			t.Fatalf("first Get() error: %v", err)
+		}
+		// Remove the file — second call should use cache
+		_ = os.Remove(filepath.Join(jobsDir, jobID, shared.SidecarJobInfoFileName))
+
+		target2, _, err := cache.Get(jobID)
+		if err != nil {
+			t.Fatalf("second Get() error: %v", err)
+		}
+		if target1 != target2 {
+			t.Error("expected same pointer from cache")
+		}
+	})
+
+	t.Run("serves cached entry after cleanAfter time", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		jobID := "job-permanent"
+		writeJobInfo(t, jobsDir, jobID, `{
+			"model": {"url": "https://model.example.com:8443/v1"}
+		}`)
+
+		now := time.Now()
+		cache := NewJobInfoCache(jobsDir, 1*time.Second, logger)
+		cache.now = func() time.Time { return now }
+
+		target1, _, err := cache.Get(jobID)
+		if err != nil {
+			t.Fatalf("first Get() error: %v", err)
+		}
+
+		// Advance well past cleanAfter — entry should still be served
+		cache.now = func() time.Time { return now.Add(1 * time.Hour) }
+
+		target2, _, err := cache.Get(jobID)
+		if err != nil {
+			t.Fatalf("second Get() error: %v", err)
+		}
+		if target1 != target2 {
+			t.Error("expected same pointer — cached entries are served indefinitely")
+		}
+	})
+
+	t.Run("returns error for missing job", func(t *testing.T) {
+		t.Parallel()
+		cache := NewJobInfoCache(t.TempDir(), DefaultJobCacheTTL, logger)
+		_, _, err := cache.Get("nonexistent-job")
+		if err == nil {
+			t.Fatal("expected error for missing job")
+		}
+	})
+
+	t.Run("rejects job-id with path separator", func(t *testing.T) {
+		t.Parallel()
+		cache := NewJobInfoCache(t.TempDir(), DefaultJobCacheTTL, logger)
+		_, _, err := cache.Get("../etc/passwd")
+		if err == nil {
+			t.Fatal("expected error for job-id with path traversal")
+		}
+	})
+
+	t.Run("returns error for missing model URL", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "no-url", `{"model": {"url": ""}}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, _, err := cache.Get("no-url")
+		if err == nil {
+			t.Fatal("expected error for empty model URL")
+		}
+	})
+
+	t.Run("returns error for invalid model URL", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "bad-url", `{"model": {"url": "not-a-url"}}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, _, err := cache.Get("bad-url")
+		if err == nil {
+			t.Fatal("expected error for non-absolute model URL")
+		}
+	})
+
+	t.Run("returns error for nil model", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "no-model", `{}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, _, err := cache.Get("no-model")
+		if err == nil {
+			t.Fatal("expected error for missing model section")
+		}
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "bad-json", `not json`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, _, err := cache.Get("bad-json")
+		if err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+	})
+
+	t.Run("loads entry successfully with auth_secret_mount_path", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		authDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(authDir, "api-key"), []byte("sk-test-key"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		writeJobInfo(t, jobsDir, "job-with-creds", `{
+			"model": {
+				"url": "https://api.example.com:443/v1",
+				"auth_secret_mount_path": "`+authDir+`"
+			}
+		}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		target, client, err := cache.Get("job-with-creds")
+		if err != nil {
+			t.Fatalf("Get() error: %v", err)
+		}
+		if target.Host != "api.example.com:443" {
+			t.Errorf("target host = %q, want %q", target.Host, "api.example.com:443")
+		}
+		if client == nil {
+			t.Error("expected non-nil HTTP client")
+		}
+	})
+
+	t.Run("caches HTTP client with job entry", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "job-client", `{
+			"model": {"url": "https://model.example.com/v1"}
+		}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, client1, err := cache.Get("job-client")
+		if err != nil {
+			t.Fatalf("first Get() error: %v", err)
+		}
+		if client1 == nil {
+			t.Fatal("expected non-nil HTTP client")
+		}
+
+		_, client2, err := cache.Get("job-client")
+		if err != nil {
+			t.Fatalf("second Get() error: %v", err)
+		}
+		if client1 != client2 {
+			t.Error("expected same client pointer from cache")
+		}
+	})
+
+	t.Run("uses custom HTTP timeout from model config", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "job-timeout", `{
+			"model": {
+				"url": "http://model.example.com/v1",
+				"http_timeout": 120000000000
+			}
+		}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, client, err := cache.Get("job-timeout")
+		if err != nil {
+			t.Fatalf("Get() error: %v", err)
+		}
+		if client.Timeout != 120*time.Second {
+			t.Errorf("timeout = %v, want 2m", client.Timeout)
+		}
+	})
+
+	t.Run("strips trailing slash from model URL", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "trailing-slash", `{
+			"model": {"url": "https://model.example.com:8443/v1/"}
+		}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		target, _, err := cache.Get("trailing-slash")
+		if err != nil {
+			t.Fatalf("Get() error: %v", err)
+		}
+		if target.Path != "/v1" {
+			t.Errorf("target path = %q, want /v1 (trailing slash stripped)", target.Path)
+		}
+	})
+}
+
+func TestNewJobInfoCache_Defaults(t *testing.T) {
+	t.Parallel()
+	logger := slog.Default()
+
+	t.Run("uses default jobs dir when empty", func(t *testing.T) {
+		t.Parallel()
+		cache := NewJobInfoCache("", DefaultJobCacheTTL, logger)
+		if cache.jobsDir != DefaultJobsDir {
+			t.Errorf("jobsDir = %q, want %q", cache.jobsDir, DefaultJobsDir)
+		}
+	})
+
+	t.Run("uses default TTL when zero", func(t *testing.T) {
+		t.Parallel()
+		cache := NewJobInfoCache("/tmp", 0, logger)
+		if cache.ttl != DefaultJobCacheTTL {
+			t.Errorf("ttl = %v, want %v", cache.ttl, DefaultJobCacheTTL)
+		}
+	})
+}
+
+func TestJobInfoCache_Sweep(t *testing.T) {
+	t.Parallel()
+	logger := slog.Default()
+
+	t.Run("removes expired entries", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "job-old", `{"model": {"url": "https://model.example.com:443/v1"}}`)
+		writeJobInfo(t, jobsDir, "job-new", `{"model": {"url": "https://model.example.com:443/v1"}}`)
+
+		now := time.Now()
+		cache := NewJobInfoCache(jobsDir, 1*time.Hour, logger)
+		cache.now = func() time.Time { return now }
+
+		// Load both entries
+		if _, _, err := cache.Get("job-old"); err != nil {
+			t.Fatal(err)
+		}
+
+		// Advance 90 minutes, then load job-new (so job-old is expired, job-new is not)
+		cache.now = func() time.Time { return now.Add(90 * time.Minute) }
+		if _, _, err := cache.Get("job-new"); err != nil {
+			t.Fatal(err)
+		}
+
+		// Advance to 2h+1m — job-old has cleanAfter at now+1h, job-new at now+90m+1h
+		cache.now = func() time.Time { return now.Add(2*time.Hour + 1*time.Minute) }
+		cache.sweep()
+
+		cache.mu.Lock()
+		_, oldExists := cache.entries["job-old"]
+		_, newExists := cache.entries["job-new"]
+		cache.mu.Unlock()
+
+		if oldExists {
+			t.Error("expected job-old to be swept")
+		}
+		if !newExists {
+			t.Error("expected job-new to still be cached")
+		}
+	})
+
+	t.Run("no-op when all entries are fresh", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "job-fresh", `{"model": {"url": "https://model.example.com:443/v1"}}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		if _, _, err := cache.Get("job-fresh"); err != nil {
+			t.Fatal(err)
+		}
+
+		cache.sweep()
+
+		cache.mu.Lock()
+		count := len(cache.entries)
+		cache.mu.Unlock()
+
+		if count != 1 {
+			t.Errorf("expected 1 entry, got %d", count)
+		}
+	})
+
+	t.Run("stops when context is cancelled", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cache.StartSweep(ctx, 10*time.Millisecond)
+		cancel()
+
+		// Give the goroutine time to exit
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	t.Run("swept entry reloads from filesystem on next Get", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "job-reload", `{"model": {"url": "https://model.example.com:443/v1"}}`)
+
+		now := time.Now()
+		cache := NewJobInfoCache(jobsDir, 1*time.Hour, logger)
+		cache.now = func() time.Time { return now }
+
+		if _, _, err := cache.Get("job-reload"); err != nil {
+			t.Fatal(err)
+		}
+
+		// Expire and sweep
+		cache.now = func() time.Time { return now.Add(2 * time.Hour) }
+		cache.sweep()
+
+		cache.mu.Lock()
+		_, exists := cache.entries["job-reload"]
+		cache.mu.Unlock()
+		if exists {
+			t.Fatal("expected entry to be swept")
+		}
+
+		// Get should reload from filesystem
+		target, _, err := cache.Get("job-reload")
+		if err != nil {
+			t.Fatalf("Get() after sweep: %v", err)
+		}
+		if target.Host != "model.example.com:443" {
+			t.Errorf("target host = %q after reload", target.Host)
+		}
+	})
+}
+
+func writeJobInfo(t *testing.T, jobsDir, jobID, content string) {
+	t.Helper()
+	dir := filepath.Join(jobsDir, jobID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, shared.SidecarJobInfoFileName), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/eval_runtime_sidecar/proxy/local_model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/local_model_proxy.go
@@ -1,0 +1,141 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+)
+
+// ParseLocalModelPath extracts the job-id and remaining path from a /model/<job-id>/<path>
+// path string. The input must be a clean path without query or fragment.
+// Returns ("", "", false) if the path does not match the expected pattern.
+func ParseLocalModelPath(path string) (jobID, remainingPath string, ok bool) {
+	rest, found := strings.CutPrefix(path, "/model/")
+	if !found || rest == "" {
+		return "", "", false
+	}
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		if i == 0 {
+			return "", "", false
+		}
+		return rest[:i], rest[i:], true
+	}
+	return rest, "", true
+}
+
+// Sentinel headers for local model proxy error signaling.
+// The Rewrite function sets these when it cannot resolve a job; the round tripper
+// intercepts them and returns the appropriate HTTP error without forwarding.
+const (
+	xLocalModelError      = "X-Local-Model-Error"        // #nosec G101 -- internal HTTP header, not a credential
+	xLocalModelErrorJobID = "X-Local-Model-Error-Job-Id" // #nosec G101
+)
+
+type contextKeyJobHTTPClient struct{}
+
+func jobClientFromContext(ctx context.Context) *http.Client {
+	v, _ := ctx.Value(contextKeyJobHTTPClient{}).(*http.Client)
+	return v
+}
+
+// NewLocalModelReverseProxy creates a reverse proxy for local mode that routes
+// model requests per-job using the TTL cache. Each request to /model/<job-id>/...
+// is forwarded to the upstream model URL from the job's sidecar-job-info.json,
+// with the /model/<job-id> prefix stripped from the path.
+// Each job gets its own HTTP client with TLS configured from the job's secret cache.
+func NewLocalModelReverseProxy(cache *JobInfoCache, logger *slog.Logger) *httputil.ReverseProxy {
+	rp := &httputil.ReverseProxy{
+		Transport: &localModelRoundTripper{
+			inner:  http.DefaultTransport,
+			logger: logger,
+		},
+	}
+
+	rp.Rewrite = func(pr *httputil.ProxyRequest) {
+		reqID := getOrCreateRequestID(pr.In)
+		reqLog := logger.With("request_id", reqID)
+		pr.Out.Header.Set(globalTransactionIDHeader, reqID)
+
+		jobID, remaining, ok := ParseLocalModelPath(pr.In.URL.Path)
+		if !ok {
+			reqLog.Error("Invalid model path", "path", pr.In.URL.Path, "method", pr.In.Method)
+			pr.Out.Header.Set(xLocalModelError, "invalid model path format, expected /model/<job-id>/<path>")
+			setDummyTarget(pr)
+			return
+		}
+
+		target, jobClient, err := cache.Get(jobID)
+		if err != nil {
+			reqLog.Error("Job info lookup failed", "job_id", jobID, "error", err)
+			pr.Out.Header.Set(xLocalModelError, "unknown job-id")
+			pr.Out.Header.Set(xLocalModelErrorJobID, jobID)
+			setDummyTarget(pr)
+			return
+		}
+
+		pr.Out.URL.Scheme = target.Scheme
+		pr.Out.URL.Host = target.Host
+		pr.Out.Host = target.Host
+		pr.Out.URL.Path = remaining
+		pr.Out.URL.RawPath = ""
+		pr.Out.RequestURI = ""
+
+		pr.Out = pr.Out.WithContext(context.WithValue(pr.Out.Context(), contextKeyJobHTTPClient{}, jobClient))
+
+		reqLog.Info("Proxying local model request",
+			"job_id", jobID, "method", pr.Out.Method, "url", pr.Out.URL.String())
+	}
+
+	rp.ModifyResponse = proxyModifyResponse(logger, "Response from local model proxy")
+
+	rp.ErrorHandler = proxyErrorHandler(logger, "Error proxying local model request")
+
+	return rp
+}
+
+// setDummyTarget fills required URL fields on pr.Out so the proxy framework
+// does not panic when the Rewrite function bails out early on error.
+func setDummyTarget(pr *httputil.ProxyRequest) {
+	pr.Out.URL.Scheme = "http"
+	pr.Out.URL.Host = "localhost"
+	pr.Out.Host = "localhost"
+	pr.Out.RequestURI = ""
+}
+
+// localModelRoundTripper intercepts requests marked with xLocalModelError and
+// returns the appropriate HTTP error without forwarding to an upstream.
+type localModelRoundTripper struct {
+	inner  http.RoundTripper
+	logger *slog.Logger
+}
+
+func (t *localModelRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	errMsg := req.Header.Get(xLocalModelError)
+	if errMsg == "" {
+		if client := jobClientFromContext(req.Context()); client != nil {
+			return client.Do(req)
+		}
+		return t.inner.RoundTrip(req)
+	}
+	req.Header.Del(xLocalModelError)
+	jobID := req.Header.Get(xLocalModelErrorJobID)
+	req.Header.Del(xLocalModelErrorJobID)
+
+	statusCode := http.StatusNotFound
+	respBody := map[string]string{"error": "unknown job-id", "job_id": jobID}
+	if jobID == "" {
+		statusCode = http.StatusBadRequest
+		respBody = map[string]string{"error": errMsg}
+	}
+	t.logger.Error("Local model proxy error",
+		"request_id", getOrCreateRequestID(req), "status", statusCode, "job_id", jobID)
+
+	body, _ := json.Marshal(respBody)
+	resp := newSyntheticResponse(req, statusCode, bytes.NewReader(append(body, '\n')))
+	resp.Header.Set("Content-Type", "application/json")
+	return resp, nil
+}

--- a/internal/eval_runtime_sidecar/proxy/local_model_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/local_model_proxy_test.go
@@ -1,0 +1,400 @@
+package proxy
+
+import (
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseLocalModelPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		path          string
+		wantJobID     string
+		wantRemaining string
+		wantOK        bool
+	}{
+		{"/model/job-123/v1/chat/completions", "job-123", "/v1/chat/completions", true},
+		{"/model/job-123/v1", "job-123", "/v1", true},
+		{"/model/job-123/", "job-123", "/", true},
+		{"/model/job-123", "job-123", "", true},
+		{"/model/abc-def-ghi/v1/models", "abc-def-ghi", "/v1/models", true},
+		{"/model//", "", "", false},
+		{"/model//v1/chat", "", "", false},
+		{"/model/", "", "", false},
+		{"/model", "", "", false},
+		{"/models/job-123/v1", "", "", false},
+		{"/other/path", "", "", false},
+		{"", "", "", false},
+	}
+	for _, tt := range tests {
+		jobID, remaining, ok := ParseLocalModelPath(tt.path)
+		if ok != tt.wantOK {
+			t.Errorf("ParseLocalModelPath(%q): ok = %v, want %v", tt.path, ok, tt.wantOK)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if jobID != tt.wantJobID {
+			t.Errorf("ParseLocalModelPath(%q): jobID = %q, want %q", tt.path, jobID, tt.wantJobID)
+		}
+		if remaining != tt.wantRemaining {
+			t.Errorf("ParseLocalModelPath(%q): remaining = %q, want %q", tt.path, remaining, tt.wantRemaining)
+		}
+	}
+}
+
+func TestLocalModelProxy_ForwardsToUpstream(t *testing.T) {
+	t.Parallel()
+
+	var receivedPath, receivedAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result": "ok"}`))
+	}))
+	defer upstream.Close()
+
+	jobsDir := t.TempDir()
+	writeJobInfo(t, jobsDir, "job-1", `{
+		"model": {"url": "`+upstream.URL+`"}
+	}`)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+	proxy := NewLocalModelReverseProxy(cache, logger)
+
+	req := httptest.NewRequest(http.MethodPost, "/model/job-1/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sk-adapter-set")
+	rw := httptest.NewRecorder()
+	proxy.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200; body = %s", rw.Code, rw.Body.String())
+	}
+	if receivedPath != "/v1/chat/completions" {
+		t.Errorf("upstream path = %q, want /v1/chat/completions", receivedPath)
+	}
+	if receivedAuth != "Bearer sk-adapter-set" {
+		t.Errorf("upstream auth = %q, want Bearer sk-adapter-set (adapter-provided auth should pass through)", receivedAuth)
+	}
+}
+
+func TestLocalModelProxy_NoAuthWithoutAdapterHeader(t *testing.T) {
+	t.Parallel()
+
+	var receivedAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	jobsDir := t.TempDir()
+	writeJobInfo(t, jobsDir, "job-noauth", `{
+		"model": {"url": "`+upstream.URL+`"}
+	}`)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+	proxy := NewLocalModelReverseProxy(cache, logger)
+
+	req := httptest.NewRequest(http.MethodPost, "/model/job-noauth/v1/completions", nil)
+	rw := httptest.NewRecorder()
+	proxy.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rw.Code)
+	}
+	if receivedAuth != "" {
+		t.Errorf("upstream auth = %q, want empty (no auth injection in local mode)", receivedAuth)
+	}
+}
+
+func TestLocalModelProxy_UnknownJobReturns404(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cache := NewJobInfoCache(t.TempDir(), DefaultJobCacheTTL, logger)
+	proxy := NewLocalModelReverseProxy(cache, logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/model/nonexistent-job/v1/models", nil)
+	rw := httptest.NewRecorder()
+	proxy.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rw.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rw.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["error"] != "unknown job-id" {
+		t.Errorf("error = %q, want %q", body["error"], "unknown job-id")
+	}
+	if body["job_id"] != "nonexistent-job" {
+		t.Errorf("job_id = %q, want %q", body["job_id"], "nonexistent-job")
+	}
+}
+
+func TestLocalModelProxy_InvalidPathReturns400(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cache := NewJobInfoCache(t.TempDir(), DefaultJobCacheTTL, logger)
+	proxy := NewLocalModelReverseProxy(cache, logger)
+
+	// Path with no job-id (just /model/)
+	req := httptest.NewRequest(http.MethodGet, "/model/", nil)
+	rw := httptest.NewRecorder()
+	proxy.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rw.Code)
+	}
+}
+
+func TestLocalModelProxy_StripsJobIDPrefix(t *testing.T) {
+	t.Parallel()
+
+	paths := []struct {
+		requestPath  string
+		expectedPath string
+	}{
+		{"/model/j1/v1/chat/completions", "/v1/chat/completions"},
+		{"/model/j1/v1", "/v1"},
+		{"/model/j1/", "/"},
+		{"/model/j1", "/"},
+	}
+
+	for _, tc := range paths {
+		var receivedPath string
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "j1", `{"model": {"url": "`+upstream.URL+`"}}`)
+
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		p := NewLocalModelReverseProxy(cache, logger)
+
+		req := httptest.NewRequest(http.MethodGet, tc.requestPath, nil)
+		rw := httptest.NewRecorder()
+		p.ServeHTTP(rw, req)
+		upstream.Close()
+
+		if rw.Code != http.StatusOK {
+			t.Errorf("%s: status = %d, want 200", tc.requestPath, rw.Code)
+			continue
+		}
+		if receivedPath != tc.expectedPath {
+			t.Errorf("%s: upstream path = %q, want %q", tc.requestPath, receivedPath, tc.expectedPath)
+		}
+	}
+}
+
+func TestLocalModelProxy_MultipleJobsRoutedIndependently(t *testing.T) {
+	t.Parallel()
+
+	var receivedPaths []string
+	upstream1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPaths = append(receivedPaths, "upstream1:"+r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream1.Close()
+
+	upstream2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPaths = append(receivedPaths, "upstream2:"+r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream2.Close()
+
+	jobsDir := t.TempDir()
+	writeJobInfo(t, jobsDir, "job-a", `{"model": {"url": "`+upstream1.URL+`"}}`)
+	writeJobInfo(t, jobsDir, "job-b", `{"model": {"url": "`+upstream2.URL+`"}}`)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+	proxy := NewLocalModelReverseProxy(cache, logger)
+
+	req1 := httptest.NewRequest(http.MethodPost, "/model/job-a/v1/chat", nil)
+	rw1 := httptest.NewRecorder()
+	proxy.ServeHTTP(rw1, req1)
+
+	req2 := httptest.NewRequest(http.MethodPost, "/model/job-b/v1/chat", nil)
+	rw2 := httptest.NewRecorder()
+	proxy.ServeHTTP(rw2, req2)
+
+	if rw1.Code != http.StatusOK || rw2.Code != http.StatusOK {
+		t.Fatalf("statuses = %d, %d; want 200, 200", rw1.Code, rw2.Code)
+	}
+	if len(receivedPaths) != 2 {
+		t.Fatalf("received %d requests, want 2", len(receivedPaths))
+	}
+	if !strings.HasPrefix(receivedPaths[0], "upstream1:") {
+		t.Errorf("first request went to %q, want upstream1", receivedPaths[0])
+	}
+	if !strings.HasPrefix(receivedPaths[1], "upstream2:") {
+		t.Errorf("second request went to %q, want upstream2", receivedPaths[1])
+	}
+}
+
+func TestLocalModelProxy_UsesPerJobCACert(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result": "tls-ok"}`))
+	}))
+	defer upstream.Close()
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: upstream.Certificate().Raw,
+	})
+
+	jobsDir := t.TempDir()
+	authDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(authDir, "ca_cert"), certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeJobInfo(t, jobsDir, "job-tls", `{
+		"model": {
+			"url": "`+upstream.URL+`",
+			"auth_secret_mount_path": "`+authDir+`"
+		}
+	}`)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+	p := NewLocalModelReverseProxy(cache, logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/model/job-tls/v1/models", nil)
+	rw := httptest.NewRecorder()
+	p.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200; body = %s (custom CA cert should allow HTTPS)", rw.Code, rw.Body.String())
+	}
+}
+
+func TestLocalModelProxy_HTTPSWithoutCACertFails(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	jobsDir := t.TempDir()
+	writeJobInfo(t, jobsDir, "job-no-ca", `{
+		"model": {"url": "`+upstream.URL+`"}
+	}`)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+	p := NewLocalModelReverseProxy(cache, logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/model/job-no-ca/v1/models", nil)
+	rw := httptest.NewRecorder()
+	p.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 (HTTPS without matching CA cert should fail)", rw.Code)
+	}
+}
+
+func TestLocalModelRoundTripper_PassesNormalRequests(t *testing.T) {
+	t.Parallel()
+
+	inner := &staticRoundTripper{status: http.StatusOK, body: "ok"}
+	rt := &localModelRoundTripper{inner: inner, logger: slog.Default()}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestLocalModelRoundTripper_Intercepts404ForUnknownJob(t *testing.T) {
+	t.Parallel()
+
+	inner := &staticRoundTripper{status: http.StatusOK, body: "should not reach"}
+	rt := &localModelRoundTripper{inner: inner, logger: slog.Default()}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set(xLocalModelError, "unknown job-id")
+	req.Header.Set(xLocalModelErrorJobID, "bad-job")
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var parsed map[string]string
+	if err := json.Unmarshal(body[:len(body)-1], &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (body=%q)", err, body)
+	}
+	if parsed["job_id"] != "bad-job" {
+		t.Errorf("job_id = %q, want bad-job", parsed["job_id"])
+	}
+}
+
+func TestLocalModelRoundTripper_Intercepts400ForInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	inner := &staticRoundTripper{status: http.StatusOK, body: "should not reach"}
+	rt := &localModelRoundTripper{inner: inner, logger: slog.Default()}
+
+	req := httptest.NewRequest(http.MethodGet, "/model/", nil)
+	req.Header.Set(xLocalModelError, "invalid model path")
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// staticRoundTripper is a test helper that returns a fixed response.
+type staticRoundTripper struct {
+	status int
+	body   string
+}
+
+func (s *staticRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: s.status,
+		Body:       io.NopCloser(strings.NewReader(s.body)),
+		Header:     make(http.Header),
+		Request:    req,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+	}, nil
+}
+
+// writeJobInfo is already defined in job_cache_test.go (same package).
+// Re-declaration is skipped here since both test files are in package proxy.
+// The helper creates jobsDir/<jobID>/sidecar-job-info.json with the given content.
+var _ = (*httputil.ReverseProxy)(nil) // keep httputil import for test readability

--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"fmt"
-	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -133,17 +132,9 @@ func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *s
 		reqLog.Info("Proxying model request", "method", pr.Out.Method, "url", pr.Out.URL.String())
 	}
 
-	rp.ModifyResponse = func(resp *http.Response) error {
-		if resp.Request != nil {
-			loggerForRequest(logger, resp.Request).Info("Response from model proxy", "method", resp.Request.Method, "url", resp.Request.URL.String(), "status", resp.StatusCode)
-		}
-		return nil
-	}
+	rp.ModifyResponse = proxyModifyResponse(logger, "Response from model proxy")
 
-	rp.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
-		loggerForRequest(logger, req).Error("Error proxying model request", "method", req.Method, "url", req.URL.String(), "error", err)
-		http.Error(w, err.Error(), http.StatusBadGateway)
-	}
+	rp.ErrorHandler = proxyErrorHandler(logger, "Error proxying model request")
 
 	return rp
 }
@@ -158,20 +149,9 @@ type modelRoundTripper struct {
 func (t *modelRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if errMsg := req.Header.Get(xModelAuthError); errMsg != "" {
 		req.Header.Del(xModelAuthError)
-		reqID := getOrCreateRequestID(req)
-		t.logger.Error("model credential resolution failed, returning 400", "request_id", reqID, "error", errMsg)
-		respHeader := make(http.Header)
-		respHeader.Set(globalTransactionIDHeader, reqID)
-		return &http.Response{
-			StatusCode: http.StatusBadRequest,
-			Status:     "400 Bad Request",
-			Body:       io.NopCloser(strings.NewReader(errMsg + "\n")),
-			Header:     respHeader,
-			Request:    req,
-			Proto:      "HTTP/1.1",
-			ProtoMajor: 1,
-			ProtoMinor: 1,
-		}, nil
+		t.logger.Error("model credential resolution failed, returning 400",
+			"request_id", getOrCreateRequestID(req), "error", errMsg)
+		return newSyntheticResponse(req, http.StatusBadRequest, strings.NewReader(errMsg+"\n")), nil
 	}
 	return t.inner.RoundTrip(req)
 }

--- a/internal/eval_runtime_sidecar/proxy/proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/proxy.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
@@ -84,6 +86,51 @@ func SetAuthHeader(req *http.Request, token string) {
 	req.Header.Set("Authorization", token)
 }
 
+// proxyModifyResponse returns a ModifyResponse callback that logs the upstream response.
+func proxyModifyResponse(logger *slog.Logger, msg string) func(*http.Response) error {
+	return func(resp *http.Response) error {
+		if resp.Request != nil {
+			l := loggerForRequest(logger, resp.Request)
+			attrs := []any{"method", resp.Request.Method, "url", resp.Request.URL.String(), "status", resp.StatusCode}
+			switch {
+			case resp.StatusCode >= 500:
+				l.Error(msg, attrs...)
+			case resp.StatusCode >= 400:
+				l.Warn(msg, attrs...)
+			default:
+				l.Info(msg, attrs...)
+			}
+		}
+		return nil
+	}
+}
+
+// proxyErrorHandler returns an ErrorHandler callback that logs and returns 502 Bad Gateway.
+func proxyErrorHandler(logger *slog.Logger, msg string) func(http.ResponseWriter, *http.Request, error) {
+	return func(w http.ResponseWriter, req *http.Request, err error) {
+		loggerForRequest(logger, req).Error(msg,
+			"method", req.Method, "url", req.URL.String(), "error", err)
+		http.Error(w, err.Error(), http.StatusBadGateway)
+	}
+}
+
+// newSyntheticResponse builds an *http.Response locally without forwarding to any upstream.
+// The response includes the request ID from X-Global-Transaction-Id (or a new UUID).
+func newSyntheticResponse(req *http.Request, statusCode int, body io.Reader) *http.Response {
+	header := make(http.Header)
+	header.Set(globalTransactionIDHeader, getOrCreateRequestID(req))
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Body:       io.NopCloser(body),
+		Header:     header,
+		Request:    req,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+	}
+}
+
 // NewReverseProxy returns an httputil.ReverseProxy that forwards to target using client.
 // Per-request auth is read from the request context (ContextWithAuthInput). Logger is used for request/response logging.
 // If modifyResponse is non-nil, it runs before the built-in response log (same contract as httputil.ReverseProxy.ModifyResponse).
@@ -109,22 +156,17 @@ func NewReverseProxy(target *url.URL, client *http.Client, logger *slog.Logger, 
 		reqLog.Info("Proxying request", "method", pr.Out.Method, "url", pr.Out.URL.String())
 	}
 
+	baseModify := proxyModifyResponse(logger, "Response from proxy")
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		if modifyResponse != nil {
 			if err := modifyResponse(resp); err != nil {
 				return err
 			}
 		}
-		if resp.Request != nil {
-			loggerForRequest(logger, resp.Request).Info("Response from proxy", "method", resp.Request.Method, "url", resp.Request.URL.String(), "status", resp.StatusCode)
-		}
-		return nil
+		return baseModify(resp)
 	}
 
-	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
-		loggerForRequest(logger, req).Error("Error proxying request", "method", req.Method, "url", req.URL.String(), "error", err)
-		http.Error(w, err.Error(), http.StatusBadGateway)
-	}
+	proxy.ErrorHandler = proxyErrorHandler(logger, "Error proxying request")
 
 	return proxy
 }

--- a/internal/eval_runtime_sidecar/server/server.go
+++ b/internal/eval_runtime_sidecar/server/server.go
@@ -14,10 +14,12 @@ import (
 )
 
 type SidecarServer struct {
-	httpServer *http.Server
-	port       int32
-	logger     *slog.Logger
-	config     *config.Config
+	httpServer  *http.Server
+	port        int32
+	logger      *slog.Logger
+	config      *config.Config
+	bgCtx       context.Context
+	bgCtxCancel context.CancelFunc
 }
 
 // NewSidecarServer creates a new sidecar HTTP server with the given logger and config.
@@ -36,11 +38,15 @@ func NewSidecarServer(logger *slog.Logger,
 		return nil, fmt.Errorf("sidecar config is required")
 	}
 
-	return &SidecarServer{
+	s := &SidecarServer{
 		port:   cfg.Sidecar.Port,
 		logger: logger,
 		config: cfg,
-	}, nil
+	}
+	if cfg.Sidecar.LocalMode {
+		s.bgCtx, s.bgCtxCancel = context.WithCancel(context.Background())
+	}
+	return s, nil
 }
 
 func (s *SidecarServer) isOTELEnabled() bool {
@@ -53,7 +59,7 @@ func (s *SidecarServer) GetPort() int {
 
 func (s *SidecarServer) setupRoutes() (http.Handler, error) {
 	router := http.NewServeMux()
-	h, err := handlers.New(s.config, s.logger)
+	h, err := handlers.New(s.bgCtx, s.config, s.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create handlers: %w", err)
 	}
@@ -115,6 +121,9 @@ func (s *SidecarServer) Start() error {
 
 func (s *SidecarServer) Shutdown(ctx context.Context) error {
 	s.logger.Info("Shutting down sidecar server gracefully...")
+	if s.bgCtxCancel != nil {
+		s.bgCtxCancel()
+	}
 	return s.httpServer.Shutdown(ctx)
 }
 


### PR DESCRIPTION

## What and why

Add local_mode to the sidecar config that skips MLflow/OCI proxy initialization, enables per-job model routing via a TTL cache of sidecar-job-info.json files, and drops SA token auth for eval-hub requests. Includes background cache sweep, per-job TLS/HTTP client construction, and config-driven tuning knobs.

Simplify handlers: make context a required parameter, collapse MLflow/OCI skip blocks, merge eval-hub auth returns, remove dead localModelProxy nil check, reuse shared.SidecarJobInfo and shared.SidecarJobInfoFileName, replace buildJobHTTPClient with existing buildTLSConfig/newHTTPClient helpers, upgrade JobInfoCache to sync.RWMutex for non-blocking cache hits.


Closes # part fix for https://redhat.atlassian.net/browse/RHOAIENG-81188

Assisted-by:  Claude

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes
No
<!-- If yes, describe migration path. Otherwise delete this section. -->
