### PR TITLE
feat(ci): bundle sidecar binary into Python server wheel

### DIFF
--- a/.github/workflows/ci-python-server.yml
+++ b/.github/workflows/ci-python-server.yml
@@ -7,6 +7,7 @@ on:
       - 'python-server/**'
       - 'config/**'
       - 'cmd/eval_hub/**'
+      - 'cmd/eval_runtime_sidecar/**'
       - 'internal/**'
       - 'pkg/**'
       - 'Makefile'
@@ -36,8 +37,10 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           python-version: '3.11'
-      - name: Build binary for this platform via cross-compile target
+      - name: Build server binary for this platform via cross-compile target
         run: make cross-compile
+      - name: Build sidecar binary for this platform via cross-compile target
+        run: make cross-compile-sidecar
       - name: Build wheel
         run: make build-wheel
       - name: Install wheel

--- a/.github/workflows/publish-python-server.yml
+++ b/.github/workflows/publish-python-server.yml
@@ -30,20 +30,25 @@ jobs:
           - goos: linux
             goarch: amd64
             output: bin/eval-hub-linux-amd64
+            sidecar-output: bin/eval-runtime-sidecar-linux-amd64
           - goos: linux
             goarch: arm64
             output: bin/eval-hub-linux-arm64
+            sidecar-output: bin/eval-runtime-sidecar-linux-arm64
           # macOS
           - goos: darwin
             goarch: amd64
             output: bin/eval-hub-darwin-amd64
+            sidecar-output: bin/eval-runtime-sidecar-darwin-amd64
           - goos: darwin
             goarch: arm64
             output: bin/eval-hub-darwin-arm64
+            sidecar-output: bin/eval-runtime-sidecar-darwin-arm64
           # Windows
           - goos: windows
             goarch: amd64
             output: bin/eval-hub-windows-amd64.exe
+            sidecar-output: bin/eval-runtime-sidecar-windows-amd64.exe
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -62,14 +67,19 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - name: Build binary
+      - name: Build server binary
         run: make cross-compile CROSS_GOOS=${{ matrix.goos }} CROSS_GOARCH=${{ matrix.goarch }}
 
-      - name: Upload binary
+      - name: Build sidecar binary
+        run: make cross-compile-sidecar CROSS_GOOS=${{ matrix.goos }} CROSS_GOARCH=${{ matrix.goarch }}
+
+      - name: Upload binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: ${{ matrix.output }}
+          path: |
+            ${{ matrix.output }}
+            ${{ matrix.sidecar-output }}
           retention-days: 7
 
   build-wheels:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-mcp build-all-platforms cross-compile-mcp build-all-platforms-mcp start-service stop-service start-sidecar stop-sidecar lint golangci-lint validate-configs test test-fuzz test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components docker-image-local docker-mcp-version test-mcp-build-all test-mcp-binary-info test-mcp-binary-naming test-mcp-version test-mcp-no-runtime-deps test-mcp-container-build test-mcp-container-http test-mcp-checksums test-mcp-formula-syntax test-mcp-native-smoke test-mcp-brew-install test-mcp-brew-test test-mcp-brew-uninstall test-mcp-cross-platform test-mcp-fvt test-mcp-e2e test-mcp test-mcp-vscode test-help clean-mcp-wheels build-mcp-wheel build-all-mcp-wheels show-local-api-docs doc-build
