### PR TITLE
ci(python-mcp): mute setup-uv empty workdir warning

### DIFF
--- a/.github/workflows/ci-python-mcp.yml
+++ b/.github/workflows/ci-python-mcp.yml
@@ -36,6 +36,7 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: '3.11'
+          ignore-empty-workdir: true
       - name: Build MCP binary for this platform via cross-compile target
         run: make cross-compile-mcp
       - name: Build MCP wheel


### PR DESCRIPTION


## What and why

The astral-sh/setup-uv action warns when no pyproject.toml or uv.lock is present in the working directory. This is expected for the MCP wheel CI job

<img width="823" height="302" alt="Screenshot 2026-08-20 at 9 09 00 AM" src="https://github.com/user-attachments/assets/608dd387-ae07-418d-9411-525e36bc6c41" />

Closes # NA

Assisted-by:  Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow handling when the working directory is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->