### PR TITLE
fix(security): remove all #nosec annotations and add CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,15 @@ jobs:
         make fmt
         git diff --exit-code -- '*.go' || (echo "Code is not formatted. Run 'make fmt' locally." && exit 1)
 
+    - name: Reject inline gosec suppressions
+      run: |
+        if grep -rn '#nosec' --include='*.go' .; then
+          echo "Found #nosec annotations in Go files. Remove them and fix the underlying code."
+          echo "If a finding cannot be structurally fixed, add a path-scoped --exclude-rules entry"
+          echo "in the Gosec Security Scanner step of this workflow instead."
+          exit 1
+        fi
+
     - name: Run linter
       run: make lint
 
@@ -106,13 +115,24 @@ jobs:
       # https://github.com/securego/gosec#integrating-with-code-scanning
       # The problem is that this can hide some errors (such as golang version mismatch)
       # that are not caught by the following steps.
+      #
+      # --exclude-rules: G204 is suppressed only for local_runtime.go because
+      # the local runtime intentionally executes provider-configured shell
+      # commands (exec.Command("sh", "-c", …)); there is no structural
+      # alternative.  Inline #nosec annotations are banned by the "Reject
+      # inline gosec suppressions" CI step; all exclusions must be managed
+      # here via --exclude-rules with a path-scoped regex.
       env:
         # make sure that we use the golang version required by the project
         GOSECGOVERSION: go1.26.5
         GOTOOLCHAIN: go1.26.5
       uses: securego/gosec@9e75c0576c9878035d4221392108d458abe10fc3 # v2.28.0
       with:
-        args: '-fmt sarif -out gosec-results.sarif -stdout -verbose=text -exclude-dir=tests ./...'
+        args: >-
+          -fmt sarif -out gosec-results.sarif -stdout -verbose=text
+          -exclude-dir=tests
+          --exclude-rules="internal/eval_hub/runtimes/local/local_runtime\.go:G204"
+          ./...
 
     - name: Upload SARIF file to GitHub Security tab
       uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
 
     - name: Reject inline gosec suppressions
       run: |
-        if grep -rn '#nosec' --include='*.go' .; then
-          echo "Found #nosec annotations in Go files. Remove them and fix the underlying code."
+        if grep -rn -E '#nosec|//gosec:disable' --include='*.go' .; then
+          echo "Found inline gosec suppression annotations (#nosec or //gosec:disable) in Go files."
+          echo "Remove them and fix the underlying code."
           echo "If a finding cannot be structurally fixed, add a path-scoped --exclude-rules entry"
           echo "in the Gosec Security Scanner step of this workflow instead."
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         args: >-
           -fmt sarif -out gosec-results.sarif -stdout -verbose=text
           -exclude-dir=tests
-          --exclude-rules="internal/eval_hub/runtimes/local/local_runtime\.go:G204"
+          --exclude-rules=internal/eval_hub/runtimes/local/local_runtime\.go:G204
           ./...
 
     - name: Upload SARIF file to GitHub Security tab

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ make vet                # Run go vet (same as lint)
 
 If a `.pre-commit-config.yaml` file exists, run `pre-commit install && pre-commit install --hook-type commit-msg` before making any commits. This automatically enforces formatting, linting, and commit message conventions on every commit.
 
-**Do not use `#nosec` annotations in Go files.** CI rejects any PR that contains inline `#nosec` comments. Fix the underlying code instead (e.g. use `os.OpenInRoot` for path-traversal-safe file access). If a gosec finding cannot be structurally fixed, add a path-scoped `--exclude-rules` entry in the Gosec Security Scanner step of `.github/workflows/ci.yml`.
+**Do not use `#nosec` or `//gosec:disable` annotations in Go files.** CI rejects any PR that contains either inline suppression form. Fix the underlying code instead (e.g. use `os.OpenInRoot` for path-traversal-safe file access). If a gosec finding cannot be structurally fixed, add a path-scoped `--exclude-rules` entry in the Gosec Security Scanner step of `.github/workflows/ci.yml`.
 
 ### Go Version
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ make vet                # Run go vet (same as lint)
 
 If a `.pre-commit-config.yaml` file exists, run `pre-commit install && pre-commit install --hook-type commit-msg` before making any commits. This automatically enforces formatting, linting, and commit message conventions on every commit.
 