+.PHONY: help autoupdate-precommit pre-commit clean build build-coverage build-service build-init build-sidecar build-mcp build-all-platforms cross-compile-mcp build-all-platforms-mcp cross-compile-sidecar build-all-platforms-sidecar start-service stop-service start-sidecar stop-sidecar lint golangci-lint validate-configs test test-fuzz test-fvt-server test-all test-coverage test-fvt-coverage test-fvt-server-coverage test-all-coverage install-deps update-deps get-deps fmt vet generate-public-docs verify-api-docs generate-ignore-file documentation check-unused-components docker-image-local docker-mcp-version test-mcp-build-all test-mcp-binary-info test-mcp-binary-naming test-mcp-version test-mcp-no-runtime-deps test-mcp-container-build test-mcp-container-http test-mcp-checksums test-mcp-formula-syntax test-mcp-native-smoke test-mcp-brew-install test-mcp-brew-test test-mcp-brew-uninstall test-mcp-cross-platform test-mcp-fvt test-mcp-e2e test-mcp test-mcp-vscode test-help clean-mcp-wheels build-mcp-wheel build-all-mcp-wheels show-local-api-docs doc-build
 
 GOPATH := $(shell go env GOPATH)
 GOBIN := $(shell go env GOPATH)/bin
@@ -337,6 +337,23 @@ build-mcp-platform-%:
 build-all-platforms-mcp: ## Build MCP for all supported platforms (parallel: make -j5 build-all-platforms-mcp)
 	@$(MAKE) -j5 $(addprefix build-mcp-platform-,$(SUPPORTED_PLATFORMS))
 
+# Sidecar cross-compilation
+SIDECAR_CROSS_OUTPUT = bin/eval-runtime-sidecar-$(CROSS_GOOS)-$(CROSS_GOARCH)$(if $(filter windows,$(CROSS_GOOS)),.exe,)
+
+.PHONY: cross-compile-sidecar
+cross-compile-sidecar: ## Build sidecar for specific platform: make cross-compile-sidecar CROSS_GOOS=linux CROSS_GOARCH=amd64
+	@echo "Cross-compiling sidecar for $(CROSS_GOOS)/$(CROSS_GOARCH)..."
+	@mkdir -p $(BIN_DIR)
+	GOOS=$(CROSS_GOOS) GOARCH=$(CROSS_GOARCH) CGO_ENABLED=0 go build -o $(SIDECAR_CROSS_OUTPUT) -ldflags="-s -w ${LDFLAGS_X}" $(SIDECAR_CMD_PATH)
+	@echo "Built: $(SIDECAR_CROSS_OUTPUT)"
+
+build-sidecar-platform-%:
+	@$(MAKE) cross-compile-sidecar CROSS_GOOS=$(word 1,$(subst -, ,$*)) CROSS_GOARCH=$(word 2,$(subst -, ,$*))
+
+.PHONY: build-all-platforms-sidecar
+build-all-platforms-sidecar: ## Build sidecar for all supported platforms (parallel: make -j5 build-all-platforms-sidecar)
+	@$(MAKE) -j5 $(addprefix build-sidecar-platform-,$(SUPPORTED_PLATFORMS))
+
 # Python virtual environment - expects uv venv
 VENV_DIR = .venv
 VENV_PYTHON = $(VENV_DIR)/bin/python
@@ -363,6 +380,7 @@ install-wheel-tools: venv ## Install Python wheel build tools using uv
 WHEEL_BUILD_DIR = python-server/build-$(CROSS_GOOS)-$(CROSS_GOARCH)
 
 WHEEL_BINARY_NAME = eval-hub$(if $(filter windows,$(CROSS_GOOS)),.exe,)
+SIDECAR_WHEEL_BINARY_NAME = eval-runtime-sidecar$(if $(filter windows,$(CROSS_GOOS)),.exe,)
 
 .PHONY: clean-wheels
 clean-wheels: ## Clean Python wheel build artifacts
@@ -389,6 +407,10 @@ build-wheel: ## Build Python wheel: make build-wheel WHEEL_PLATFORM=manylinux_2_
 	@echo "Staging binary $(CROSS_OUTPUT) as $(WHEEL_BINARY_NAME)"
 	@cp $(CROSS_OUTPUT) $(WHEEL_BUILD_DIR)/binaries/$(WHEEL_BINARY_NAME)
 	@chmod +x $(WHEEL_BUILD_DIR)/binaries/$(WHEEL_BINARY_NAME)
