### PR TITLE
docs: convert yaml comments to agent hints for open telco benchmarks and collection

### DIFF
--- a/config/collections/open-telco-v1.yaml
+++ b/config/collections/open-telco-v1.yaml
@@ -18,9 +18,15 @@ tags:
   - reasoning
   - inspect
   - vllm
+agent:
+  result_interpretation:
+    - "Collection pass threshold is the equal-weight average of the four Open-Telco benchmarks: (0.50 + 0.70 + 0.25 + 0.45) / 4 = 0.475"
+    - "HIGHER is better -- all four benchmarks report accuracy"
+    - "telemath: GSMA leaderboard median ≈ 0.42; GPT-5 ≈ 0.79"
+    - "teleqna: GSMA leaderboard median ≈ 0.75; GPT-5 ≈ 0.84"
+    - "telelogs: GSMA leaderboard median ≈ 0.23; GPT-5 ≈ 0.78"
+    - "3gpp-tsg: GSMA leaderboard median ≈ 0.43; GPT-5 ≈ 0.58"
 pass_criteria:
-  # Equal-weight average across four Open-Telco benchmarks:
-  # (0.50 + 0.70 + 0.25 + 0.45) / 4 = 0.475
   threshold: 0.475
 benchmarks:
   - id: inspect/telemath
@@ -30,7 +36,6 @@ benchmarks:
       metric: telemath_scorer/accuracy
       lower_is_better: false
     pass_criteria:
-      # GSMA leaderboard median ≈ 0.42; GPT-5 ≈ 0.79.
       threshold: 0.50
     parameters:
       full: true
@@ -43,7 +48,6 @@ benchmarks:
       metric: choice/accuracy
       lower_is_better: false
     pass_criteria:
-      # GSMA leaderboard median ≈ 0.75; GPT-5 ≈ 0.84.
       threshold: 0.70
     parameters:
       full: true
@@ -57,7 +61,6 @@ benchmarks:
       metric: telelogs_scorer/accuracy
       lower_is_better: false
     pass_criteria:
-      # GSMA leaderboard median ≈ 0.23; GPT-5 ≈ 0.78.
       threshold: 0.25
     parameters:
       full: true
@@ -71,7 +74,6 @@ benchmarks:
       metric: pattern/accuracy
       lower_is_better: false
     pass_criteria:
-      # GSMA leaderboard median ≈ 0.43; GPT-5 ≈ 0.58.
       threshold: 0.45
     parameters:
       full: true

--- a/config/providers/inspect.yaml
+++ b/config/providers/inspect.yaml
@@ -527,9 +527,10 @@ benchmarks:
       metric: telemath_scorer/accuracy
       lower_is_better: false
     pass_criteria:
-      # GSMA leaderboard (Mar 2026): median ≈ 0.42, GPT-5 ≈ 0.79, top ≈ 0.87.
       threshold: 0.50
     tags: [telecom, math, reasoning, open-telco, inspect-ai]
+    agent:
+      result_interpretation: "Accuracy on telecom-domain numerical math; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.42, GPT-5 ≈ 0.79, top ≈ 0.87."
 
   - id: inspect/teleqna
     name: TeleQnA
@@ -546,9 +547,10 @@ benchmarks:
       metric: choice/accuracy
       lower_is_better: false
     pass_criteria:
-      # GSMA leaderboard (Mar 2026): median ≈ 0.75, GPT-5 ≈ 0.84, top ≈ 0.91.
       threshold: 0.70
     tags: [telecom, knowledge, qa, open-telco, inspect-ai]
+    agent:
+      result_interpretation: "Accuracy on telecom domain MCQ; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.75, GPT-5 ≈ 0.84, top ≈ 0.91."
 
   - id: inspect/telelogs
     name: TeleLogs
@@ -566,9 +568,10 @@ benchmarks:
       metric: telelogs_scorer/accuracy
       lower_is_better: false
     pass_criteria:
-      # GSMA leaderboard (Mar 2026): median ≈ 0.23, GPT-5 ≈ 0.78, top ≈ 0.96.
       threshold: 0.25
     tags: [telecom, operations, rca, troubleshooting, open-telco, inspect-ai]
+    agent:
+      result_interpretation: "Accuracy on 5G root-cause analysis; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.23, GPT-5 ≈ 0.78, top ≈ 0.96."
 
   - id: inspect/3gpp-tsg
     name: 3GPP-TSG
@@ -585,9 +588,10 @@ benchmarks:
       metric: pattern/accuracy
       lower_is_better: false
     pass_criteria:
-      # GSMA leaderboard (Mar 2026): median ≈ 0.43, GPT-5 ≈ 0.58, top ≈ 0.81.
       threshold: 0.45
     tags: [telecom, standards, 3gpp, knowledge, open-telco, inspect-ai]
+    agent:
+      result_interpretation: "Accuracy on 3GPP working-group classification; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.43, GPT-5 ≈ 0.58, top ≈ 0.81."
 
   # Knowledge & reasoning
   - id: inspect/mmlu


### PR DESCRIPTION
## What and why

Convert yaml comments to agent hints for open telco benchmarks and collection.

Closes #

Assisted-by: Cursor

## Type

- [ ] feat
- [ ] fix
- [X] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->
