### PR TITLE
test: add FVT for metrics_schema

### DIFF
--- a/internal/eval_hub/storage/sql/evaluations_test.go
+++ b/internal/eval_hub/storage/sql/evaluations_test.go
@@ -908,6 +908,81 @@ func testEvaluationsStorage(t *testing.T, driver string, databaseName string) {
 		}
 	})
 
+	t.Run("UpdateEvaluationJob persists metrics_schema and backfills numeric defaults on read", func(t *testing.T) {
+		jobID := common.GUID()
+		now := time.Now()
+		job := &api.EvaluationJobResource{
+			Resource: api.EvaluationResource{
+				Resource: api.Resource{
+					ID:        jobID,
+					Tenant:    api.Tenant(tenant),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				MLFlowExperimentID: "experiment-1",
+			},
+			Status: &api.EvaluationJobStatus{
+				EvaluationJobState: api.EvaluationJobState{
+					State: api.OverallStateRunning,
+					Message: &api.MessageInfo{
+						Message:     "Job is running",
+						MessageCode: "JOB_RUNNING",
+					},
+				},
+			},
+			EvaluationJobConfig: api.EvaluationJobConfig{
+				Model:      &api.ModelRef{URL: "http://test.com", Name: "test"},
+				Benchmarks: []api.EvaluationBenchmarkConfig{benchmarkConfig},
+			},
+		}
+		if err := store.CreateEvaluationJob(job); err != nil {
+			t.Fatalf("CreateEvaluationJob: %v", err)
+		}
+
+		explicitSchema := []api.MetricSchema{
+			{Name: "labels", Type: api.ResultTypeArrayUnordered},
+		}
+		status := &api.StatusEvent{
+			BenchmarkStatusEvent: &api.BenchmarkStatusEvent{
+				ID:             benchmarkConfig.ID,
+				ProviderID:     benchmarkConfig.ProviderID,
+				BenchmarkIndex: 0,
+				Status:         api.StateCompleted,
+				Metrics: map[string]any{
+					"acc":    0.85,
+					"labels": []string{"A", "B"},
+				},
+				MetricsSchema: explicitSchema,
+			},
+		}
+		status.BenchmarkStatusEvent.StampRuntimeMessageOrigins()
+		if err := store.UpdateEvaluationJob(jobID, status); err != nil {
+			t.Fatalf("UpdateEvaluationJob: %v", err)
+		}
+
+		got, err := store.GetEvaluationJob(jobID)
+		if err != nil {
+			t.Fatalf("GetEvaluationJob: %v", err)
+		}
+		if len(got.Results.Benchmarks) != 1 {
+			t.Fatalf("benchmark results len = %d, want 1", len(got.Results.Benchmarks))
+		}
+		schema := got.Results.Benchmarks[0].MetricsSchema
+		if len(schema) != 2 {
+			t.Fatalf("metrics_schema len = %d, want 2 after backfill", len(schema))
+		}
+		byName := make(map[string]api.ResultType, len(schema))
+		for _, entry := range schema {
+			byName[entry.Name] = entry.Type
+		}
+		if byName["labels"] != api.ResultTypeArrayUnordered {
+			t.Fatalf("labels type = %q, want array_unordered", byName["labels"])
+		}
+		if byName["acc"] != api.ResultTypeNumeric {
+			t.Fatalf("acc type = %q, want numeric backfill", byName["acc"])
+		}
+	})
+
 	t.Run("UpdateEvaluationJob persists endpoint HTTP error detail without truncation", func(t *testing.T) {
 		jobID := common.GUID()
 		now := time.Now()

--- a/pkg/cards/from_job_test.go
+++ b/pkg/cards/from_job_test.go
@@ -7,6 +7,62 @@ import (
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
+func TestNewEvaluationCardPropagatesMetricsSchema(t *testing.T) {
+	job := &api.EvaluationJobResource{
+		Resource: api.EvaluationResource{
+			Resource: api.Resource{ID: "job-metrics-schema"},
+		},
+		EvaluationJobConfig: api.EvaluationJobConfig{
+			Model: &api.ModelRef{URL: "https://vllm.example.com/v1", Name: "model"},
+			Benchmarks: []api.EvaluationBenchmarkConfig{
+				{Ref: api.Ref{ID: "arc_easy"}, ProviderID: "lm_evaluation_harness"},
+			},
+		},
+		Status: &api.EvaluationJobStatus{
+			EvaluationJobState: api.EvaluationJobState{
+				State: api.OverallStateCompleted,
+				Message: &api.MessageInfo{
+					Message:     "Evaluation job is completed",
+					MessageCode: "evaluation.job.updated",
+				},
+			},
+			Benchmarks: []api.BenchmarkStatus{
+				{
+					ID:             "arc_easy",
+					ProviderID:     "lm_evaluation_harness",
+					BenchmarkIndex: 0,
+					Status:         api.StateCompleted,
+				},
+			},
+		},
+		Results: &api.EvaluationJobResults{
+			Benchmarks: []api.BenchmarkResult{
+				{
+					ID:             "arc_easy",
+					ProviderID:     "lm_evaluation_harness",
+					BenchmarkIndex: 0,
+					Metrics:        map[string]any{"acc": 0.9},
+					MetricsSchema: []api.MetricSchema{
+						{Name: "acc", Type: api.ResultTypeNumeric},
+					},
+				},
+			},
+		},
+	}
+
+	card := NewEvaluationCard(job)
+	if card == nil || card.Results == nil || len(card.Results.Benchmarks) != 1 {
+		t.Fatalf("card results = %#v", card)
+	}
+	got := card.Results.Benchmarks[0]
+	if len(got.MetricsSchema) != 1 {
+		t.Fatalf("metrics_schema len = %d, want 1", len(got.MetricsSchema))
+	}
+	if got.MetricsSchema[0].Name != "acc" || got.MetricsSchema[0].Type != api.ResultTypeNumeric {
+		t.Fatalf("metrics_schema = %#v", got.MetricsSchema)
+	}
+}
+
 func TestNewEvaluationCardFromDirectBenchmarkJob(t *testing.T) {
 	threshold := float32(0.3)
 	job := &api.EvaluationJobResource{

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -48,6 +48,11 @@ Feature: Evaluation Jobs
     And the response should contain the value "lm_evaluation_harness" at path "$.results.benchmarks[0].provider_id"
     And the response should contain at least the value "0.2" at path "$.results.benchmarks[0].metrics.acc"
     And the response should contain at least the value "0.4" at path "$.results.benchmarks[0].metrics.acc_norm"
+    And the array at path "$.results.benchmarks[0].metrics_schema" in the response should have length at least 2
+    And the response should contain the value "acc" at path "$.results.benchmarks[0].metrics_schema[?(@.name == &quot;acc&quot;)].name"
+    And the response should contain the value "numeric" at path "$.results.benchmarks[0].metrics_schema[?(@.name == &quot;acc&quot;)].type"
+    And the response should contain the value "acc_norm" at path "$.results.benchmarks[0].metrics_schema[?(@.name == &quot;acc_norm&quot;)].name"
+    And the response should contain the value "numeric" at path "$.results.benchmarks[0].metrics_schema[?(@.name == &quot;acc_norm&quot;)].type"
     And the response should contain the value "{{env:MODEL_NAME|test}}" at path "$.model.name"
     And the response should contain the value "{{env:MODEL_URL|http://test.com}}" at path "$.model.url"
     And the response should contain the value "test-evaluation-job" at path "$.name"
@@ -120,6 +125,12 @@ Feature: Evaluation Jobs
     And the response should contain at least the value "0.4" at path "$.results.benchmarks[0].metrics.acc_norm"
     And the response should contain at least the value "0.2" at path "$.results.benchmarks[1].metrics.acc"
     And the response should contain at least the value "0.4" at path "$.results.benchmarks[1].metrics.acc_norm"
+    And the array at path "$.results.benchmarks[0].metrics_schema" in the response should have length at least 2
+    And the response should contain the value "numeric" at path "$.results.benchmarks[0].metrics_schema[?(@.name == &quot;acc&quot;)].type"
+    And the response should contain the value "numeric" at path "$.results.benchmarks[0].metrics_schema[?(@.name == &quot;acc_norm&quot;)].type"
+    And the array at path "$.results.benchmarks[1].metrics_schema" in the response should have length at least 2
+    And the response should contain the value "numeric" at path "$.results.benchmarks[1].metrics_schema[?(@.name == &quot;acc&quot;)].type"
+    And the response should contain the value "numeric" at path "$.results.benchmarks[1].metrics_schema[?(@.name == &quot;acc_norm&quot;)].type"
     And the response should contain the value "arc_easy" at path "$.benchmarks[0].id"
     And the response should contain the value "5" at path "$.benchmarks[0].parameters.num_examples"
     And the response should contain the value "arc_easy" at path "$.benchmarks[1].id"


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->
https://redhat.atlassian.net/browse/RHAISTRAT-1918
Closes # 

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Evaluation results now consistently retain benchmark metric schemas, including metric names and numeric types.
  * Single- and multi-benchmark evaluation jobs expose complete numeric metric information, including accuracy metrics.
  * Numeric metrics not explicitly defined in a schema are correctly recognized when results are retrieved.

* **Tests**
  * Added coverage for metric schema persistence across job updates and evaluation card generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->