+	@test -f $(SIDECAR_CROSS_OUTPUT) || $(MAKE) cross-compile-sidecar
+	@echo "Staging sidecar binary $(SIDECAR_CROSS_OUTPUT) as $(SIDECAR_WHEEL_BINARY_NAME)"
+	@cp $(SIDECAR_CROSS_OUTPUT) $(WHEEL_BUILD_DIR)/binaries/$(SIDECAR_WHEEL_BINARY_NAME)
+	@chmod +x $(WHEEL_BUILD_DIR)/binaries/$(SIDECAR_WHEEL_BINARY_NAME)
 	@echo "Building wheel for $(WHEEL_PLATFORM)..."
 	WHEEL_PLATFORM=$(WHEEL_PLATFORM) uv build --wheel $(WHEEL_BUILD_DIR) --out-dir python-server/dist
 	@rm -rf $(WHEEL_BUILD_DIR)

--- a/scripts/gha_wheel_sanity_test.sh
+++ b/scripts/gha_wheel_sanity_test.sh
@@ -25,6 +25,13 @@ else
     mkdir -p /tmp
 fi
 
+echo "Checking sidecar binary is available..."
+if ! command -v eval-runtime-sidecar >/dev/null 2>&1; then
+    echo "FAIL: eval-runtime-sidecar not found on PATH"
+    exit 1
+fi
+echo "eval-runtime-sidecar found: $(command -v eval-runtime-sidecar)"
+
 echo "Starting: ${BINARY} -configdir ${CONFIG_DIR} -local"
 "${BINARY}" -configdir "${CONFIG_DIR}" -local > "${LOGFILE}" 2>&1 &
 SERVER_PID=$!

--- a/scripts/gha_wheel_sanity_test.sh
+++ b/scripts/gha_wheel_sanity_test.sh
@@ -30,7 +30,17 @@ if ! command -v eval-runtime-sidecar >/dev/null 2>&1; then
     echo "FAIL: eval-runtime-sidecar not found on PATH"
     exit 1
 fi
-echo "eval-runtime-sidecar found: $(command -v eval-runtime-sidecar)"
+SIDECAR_PATH="$(command -v eval-runtime-sidecar)"
+if [[ -n "${WINDIR:-}" ]]; then
+    VENV_BIN="${VIRTUAL_ENV:-}/Scripts"
+else
+    VENV_BIN="${VIRTUAL_ENV:-}/bin"
+fi
+if [[ "$SIDECAR_PATH" != "$VENV_BIN/"* ]]; then
+    echo "FAIL: eval-runtime-sidecar not found on PATH"
+    exit 1
+fi
+echo "eval-runtime-sidecar found: ${SIDECAR_PATH}"
 
 echo "Starting: ${BINARY} -configdir ${CONFIG_DIR} -local"
 "${BINARY}" -configdir "${CONFIG_DIR}" -local > "${LOGFILE}" 2>&1 &


### PR DESCRIPTION
## What and why
The eval-hub-server whl now includes both `eval-runtime-sidecar` as well as `eval-hub` Go binary.

Add cross-compilation targets for the eval-runtime-sidecar binary and include it alongside the server binary in CI builds and Python wheel packaging. The sanity test script now verifies the sidecar is accessible on PATH after wheel installation.

Generated with: Claude Code


Closes # Part delivery for https://redhat.atlassian.net/browse/RHOAIENG-81188

Assisted-by: Claude

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually
<img width="769" height="928" alt="Screenshot 2026-08-17 at 2 44 58 PM" src="https://github.com/user-attachments/assets/409d9ecc-d355-4148-b894-1074cc98dbf5" />



## Breaking changes
No
<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime sidecar binaries to Python wheel builds across supported platforms.
  * Added cross-platform sidecar build targets for individual platforms and all platforms.
  * Published sidecar binaries alongside the main server artifacts.

* **Bug Fixes**
  * Wheel sanity checks now confirm the runtime sidecar is available on `PATH` and installed in the active environment’s platform-specific binary directory.
  * Sanity checks report the resolved sidecar location and flag incorrect installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->