### PR TITLE
fix: correct lighteval truthfulqa:gen task ID and metrics

### DIFF
--- a/config/providers/lighteval.yaml
+++ b/config/providers/lighteval.yaml
@@ -262,13 +262,12 @@ benchmarks:
       lower_is_better: false
     pass_criteria:
       threshold: 0.25
-  - id: truthfulqa:generation
+  - id: truthfulqa:gen
     name: Misconception resistance (generative)
     description: Tests whether generated answers are truthful and non-misleading (817 questions).
     category: safety
     metrics:
-      - bleu
-      - rouge
+      - exact_match
     num_few_shot: 0
     dataset_size: 817
     tags:
@@ -276,10 +275,10 @@ benchmarks:
       - truthfulness
       - lighteval
     primary_score:
-      metric: bleu
+      metric: exact_match
       lower_is_better: false
     pass_criteria:
-      threshold: 0.1
+      threshold: 0.25
   - id: gsm8k
     name: Grade-school math word problems
     description: |-


### PR DESCRIPTION


## What and why

The generative TruthfulQA benchmark was registered as "truthfulqa:generation" with bleu/rouge metrics, but upstream lighteval v0.13.0 defines it as "truthfulqa:gen" with exact_match. Update the task ID, metrics, and pass threshold to match the upstream definition.

Reference: https://github.com/huggingface/lighteval/blob/v0.13.0/src/lighteval/tasks/tasks/truthfulqa.py#L59
```python
truthfulqa_gen = LightevalTaskConfig(
    name="truthfulqa:gen",
    prompt_function=truthful_qa_generative_prompt,
    hf_repo="truthfulqa/truthful_qa",
    hf_subset="generation",
    hf_avail_splits=["validation"],
    evaluation_splits=["validation"],
    few_shots_split=None,
    few_shots_select=None,
    generation_size=200,
    metrics=[Metrics.exact_match],
    stop_sequence=["\n"],
    version=0,
)
```
Closes # https://redhat.atlassian.net/browse/RHOAIENG-84705

Assisted-by: Claude

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

As mentioned in https://redhat.atlassian.net/browse/RHOAIENG-84705?focusedCommentId=18056730
For E2E flow we will need upstream fix to be available in lighteval first: https://github.com/huggingface/lighteval/pull/1127 https://github.com/huggingface/lighteval/issues/1130  . I can see this PR not merged yet
We are expected to hit the same issue as mentioned above.

## Breaking changes

No
<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the TruthfulQA generative benchmark name to `truthfulqa:gen`.
  * Replaced BLEU and ROUGE scoring with exact-match evaluation.
  * Raised the passing threshold from 0.1 to 0.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->