+**Do not use `#nosec` annotations in Go files.** CI rejects any PR that contains inline `#nosec` comments. Fix the underlying code instead (e.g. use `os.OpenInRoot` for path-traversal-safe file access). If a gosec finding cannot be structurally fixed, add a path-scoped `--exclude-rules` entry in the Gosec Security Scanner step of `.github/workflows/ci.yml`.
+
 ### Go Version
 
 The version in `go.mod` is the source of truth for local development. If your local Go toolchain is older than the version in `go.mod` but at least Go 1.21, use `GOTOOLCHAIN=auto` to let Go automatically download the required version. Never downgrade `go.mod` to match a locally installed toolchain.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,7 @@ pre-commit run --all-files
 - **Error Handling**: Always check and handle errors explicitly
 - **Documentation**: Use godoc-style comments for exported types and functions
 - **Import Grouping**: Standard library, then external packages, then internal packages
+- **No `#nosec` annotations**: CI rejects PRs containing inline `#nosec` comments. Fix the underlying code instead (e.g. use `os.OpenInRoot` for path-traversal-safe file access). If a gosec finding cannot be structurally fixed, add a path-scoped `--exclude-rules` entry in the Gosec Security Scanner step of `.github/workflows/ci.yml`
 
 ### Code Organization
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,7 @@ pre-commit run --all-files
 - **Error Handling**: Always check and handle errors explicitly
 - **Documentation**: Use godoc-style comments for exported types and functions
 - **Import Grouping**: Standard library, then external packages, then internal packages
-- **No `#nosec` annotations**: CI rejects PRs containing inline `#nosec` comments. Fix the underlying code instead (e.g. use `os.OpenInRoot` for path-traversal-safe file access). If a gosec finding cannot be structurally fixed, add a path-scoped `--exclude-rules` entry in the Gosec Security Scanner step of `.github/workflows/ci.yml`
+- **No `#nosec` or `//gosec:disable` annotations**: CI rejects PRs containing either inline suppression form (`#nosec` or `//gosec:disable`). Fix the underlying code instead (e.g. use `os.OpenInRoot` for path-traversal-safe file access). If a gosec finding cannot be structurally fixed, add a path-scoped `--exclude-rules` entry in the Gosec Security Scanner step of `.github/workflows/ci.yml`
 
 ### Code Organization
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Eval Hub is an API REST server that serves as a routing and orchestration layer 
 
 **Required for All Development:**
 
