### PR TITLE
fix(sidecar,eval-hub): local mode require file:/// URI scheme for auth secret_ref and return 400

### DIFF
--- a/internal/eval_hub/messages/messages.go
+++ b/internal/eval_hub/messages/messages.go
@@ -274,10 +274,10 @@ var (
 		"hardware_profile_invalid",
 	)
 
-	// InvalidSecretRefURI The model.auth.secret_ref '{{.SecretRef}}' must use the file:/// URI scheme in local mode.
+	// InvalidSecretRefURI The model.auth.secret_ref '{{.SecretRef}}' must use the file:///path form in local mode.
 	InvalidSecretRefURI = createMessage(
 		constants.HTTPCodeBadRequest,
-		"The model.auth.secret_ref '{{.SecretRef}}' must use the file:/// URI scheme in local mode.",
+		"The model.auth.secret_ref '{{.SecretRef}}' must use the file:///path form (e.g. file:///home/user/secret) in local mode.",
 		"invalid_secret_ref_uri",
 	)
 

--- a/internal/eval_hub/messages/messages.go
+++ b/internal/eval_hub/messages/messages.go
@@ -274,6 +274,13 @@ var (
 		"hardware_profile_invalid",
 	)
 
+	// InvalidSecretRefURI The model.auth.secret_ref '{{.SecretRef}}' must use the file:/// URI scheme in local mode.
+	InvalidSecretRefURI = createMessage(
+		constants.HTTPCodeBadRequest,
+		"The model.auth.secret_ref '{{.SecretRef}}' must use the file:/// URI scheme in local mode.",
+		"invalid_secret_ref_uri",
+	)
+
 	// ResolvedSHAReadOnly The field 'resolved_sha' is read-only and must not be set on create.
 	ResolvedSHAReadOnly = createMessage(
 		constants.HTTPCodeBadRequest,

--- a/internal/eval_hub/messages/messages.go
+++ b/internal/eval_hub/messages/messages.go
@@ -274,6 +274,13 @@ var (
 		"hardware_profile_invalid",
 	)
 
+	// InvalidSecretRefURIParse The model.auth.secret_ref '{{.SecretRef}}' is not a valid URI: {{.Detail}}.
+	InvalidSecretRefURIParse = createMessage(
+		constants.HTTPCodeBadRequest,
+		"The model.auth.secret_ref '{{.SecretRef}}' is not a valid URI: {{.Detail}}.",
+		"invalid_secret_ref_uri_parse",
+	)
+
 	// InvalidSecretRefURI The model.auth.secret_ref '{{.SecretRef}}' must use the file:///path form in local mode.
 	InvalidSecretRefURI = createMessage(
 		constants.HTTPCodeBadRequest,

--- a/internal/eval_hub/runtimes/k8s/job_config.go
+++ b/internal/eval_hub/runtimes/k8s/job_config.go
@@ -129,10 +129,6 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 	if err != nil {
 		return nil, err
 	}
-	if spec.Model != nil {
-		spec.Model.URL = strings.TrimSpace(spec.Model.URL)
-	}
-
 	// Get EvalHub instance name from environment (set by operator in deployment)
 	evalHubInstanceName := strings.TrimSpace(os.Getenv(evalHubInstanceNameEnv))
 

--- a/internal/eval_hub/runtimes/local/local_runtime.go
+++ b/internal/eval_hub/runtimes/local/local_runtime.go
@@ -171,7 +171,8 @@ func (r *LocalRuntime) RunEvaluationJob(
 	if r.sidecarEnabled() {
 		if evaluation.Model != nil && evaluation.Model.Auth != nil && evaluation.Model.Auth.SecretRef != "" {
 			parsed, err := url.Parse(evaluation.Model.Auth.SecretRef)
-			if err != nil || parsed.Scheme != "file" || parsed.Host != "" {
+			if err != nil || parsed.Scheme != "file" || parsed.Host != "" ||
+				!strings.HasPrefix(evaluation.Model.Auth.SecretRef, "file:///") {
 				return serviceerrors.NewServiceError(messages.InvalidSecretRefURI, "SecretRef", evaluation.Model.Auth.SecretRef)
 			}
 		}

--- a/internal/eval_hub/runtimes/local/local_runtime.go
+++ b/internal/eval_hub/runtimes/local/local_runtime.go
@@ -172,7 +172,8 @@ func (r *LocalRuntime) RunEvaluationJob(
 		if evaluation.Model != nil && evaluation.Model.Auth != nil && evaluation.Model.Auth.SecretRef != "" {
 			parsed, err := url.Parse(evaluation.Model.Auth.SecretRef)
 			if err != nil {
-				return fmt.Errorf("invalid secret_ref URI %q: %w", evaluation.Model.Auth.SecretRef, err)
+				return serviceerrors.NewServiceError(messages.InvalidSecretRefURIParse,
+					"SecretRef", evaluation.Model.Auth.SecretRef, "Detail", err.Error())
 			}
 			// Only the file:/// form (empty authority, non-empty path) is accepted.
 			if parsed.Scheme != "file" || parsed.Host != "" || parsed.Opaque != "" || parsed.Path == "" || parsed.OmitHost {

--- a/internal/eval_hub/runtimes/local/local_runtime.go
+++ b/internal/eval_hub/runtimes/local/local_runtime.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -169,7 +170,8 @@ func (r *LocalRuntime) RunEvaluationJob(
 	callbackURL := r.callbackURL
 	if r.sidecarEnabled() {
 		if evaluation.Model != nil && evaluation.Model.Auth != nil && evaluation.Model.Auth.SecretRef != "" {
-			if !strings.HasPrefix(evaluation.Model.Auth.SecretRef, "file:///") {
+			parsed, err := url.Parse(evaluation.Model.Auth.SecretRef)
+			if err != nil || parsed.Scheme != "file" || parsed.Host != "" {
 				return serviceerrors.NewServiceError(messages.InvalidSecretRefURI, "SecretRef", evaluation.Model.Auth.SecretRef)
 			}
 		}

--- a/internal/eval_hub/runtimes/local/local_runtime.go
+++ b/internal/eval_hub/runtimes/local/local_runtime.go
@@ -168,6 +168,11 @@ func (r *LocalRuntime) RunEvaluationJob(
 
 	callbackURL := r.callbackURL
 	if r.sidecarEnabled() {
+		if evaluation.Model != nil && evaluation.Model.Auth != nil && evaluation.Model.Auth.SecretRef != "" {
+			if !strings.HasPrefix(evaluation.Model.Auth.SecretRef, "file:///") {
+				return serviceerrors.NewServiceError(messages.InvalidSecretRefURI, "SecretRef", evaluation.Model.Auth.SecretRef)
+			}
+		}
 		if err := r.writeSidecarJobInfo(evaluation); err != nil {
 			return fmt.Errorf("write sidecar job info: %w", err)
 		}
@@ -224,9 +229,6 @@ func (r *LocalRuntime) runBenchmark(
 		return fmt.Errorf("build job spec: %w", err)
 	}
 
-	if spec.Model != nil {
-		spec.Model.URL = strings.TrimSpace(spec.Model.URL)
-	}
 	if r.sidecarEnabled() && spec.Model != nil && spec.Model.URL != "" {
 		modelCopy := *spec.Model
 		rewrittenURL, err := shared.RewriteModelURLForLocalSidecar(r.sidecarBaseURL, jobID, modelCopy.URL)

--- a/internal/eval_hub/runtimes/local/local_runtime.go
+++ b/internal/eval_hub/runtimes/local/local_runtime.go
@@ -171,8 +171,11 @@ func (r *LocalRuntime) RunEvaluationJob(
 	if r.sidecarEnabled() {
 		if evaluation.Model != nil && evaluation.Model.Auth != nil && evaluation.Model.Auth.SecretRef != "" {
 			parsed, err := url.Parse(evaluation.Model.Auth.SecretRef)
-			if err != nil || parsed.Scheme != "file" || parsed.Host != "" ||
-				!strings.HasPrefix(evaluation.Model.Auth.SecretRef, "file:///") {
+			if err != nil {
+				return fmt.Errorf("invalid secret_ref URI %q: %w", evaluation.Model.Auth.SecretRef, err)
+			}
+			// Only the file:/// form (empty authority, non-empty path) is accepted.
+			if parsed.Scheme != "file" || parsed.Host != "" || parsed.Opaque != "" || parsed.Path == "" || parsed.OmitHost {
 				return serviceerrors.NewServiceError(messages.InvalidSecretRefURI, "SecretRef", evaluation.Model.Auth.SecretRef)
 			}
 		}

--- a/internal/eval_hub/runtimes/local/local_runtime_test.go
+++ b/internal/eval_hub/runtimes/local/local_runtime_test.go
@@ -1203,6 +1203,82 @@ func TestRunEvaluationJobSidecarRejectsFileURIWithAuthority(t *testing.T) {
 	}
 }
 
+func TestRunEvaluationJobSidecarRejectsFileSingleSlash(t *testing.T) {
+	providerID := "provider-1"
+	evaluation := sampleEvaluation(providerID)
+	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "file:/tmp/key"}
+
+	providers := sampleLocalProviders(providerID, "true")
+	cleanupDir(t, "job-1")
+
+	cfg := &config.Config{
+		Service: &config.ServiceConfig{Port: 8080},
+		Sidecar: &config.SidecarConfig{LocalMode: true, BaseURL: "http://localhost:8082"},
+	}
+	rt, err := NewLocalRuntime(discardLogger(), cfg)
+	if err != nil {
+		t.Fatalf("NewLocalRuntime failed: %v", err)
+	}
+	rt = rt.WithContext(testContext(t))
+
+	storage := &fakeStorage{providerConfigs: providers}
+
+	benchmarks, err := handlers.GetJobBenchmarks(evaluation, nil)
+	if err != nil {
+		t.Fatalf("failed to resolve benchmarks: %v", err)
+	}
+
+	err = rt.RunEvaluationJob(evaluation, benchmarks, storage)
+	if err == nil {
+		t.Fatal("expected error for file:/path (missing authority), got nil")
+	}
+	svcErr, ok := err.(abstractions.ServiceError)
+	if !ok {
+		t.Fatalf("expected ServiceError, got %T: %v", err, err)
+	}
+	if svcErr.MessageCode() != messages.InvalidSecretRefURI {
+		t.Fatalf("expected message code %q, got %q", messages.InvalidSecretRefURI.GetCode(), svcErr.MessageCode().GetCode())
+	}
+}
+
+func TestRunEvaluationJobSidecarRejectsFileOpaqueRelative(t *testing.T) {
+	providerID := "provider-1"
+	evaluation := sampleEvaluation(providerID)
+	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "file:tmp/key"}
+
+	providers := sampleLocalProviders(providerID, "true")
+	cleanupDir(t, "job-1")
+
+	cfg := &config.Config{
+		Service: &config.ServiceConfig{Port: 8080},
+		Sidecar: &config.SidecarConfig{LocalMode: true, BaseURL: "http://localhost:8082"},
+	}
+	rt, err := NewLocalRuntime(discardLogger(), cfg)
+	if err != nil {
+		t.Fatalf("NewLocalRuntime failed: %v", err)
+	}
+	rt = rt.WithContext(testContext(t))
+
+	storage := &fakeStorage{providerConfigs: providers}
+
+	benchmarks, err := handlers.GetJobBenchmarks(evaluation, nil)
+	if err != nil {
+		t.Fatalf("failed to resolve benchmarks: %v", err)
+	}
+
+	err = rt.RunEvaluationJob(evaluation, benchmarks, storage)
+	if err == nil {
+		t.Fatal("expected error for file:relative/path (opaque URI), got nil")
+	}
+	svcErr, ok := err.(abstractions.ServiceError)
+	if !ok {
+		t.Fatalf("expected ServiceError, got %T: %v", err, err)
+	}
+	if svcErr.MessageCode() != messages.InvalidSecretRefURI {
+		t.Fatalf("expected message code %q, got %q", messages.InvalidSecretRefURI.GetCode(), svcErr.MessageCode().GetCode())
+	}
+}
+
 func TestRunEvaluationJobWithoutSidecarNoRewrite(t *testing.T) {
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)

--- a/internal/eval_hub/runtimes/local/local_runtime_test.go
+++ b/internal/eval_hub/runtimes/local/local_runtime_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/eval-hub/eval-hub/internal/eval_hub/abstractions"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/handlers"
+	"github.com/eval-hub/eval-hub/internal/eval_hub/messages"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/runtimes/shared"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
@@ -933,7 +934,7 @@ func runSidecarEvalJob(t *testing.T) string {
 	t.Helper()
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)
-	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "/home/user1/model-auth"}
+	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "file:///home/user1/model-auth"}
 	dirName := localJobDir("job-1", 0, providerID, "bench-1")
 	sentinelPath := filepath.Join(dirName, "done")
 	providers := sampleLocalProviders(providerID, fmt.Sprintf("touch %s", sentinelPath))
@@ -982,8 +983,8 @@ func TestRunEvaluationJobWithSidecarWritesSidecarJobInfo(t *testing.T) {
 	if info.Model.URL != "http://model.example" {
 		t.Fatalf("expected model URL %q, got %q", "http://model.example", info.Model.URL)
 	}
-	if info.Model.AuthSecretMountPath != "/home/user1/model-auth" {
-		t.Fatalf("expected auth path %q, got %q", "/home/user1/model-auth", info.Model.AuthSecretMountPath)
+	if info.Model.AuthSecretMountPath != "file:///home/user1/model-auth" {
+		t.Fatalf("expected auth path %q, got %q", "file:///home/user1/model-auth", info.Model.AuthSecretMountPath)
 	}
 	if info.Model.HTTPTimeout != shared.DefaultModelHTTPTimeout {
 		t.Fatalf("expected timeout %v, got %v", shared.DefaultModelHTTPTimeout, info.Model.HTTPTimeout)
@@ -1020,15 +1021,15 @@ func TestRunEvaluationJobWithSidecarRewritesJobSpec(t *testing.T) {
 	if spec.Model.Auth == nil {
 		t.Fatal("expected model auth to be set, got nil")
 	}
-	if spec.Model.Auth.SecretRef != "/home/user1/model-auth" {
-		t.Fatalf("expected auth secret_ref %q, got %q", "/home/user1/model-auth", spec.Model.Auth.SecretRef)
+	if spec.Model.Auth.SecretRef != "file:///home/user1/model-auth" {
+		t.Fatalf("expected auth secret_ref %q, got %q", "file:///home/user1/model-auth", spec.Model.Auth.SecretRef)
 	}
 }
 
 func TestRunEvaluationJobWithSidecarModelDefaults(t *testing.T) {
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)
-	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "/home/user1/model-auth"}
+	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "file:///home/user1/model-auth"}
 	dirName := localJobDir("job-1", 0, providerID, "bench-1")
 	sentinelPath := filepath.Join(dirName, "done")
 	providers := sampleLocalProviders(providerID, fmt.Sprintf("touch %s", sentinelPath))
@@ -1123,6 +1124,44 @@ func TestRunEvaluationJobSidecarRewriteError(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for failed benchmark status update")
+	}
+}
+
+func TestRunEvaluationJobSidecarRejectsRawSecretRefPath(t *testing.T) {
+	providerID := "provider-1"
+	evaluation := sampleEvaluation(providerID)
+	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "/home/user1/model-auth"}
+
+	providers := sampleLocalProviders(providerID, "true")
+	cleanupDir(t, "job-1")
+
+	cfg := &config.Config{
+		Service: &config.ServiceConfig{Port: 8080},
+		Sidecar: &config.SidecarConfig{LocalMode: true, BaseURL: "http://localhost:8082"},
+	}
+	rt, err := NewLocalRuntime(discardLogger(), cfg)
+	if err != nil {
+		t.Fatalf("NewLocalRuntime failed: %v", err)
+	}
+	rt = rt.WithContext(testContext(t))
+
+	storage := &fakeStorage{providerConfigs: providers}
+
+	benchmarks, err := handlers.GetJobBenchmarks(evaluation, nil)
+	if err != nil {
+		t.Fatalf("failed to resolve benchmarks: %v", err)
+	}
+
+	err = rt.RunEvaluationJob(evaluation, benchmarks, storage)
+	if err == nil {
+		t.Fatal("expected error for secret_ref without file:/// prefix, got nil")
+	}
+	svcErr, ok := err.(abstractions.ServiceError)
+	if !ok {
+		t.Fatalf("expected ServiceError, got %T: %v", err, err)
+	}
+	if svcErr.MessageCode() != messages.InvalidSecretRefURI {
+		t.Fatalf("expected message code %q, got %q", messages.InvalidSecretRefURI.GetCode(), svcErr.MessageCode().GetCode())
 	}
 }
 

--- a/internal/eval_hub/runtimes/local/local_runtime_test.go
+++ b/internal/eval_hub/runtimes/local/local_runtime_test.go
@@ -1165,6 +1165,44 @@ func TestRunEvaluationJobSidecarRejectsRawSecretRefPath(t *testing.T) {
 	}
 }
 
+func TestRunEvaluationJobSidecarRejectsFileURIWithAuthority(t *testing.T) {
+	providerID := "provider-1"
+	evaluation := sampleEvaluation(providerID)
+	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "file://host/path"}
+
+	providers := sampleLocalProviders(providerID, "true")
+	cleanupDir(t, "job-1")
+
+	cfg := &config.Config{
+		Service: &config.ServiceConfig{Port: 8080},
+		Sidecar: &config.SidecarConfig{LocalMode: true, BaseURL: "http://localhost:8082"},
+	}
+	rt, err := NewLocalRuntime(discardLogger(), cfg)
+	if err != nil {
+		t.Fatalf("NewLocalRuntime failed: %v", err)
+	}
+	rt = rt.WithContext(testContext(t))
+
+	storage := &fakeStorage{providerConfigs: providers}
+
+	benchmarks, err := handlers.GetJobBenchmarks(evaluation, nil)
+	if err != nil {
+		t.Fatalf("failed to resolve benchmarks: %v", err)
+	}
+
+	err = rt.RunEvaluationJob(evaluation, benchmarks, storage)
+	if err == nil {
+		t.Fatal("expected error for file:// URI with authority component, got nil")
+	}
+	svcErr, ok := err.(abstractions.ServiceError)
+	if !ok {
+		t.Fatalf("expected ServiceError, got %T: %v", err, err)
+	}
+	if svcErr.MessageCode() != messages.InvalidSecretRefURI {
+		t.Fatalf("expected message code %q, got %q", messages.InvalidSecretRefURI.GetCode(), svcErr.MessageCode().GetCode())
+	}
+}
+
 func TestRunEvaluationJobWithoutSidecarNoRewrite(t *testing.T) {
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)

--- a/internal/eval_hub/runtimes/local/local_runtime_test.go
+++ b/internal/eval_hub/runtimes/local/local_runtime_test.go
@@ -1127,155 +1127,56 @@ func TestRunEvaluationJobSidecarRewriteError(t *testing.T) {
 	}
 }
 
-func TestRunEvaluationJobSidecarRejectsRawSecretRefPath(t *testing.T) {
-	providerID := "provider-1"
-	evaluation := sampleEvaluation(providerID)
-	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "/home/user1/model-auth"}
-
-	providers := sampleLocalProviders(providerID, "true")
-	cleanupDir(t, "job-1")
-
-	cfg := &config.Config{
-		Service: &config.ServiceConfig{Port: 8080},
-		Sidecar: &config.SidecarConfig{LocalMode: true, BaseURL: "http://localhost:8082"},
+func TestRunEvaluationJobSidecarRejectsInvalidSecretRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		secretRef string
+	}{
+		{"raw path", "/home/user1/model-auth"},
+		{"host without path", "file://path"},
+		{"host with path", "file://host/path"},
+		{"single slash", "file:/tmp/key"},
+		{"opaque relative", "file:tmp/key"},
+		{"empty path", "file://"},
 	}
-	rt, err := NewLocalRuntime(discardLogger(), cfg)
-	if err != nil {
-		t.Fatalf("NewLocalRuntime failed: %v", err)
-	}
-	rt = rt.WithContext(testContext(t))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			providerID := "provider-1"
+			evaluation := sampleEvaluation(providerID)
+			evaluation.Model.Auth = &api.ModelAuth{SecretRef: tc.secretRef}
 
-	storage := &fakeStorage{providerConfigs: providers}
+			providers := sampleLocalProviders(providerID, "true")
+			cleanupDir(t, "job-1")
 
-	benchmarks, err := handlers.GetJobBenchmarks(evaluation, nil)
-	if err != nil {
-		t.Fatalf("failed to resolve benchmarks: %v", err)
-	}
+			cfg := &config.Config{
+				Service: &config.ServiceConfig{Port: 8080},
+				Sidecar: &config.SidecarConfig{LocalMode: true, BaseURL: "http://localhost:8082"},
+			}
+			rt, err := NewLocalRuntime(discardLogger(), cfg)
+			if err != nil {
+				t.Fatalf("NewLocalRuntime failed: %v", err)
+			}
+			rt = rt.WithContext(testContext(t))
 
-	err = rt.RunEvaluationJob(evaluation, benchmarks, storage)
-	if err == nil {
-		t.Fatal("expected error for secret_ref without file:/// prefix, got nil")
-	}
-	svcErr, ok := err.(abstractions.ServiceError)
-	if !ok {
-		t.Fatalf("expected ServiceError, got %T: %v", err, err)
-	}
-	if svcErr.MessageCode() != messages.InvalidSecretRefURI {
-		t.Fatalf("expected message code %q, got %q", messages.InvalidSecretRefURI.GetCode(), svcErr.MessageCode().GetCode())
-	}
-}
+			storage := &fakeStorage{providerConfigs: providers}
 
-func TestRunEvaluationJobSidecarRejectsFileURIWithAuthority(t *testing.T) {
-	providerID := "provider-1"
-	evaluation := sampleEvaluation(providerID)
-	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "file://host/path"}
+			benchmarks, err := handlers.GetJobBenchmarks(evaluation, nil)
+			if err != nil {
+				t.Fatalf("failed to resolve benchmarks: %v", err)
+			}
 
-	providers := sampleLocalProviders(providerID, "true")
-	cleanupDir(t, "job-1")
-
-	cfg := &config.Config{
-		Service: &config.ServiceConfig{Port: 8080},
-		Sidecar: &config.SidecarConfig{LocalMode: true, BaseURL: "http://localhost:8082"},
-	}
-	rt, err := NewLocalRuntime(discardLogger(), cfg)
-	if err != nil {
-		t.Fatalf("NewLocalRuntime failed: %v", err)
-	}
-	rt = rt.WithContext(testContext(t))
-
-	storage := &fakeStorage{providerConfigs: providers}
-
-	benchmarks, err := handlers.GetJobBenchmarks(evaluation, nil)
-	if err != nil {
-		t.Fatalf("failed to resolve benchmarks: %v", err)
-	}
-
-	err = rt.RunEvaluationJob(evaluation, benchmarks, storage)
-	if err == nil {
-		t.Fatal("expected error for file:// URI with authority component, got nil")
-	}
-	svcErr, ok := err.(abstractions.ServiceError)
-	if !ok {
-		t.Fatalf("expected ServiceError, got %T: %v", err, err)
-	}
-	if svcErr.MessageCode() != messages.InvalidSecretRefURI {
-		t.Fatalf("expected message code %q, got %q", messages.InvalidSecretRefURI.GetCode(), svcErr.MessageCode().GetCode())
-	}
-}
-
-func TestRunEvaluationJobSidecarRejectsFileSingleSlash(t *testing.T) {
-	providerID := "provider-1"
-	evaluation := sampleEvaluation(providerID)
-	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "file:/tmp/key"}
-
-	providers := sampleLocalProviders(providerID, "true")
-	cleanupDir(t, "job-1")
-
-	cfg := &config.Config{
-		Service: &config.ServiceConfig{Port: 8080},
-		Sidecar: &config.SidecarConfig{LocalMode: true, BaseURL: "http://localhost:8082"},
-	}
-	rt, err := NewLocalRuntime(discardLogger(), cfg)
-	if err != nil {
-		t.Fatalf("NewLocalRuntime failed: %v", err)
-	}
-	rt = rt.WithContext(testContext(t))
-
-	storage := &fakeStorage{providerConfigs: providers}
-
-	benchmarks, err := handlers.GetJobBenchmarks(evaluation, nil)
-	if err != nil {
-		t.Fatalf("failed to resolve benchmarks: %v", err)
-	}
-
-	err = rt.RunEvaluationJob(evaluation, benchmarks, storage)
-	if err == nil {
-		t.Fatal("expected error for file:/path (missing authority), got nil")
-	}
-	svcErr, ok := err.(abstractions.ServiceError)
-	if !ok {
-		t.Fatalf("expected ServiceError, got %T: %v", err, err)
-	}
-	if svcErr.MessageCode() != messages.InvalidSecretRefURI {
-		t.Fatalf("expected message code %q, got %q", messages.InvalidSecretRefURI.GetCode(), svcErr.MessageCode().GetCode())
-	}
-}
-
-func TestRunEvaluationJobSidecarRejectsFileOpaqueRelative(t *testing.T) {
-	providerID := "provider-1"
-	evaluation := sampleEvaluation(providerID)
-	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "file:tmp/key"}
-
-	providers := sampleLocalProviders(providerID, "true")
-	cleanupDir(t, "job-1")
-
-	cfg := &config.Config{
-		Service: &config.ServiceConfig{Port: 8080},
-		Sidecar: &config.SidecarConfig{LocalMode: true, BaseURL: "http://localhost:8082"},
-	}
-	rt, err := NewLocalRuntime(discardLogger(), cfg)
-	if err != nil {
-		t.Fatalf("NewLocalRuntime failed: %v", err)
-	}
-	rt = rt.WithContext(testContext(t))
-
-	storage := &fakeStorage{providerConfigs: providers}
-
-	benchmarks, err := handlers.GetJobBenchmarks(evaluation, nil)
-	if err != nil {
-		t.Fatalf("failed to resolve benchmarks: %v", err)
-	}
-
-	err = rt.RunEvaluationJob(evaluation, benchmarks, storage)
-	if err == nil {
-		t.Fatal("expected error for file:relative/path (opaque URI), got nil")
-	}
-	svcErr, ok := err.(abstractions.ServiceError)
-	if !ok {
-		t.Fatalf("expected ServiceError, got %T: %v", err, err)
-	}
-	if svcErr.MessageCode() != messages.InvalidSecretRefURI {
-		t.Fatalf("expected message code %q, got %q", messages.InvalidSecretRefURI.GetCode(), svcErr.MessageCode().GetCode())
+			err = rt.RunEvaluationJob(evaluation, benchmarks, storage)
+			if err == nil {
+				t.Fatalf("expected error for secret_ref %q, got nil", tc.secretRef)
+			}
+			svcErr, ok := err.(abstractions.ServiceError)
+			if !ok {
+				t.Fatalf("expected ServiceError, got %T: %v", err, err)
+			}
+			if svcErr.MessageCode() != messages.InvalidSecretRefURI {
+				t.Fatalf("expected message code %q, got %q", messages.InvalidSecretRefURI.GetCode(), svcErr.MessageCode().GetCode())
+			}
+		})
 	}
 }
 

--- a/internal/eval_hub/runtimes/local/local_runtime_test.go
+++ b/internal/eval_hub/runtimes/local/local_runtime_test.go
@@ -1180,6 +1180,44 @@ func TestRunEvaluationJobSidecarRejectsInvalidSecretRef(t *testing.T) {
 	}
 }
 
+func TestRunEvaluationJobSidecarRejectsMalformedURI(t *testing.T) {
+	providerID := "provider-1"
+	evaluation := sampleEvaluation(providerID)
+	evaluation.Model.Auth = &api.ModelAuth{SecretRef: "file:///%zz"}
+
+	providers := sampleLocalProviders(providerID, "true")
+	cleanupDir(t, "job-1")
+
+	cfg := &config.Config{
+		Service: &config.ServiceConfig{Port: 8080},
+		Sidecar: &config.SidecarConfig{LocalMode: true, BaseURL: "http://localhost:8082"},
+	}
+	rt, err := NewLocalRuntime(discardLogger(), cfg)
+	if err != nil {
+		t.Fatalf("NewLocalRuntime failed: %v", err)
+	}
+	rt = rt.WithContext(testContext(t))
+
+	storage := &fakeStorage{providerConfigs: providers}
+
+	benchmarks, err := handlers.GetJobBenchmarks(evaluation, nil)
+	if err != nil {
+		t.Fatalf("failed to resolve benchmarks: %v", err)
+	}
+
+	err = rt.RunEvaluationJob(evaluation, benchmarks, storage)
+	if err == nil {
+		t.Fatal("expected error for malformed URI, got nil")
+	}
+	svcErr, ok := err.(abstractions.ServiceError)
+	if !ok {
+		t.Fatalf("expected ServiceError, got %T: %v", err, err)
+	}
+	if svcErr.MessageCode() != messages.InvalidSecretRefURIParse {
+		t.Fatalf("expected message code %q, got %q", messages.InvalidSecretRefURIParse.GetCode(), svcErr.MessageCode().GetCode())
+	}
+}
+
 func TestRunEvaluationJobWithoutSidecarNoRewrite(t *testing.T) {
 	providerID := "provider-1"
 	evaluation := sampleEvaluation(providerID)

--- a/internal/eval_hub/runtimes/shared/jobspec.go
+++ b/internal/eval_hub/runtimes/shared/jobspec.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
@@ -80,7 +79,6 @@ func cloneModelRef(m *api.ModelRef) *api.ModelRef {
 		return nil
 	}
 	out := *m
-	out.URL = strings.TrimSpace(out.URL)
 	if m.Auth != nil {
 		auth := *m.Auth
 		out.Auth = &auth

--- a/internal/eval_hub/runtimes/shared/jobspec.go
+++ b/internal/eval_hub/runtimes/shared/jobspec.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
@@ -79,6 +80,7 @@ func cloneModelRef(m *api.ModelRef) *api.ModelRef {
 		return nil
 	}
 	out := *m
+	out.URL = strings.TrimSpace(out.URL)
 	if m.Auth != nil {
 		auth := *m.Auth
 		out.Auth = &auth

--- a/internal/eval_runtime_sidecar/handlers/handlers_test.go
+++ b/internal/eval_runtime_sidecar/handlers/handlers_test.go
@@ -149,7 +149,7 @@ func TestHandleProxyCall_LocalMode_ModelRouting(t *testing.T) {
 	if err := os.MkdirAll(jobDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	jobInfo := `{"model": {"url": "` + upstream.URL + `", "auth_secret_mount_path": "` + authDir + `"}}`
+	jobInfo := `{"model": {"url": "` + upstream.URL + `", "auth_secret_mount_path": "file://` + authDir + `"}}`
 	if err := os.WriteFile(filepath.Join(jobDir, "sidecar-job-info.json"), []byte(jobInfo), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/eval_runtime_sidecar/proxy/job_cache.go
+++ b/internal/eval_runtime_sidecar/proxy/job_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -16,6 +17,10 @@ import (
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/runtimes/shared"
 )
+
+// ErrInvalidAuthSecretPath indicates that auth_secret_mount_path is present
+// but does not use the required file:/// URI scheme.
+var ErrInvalidAuthSecretPath = errors.New("invalid auth_secret_mount_path")
 
 const (
 	DefaultJobCacheTTL           = 2 * time.Hour
@@ -122,7 +127,14 @@ func (c *JobInfoCache) loadEntry(jobID string) (*jobCacheEntry, error) {
 
 	caCertPath := ""
 	if mountPath := strings.TrimSpace(info.Model.AuthSecretMountPath); mountPath != "" {
-		candidate := filepath.Join(mountPath, "ca_cert")
+		fsPath, ok := strings.CutPrefix(mountPath, "file://")
+		if !ok {
+			c.logger.Error("auth_secret_mount_path missing file:/// prefix",
+				"job_id", jobID, "auth_secret_mount_path", mountPath)
+			return nil, fmt.Errorf("%w: missing file:/// prefix in %q for job %q",
+				ErrInvalidAuthSecretPath, mountPath, jobID)
+		}
+		candidate := filepath.Join(fsPath, "ca_cert")
 		if _, statErr := os.Stat(candidate); statErr == nil {
 			caCertPath = candidate
 		}

--- a/internal/eval_runtime_sidecar/proxy/job_cache.go
+++ b/internal/eval_runtime_sidecar/proxy/job_cache.go
@@ -134,6 +134,12 @@ func (c *JobInfoCache) loadEntry(jobID string) (*jobCacheEntry, error) {
 			return nil, fmt.Errorf("%w: missing file:/// prefix in %q for job %q",
 				ErrInvalidAuthSecretPath, mountPath, jobID)
 		}
+		if !strings.HasPrefix(fsPath, "/") {
+			c.logger.Error("auth_secret_mount_path has non-local authority component",
+				"job_id", jobID, "auth_secret_mount_path", mountPath)
+			return nil, fmt.Errorf("%w: file:// URI must use an empty authority (file:///…), got %q for job %q",
+				ErrInvalidAuthSecretPath, mountPath, jobID)
+		}
 		candidate := filepath.Join(fsPath, "ca_cert")
 		if _, statErr := os.Stat(candidate); statErr == nil {
 			caCertPath = candidate

--- a/internal/eval_runtime_sidecar/proxy/job_cache_test.go
+++ b/internal/eval_runtime_sidecar/proxy/job_cache_test.go
@@ -204,6 +204,26 @@ func TestJobInfoCache_Get(t *testing.T) {
 		}
 	})
 
+	t.Run("returns error when auth_secret_mount_path uses non-local file URI authority", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "job-file-authority", `{
+			"model": {
+				"url": "https://api.example.com/v1",
+				"auth_secret_mount_path": "file://host/path"
+			}
+		}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, _, err := cache.Get("job-file-authority")
+		if err == nil {
+			t.Fatal("expected error for file:// URI with authority component")
+		}
+		if !errors.Is(err, ErrInvalidAuthSecretPath) {
+			t.Errorf("expected ErrInvalidAuthSecretPath, got: %v", err)
+		}
+	})
+
 	t.Run("accepts empty auth_secret_mount_path", func(t *testing.T) {
 		t.Parallel()
 		jobsDir := t.TempDir()

--- a/internal/eval_runtime_sidecar/proxy/job_cache_test.go
+++ b/internal/eval_runtime_sidecar/proxy/job_cache_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -22,7 +23,7 @@ func TestJobInfoCache_Get(t *testing.T) {
 		writeJobInfo(t, jobsDir, jobID, `{
 			"model": {
 				"url": "https://model.example.com/v1",
-				"auth_secret_mount_path": "/home/user/creds"
+				"auth_secret_mount_path": "file:///home/user/creds"
 			}
 		}`)
 
@@ -166,7 +167,7 @@ func TestJobInfoCache_Get(t *testing.T) {
 		writeJobInfo(t, jobsDir, "job-with-creds", `{
 			"model": {
 				"url": "https://api.example.com:443/v1",
-				"auth_secret_mount_path": "`+authDir+`"
+				"auth_secret_mount_path": "file://`+authDir+`"
 			}
 		}`)
 
@@ -177,6 +178,46 @@ func TestJobInfoCache_Get(t *testing.T) {
 		}
 		if target.Host != "api.example.com:443" {
 			t.Errorf("target host = %q, want %q", target.Host, "api.example.com:443")
+		}
+		if client == nil {
+			t.Error("expected non-nil HTTP client")
+		}
+	})
+
+	t.Run("returns error when auth_secret_mount_path missing file prefix", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "job-bad-auth", `{
+			"model": {
+				"url": "https://api.example.com/v1",
+				"auth_secret_mount_path": "/home/user/model-auth"
+			}
+		}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, _, err := cache.Get("job-bad-auth")
+		if err == nil {
+			t.Fatal("expected error for auth_secret_mount_path without file:/// prefix")
+		}
+		if !errors.Is(err, ErrInvalidAuthSecretPath) {
+			t.Errorf("expected ErrInvalidAuthSecretPath, got: %v", err)
+		}
+	})
+
+	t.Run("accepts empty auth_secret_mount_path", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		writeJobInfo(t, jobsDir, "job-no-auth", `{
+			"model": {
+				"url": "https://api.example.com/v1",
+				"auth_secret_mount_path": ""
+			}
+		}`)
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, client, err := cache.Get("job-no-auth")
+		if err != nil {
+			t.Fatalf("Get() error: %v", err)
 		}
 		if client == nil {
 			t.Error("expected non-nil HTTP client")

--- a/internal/eval_runtime_sidecar/proxy/local_model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/local_model_proxy.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
@@ -93,10 +94,17 @@ func NewLocalModelReverseProxy(cache *JobInfoCache, logger *slog.Logger) http.Ha
 		target, jobClient, err := cache.Get(jobID)
 		if err != nil {
 			reqLog.Error("Job info lookup failed", "job_id", jobID, "error", err)
-			writeJSONError(w, reqID, http.StatusNotFound, map[string]string{
-				"error":  "unknown job-id",
-				"job_id": jobID,
-			})
+			if errors.Is(err, ErrInvalidAuthSecretPath) {
+				writeJSONError(w, reqID, http.StatusBadRequest, map[string]string{
+					"error":  "invalid auth_secret_mount_path: missing file:/// prefix",
+					"job_id": jobID,
+				})
+			} else {
+				writeJSONError(w, reqID, http.StatusNotFound, map[string]string{
+					"error":  "unknown job-id",
+					"job_id": jobID,
+				})
+			}
 			return
 		}
 

--- a/internal/eval_runtime_sidecar/proxy/local_model_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/local_model_proxy_test.go
@@ -249,6 +249,40 @@ func TestLocalModelProxy_MultipleJobsRoutedIndependently(t *testing.T) {
 	}
 }
 
+func TestLocalModelProxy_InvalidAuthSecretPathReturns400(t *testing.T) {
+	t.Parallel()
+
+	jobsDir := t.TempDir()
+	writeJobInfo(t, jobsDir, "job-bad-path", `{
+		"model": {
+			"url": "https://api.example.com/v1",
+			"auth_secret_mount_path": "/home/user/model-auth"
+		}
+	}`)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+	proxy := NewLocalModelReverseProxy(cache, logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/model/job-bad-path/v1/models", nil)
+	rw := httptest.NewRecorder()
+	proxy.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rw.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rw.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["error"] != "invalid auth_secret_mount_path: missing file:/// prefix" {
+		t.Errorf("error = %q, want %q", body["error"], "invalid auth_secret_mount_path: missing file:/// prefix")
+	}
+	if body["job_id"] != "job-bad-path" {
+		t.Errorf("job_id = %q, want %q", body["job_id"], "job-bad-path")
+	}
+}
+
 func TestLocalModelProxy_UsesPerJobCACert(t *testing.T) {
 	t.Parallel()
 
@@ -271,7 +305,7 @@ func TestLocalModelProxy_UsesPerJobCACert(t *testing.T) {
 	writeJobInfo(t, jobsDir, "job-tls", `{
 		"model": {
 			"url": "`+upstream.URL+`",
-			"auth_secret_mount_path": "`+authDir+`"
+			"auth_secret_mount_path": "file://`+authDir+`"
 		}
 	}`)
 


### PR DESCRIPTION

## What and why

local mode model.auth.secret_ref should follow `file:///` URI schema

Changes
- In local mode Invalid `model.auth.secret_ref` values without the `file:///` URI prefix return 400 Bad Request.  `model.auth` is still optional
- Also enforce the file:/// contract in the sidecar job cache (defense-in-depth) and centralise model URL trimming in cloneModelRef.

e.g. Bad request:
```yaml
model:
  url: https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1
  name: meta-llama/Llama-3.2-1B-Instruct
  auth:
    secret_ref: /Users/gnaulak/workspace/secret_ref/vllm-llama-prabhu-apikey
```

Good request
```yaml
model:
  url: https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1
  name: meta-llama/Llama-3.2-1B-Instruct
  auth:
    secret_ref: file:///Users/gnaulak/workspace/secret_ref/vllm-llama-prabhu-apikey
```
Closes # Part delivery for https://redhat.atlassian.net/browse/RHOAIENG-81188

SDK pr: https://github.com/eval-hub/eval-hub-sdk/pull/170
Assisted-by: Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

<img width="889" height="923" alt="Screenshot 2026-08-18 at 8 04 50 PM" src="https://github.com/user-attachments/assets/84edf1e1-42b5-45b0-b501-f5743d46fabb" />

Bad Request:
<img width="876" height="83" alt="Screenshot 2026-08-18 at 8 21 22 PM" src="https://github.com/user-attachments/assets/ba53771d-2402-4a68-a3cf-ef690805b3f7" />

## Breaking changes

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation requiring local authentication secret references to use valid `file:///path` URIs.
  * Added clear HTTP 400 responses for invalid secret reference formats.
  * Improved error messages with the required format and an example.

* **Bug Fixes**
  * Distinguished invalid authentication secret paths from unknown jobs.
  * Preserved model URLs without altering their whitespace.
  * Updated proxy handling for malformed or unsupported secret paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->