-- Go 1.26.0+
+- Go at the version specified in `go.mod` or newer
 - [Make](https://www.gnu.org/software/make/) for build automation
 - Git
 - [uv](https://docs.astral.sh/uv/) for Python virtual environment management (required by `make test-fvt`, `make start-service`, and pre-commit hooks)
@@ -202,7 +202,7 @@ pre-commit run --all-files
 
 ### Go Standards
 
-- **Go Version**: Support 1.26.0+
+- **Go Version**: Must be equal to or greater than the version in `go.mod`
 - **Code Style**: Follow standard Go conventions (enforced by gofmt)
 - **Error Handling**: Always check and handle errors explicitly
 - **Documentation**: Use godoc-style comments for exported types and functions

--- a/internal/eval_hub/runtimes/local/local_runtime.go
+++ b/internal/eval_hub/runtimes/local/local_runtime.go
@@ -271,7 +271,7 @@ func (r *LocalRuntime) runBenchmark(
 
 	// Build command using shell interpretation
 	command := provider.Runtime.Local.Command
-	cmd := exec.Command("sh", "-c", command) // #nosec G204 -- local runtime executes provider-defined commands by design
+	cmd := exec.Command("sh", "-c", command)
 	// Setpgid places the child in its own process group (PGID = child PID).
 	// This is critical for two reasons:
 	//   1. cancelJob calls Kill(-PID, SIGKILL) which targets the entire process

--- a/internal/eval_hub/runtimes/local/local_runtime.go
+++ b/internal/eval_hub/runtimes/local/local_runtime.go
@@ -280,6 +280,7 @@ func (r *LocalRuntime) runBenchmark(
 
 	// Build command using shell interpretation
 	command := provider.Runtime.Local.Command
+	// G204 -- local runtime executes provider-defined commands by design
 	cmd := exec.Command("sh", "-c", command)
 	// Setpgid places the child in its own process group (PGID = child PID).
 	// This is critical for two reasons:

--- a/internal/eval_runtime_sidecar/proxy/job_cache.go
+++ b/internal/eval_runtime_sidecar/proxy/job_cache.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -92,12 +93,13 @@ func (c *JobInfoCache) loadEntry(jobID string) (*jobCacheEntry, error) {
 		return nil, fmt.Errorf("invalid job-id %q", jobID)
 	}
 
-	infoPath := filepath.Join(c.jobsDir, jobID, shared.SidecarJobInfoFileName)
-	cleanBase := filepath.Clean(c.jobsDir) + string(os.PathSeparator)
-	if !strings.HasPrefix(filepath.Clean(infoPath), cleanBase) {
-		return nil, fmt.Errorf("invalid job-id %q: resolved path escapes base directory", jobID)
+	relPath := filepath.Join(jobID, shared.SidecarJobInfoFileName)
+	f, err := os.OpenInRoot(c.jobsDir, relPath)
+	if err != nil {
+		return nil, fmt.Errorf("job info not found for %q: %w", jobID, err)
 	}
-	data, err := os.ReadFile(infoPath) // #nosec G304,G703 -- path validated to stay within jobsDir
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("job info not found for %q: %w", jobID, err)
 	}

--- a/internal/eval_runtime_sidecar/proxy/job_cache_test.go
+++ b/internal/eval_runtime_sidecar/proxy/job_cache_test.go
@@ -289,6 +289,62 @@ func TestJobInfoCache_Get(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects symlinked job directory escaping jobsDir", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		outsideDir := t.TempDir()
+
+		writeJobInfo(t, outsideDir, "real-job", `{
+			"model": {"url": "https://model.example.com/v1"}
+		}`)
+
+		// Create a symlink inside jobsDir that points to outsideDir/real-job
+		if err := os.Symlink(
+			filepath.Join(outsideDir, "real-job"),
+			filepath.Join(jobsDir, "symlink-job"),
+		); err != nil {
+			t.Skipf("symlinks not supported: %v", err)
+		}
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, _, err := cache.Get("symlink-job")
+		if err == nil {
+			t.Fatal("expected error when job directory is a symlink escaping jobsDir")
+		}
+	})
+
+	t.Run("rejects symlinked job-info file escaping jobsDir", func(t *testing.T) {
+		t.Parallel()
+		jobsDir := t.TempDir()
+		outsideDir := t.TempDir()
+
+		// Write a valid job-info file outside jobsDir
+		outsideFile := filepath.Join(outsideDir, shared.SidecarJobInfoFileName)
+		if err := os.WriteFile(outsideFile, []byte(`{
+			"model": {"url": "https://model.example.com/v1"}
+		}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create the job directory inside jobsDir, then symlink the info file out
+		jobDir := filepath.Join(jobsDir, "symlink-file-job")
+		if err := os.MkdirAll(jobDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(
+			outsideFile,
+			filepath.Join(jobDir, shared.SidecarJobInfoFileName),
+		); err != nil {
+			t.Skipf("symlinks not supported: %v", err)
+		}
+
+		cache := NewJobInfoCache(jobsDir, DefaultJobCacheTTL, logger)
+		_, _, err := cache.Get("symlink-file-job")
+		if err == nil {
+			t.Fatal("expected error when job-info file is a symlink escaping jobsDir")
+		}
+	})
+
 	t.Run("strips trailing slash from model URL", func(t *testing.T) {
 		t.Parallel()
 		jobsDir := t.TempDir()


### PR DESCRIPTION
## Summary

- Replace `os.ReadFile` with `os.OpenInRoot` in `job_cache.go` for OS-level path traversal protection, removing the manual `cleanBase`/`HasPrefix` guard and the `#nosec G304,G703` annotation
- Remove the `#nosec G204` annotation from `local_runtime.go` and use gosec's `--exclude-rules` flag scoped to that single file (`local_runtime\.go:G204`), keeping G204 active everywhere else
- Add a "Reject inline gosec suppressions" CI step that fails any PR containing `#nosec` in Go files
- Document the `#nosec` ban in `AGENTS.md` under Code Quality

## Test plan

- [x] All existing `TestJobInfoCache_*` tests pass with the `os.OpenInRoot` change (17/17)
- [x] All pre-commit hooks pass (fmt, lint, vet, golangci-lint, gitleaks, tests)
- [x] `grep -rn '#nosec' --include='*.go' .` returns zero matches
- [ ] CI `quality-checks` job runs the new "Reject inline gosec suppressions" step
- [ ] CI `security-scan` job runs gosec with path-scoped `--exclude-rules` instead of global `-exclude`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened validation when loading job information, preventing access through symlinks that escape the configured jobs directory.
  * CI now rejects inline security-scan suppressions in Go code while allowing narrowly scoped, documented exceptions where necessary.

* **Documentation**
  * Updated contributor guidance to align Go version requirements with the project configuration.
  * Added secure remediation guidance for security findings and approved exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->