### PR TITLE
test: fix failing GPU nodeselector scenarios

### DIFF
--- a/tests/features/gpu_resources.feature
+++ b/tests/features/gpu_resources.feature
@@ -77,6 +77,8 @@ Feature: GPU Resource Management
     Then the Job spec should have GPU request set to "1"
     And the Job spec should have GPU limit set to "1"
     And the Job spec should have label "kueue.x-k8s.io/queue-name=test-local-queue"
+    # eval-hub must not set a nodeSelector for a queue-backed job; Kueue may inject the
+    # admitted ResourceFlavor's label (nvidia.com/gpu.product=<GPU_PRODUCT>), which is tolerated
     And the Job spec should not have nodeSelector
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"
     Then the response code should be 204
@@ -97,6 +99,8 @@ Feature: GPU Resource Management
     And I wait for the Kubernetes Job to be created for evaluation job "{id}"
     Then the Job spec should have GPU request set to "1"
     And the Job spec should have GPU limit set to "1"
+    # eval-hub must strip the provider's conflicting node_selector (DOES_NOT_EXIST) so Kueue
+    # can schedule via the ResourceFlavor; the injected flavor label (GPU_PRODUCT) is tolerated
     And the Job spec should not have nodeSelector
     And the Job spec should have label "kueue.x-k8s.io/queue-name=test-local-queue"
     When I send a DELETE request to "/api/v1/evaluations/jobs/{id}?hard_delete=true"

--- a/tests/features/gpu_step_definitions_test.go
+++ b/tests/features/gpu_step_definitions_test.go
@@ -774,9 +774,14 @@ func (tc *scenarioConfig) jobSpecShouldHaveNodeSelector(selectorKeyValue string)
 // so assertions must distinguish them by value.
 const gpuProductNodeSelectorKey = "nvidia.com/gpu.product"
 
-// getJobNodeSelector returns the nodeSelector map from the evaluation job's Kubernetes
-// Job pod template. Returns an empty (non-nil) map when no nodeSelector is set.
-func (tc *scenarioConfig) getJobNodeSelector() (map[string]string, error) {
+// kueueQueueNameLabelKey is set by eval-hub at Job creation for queue-backed Kueue
+// Jobs. Its presence is the race-free signal that a GPU_PRODUCT nodeSelector may
+// have been injected by Kueue admission rather than leaked by eval-hub.
+const kueueQueueNameLabelKey = "kueue.x-k8s.io/queue-name"
+
+// getJobNodeSelector returns the nodeSelector map and Job labels from the
+// evaluation job's Kubernetes Job. Maps are empty (non-nil) when unset.
+func (tc *scenarioConfig) getJobNodeSelector() (map[string]string, map[string]string, error) {
 	namespace := tc.reqHeaders["X-Tenant"]
 	if namespace == "" {
 		namespace = "test-tenant"
@@ -784,7 +789,7 @@ func (tc *scenarioConfig) getJobNodeSelector() (map[string]string, error) {
 
 	id := tc.lastId
 	if id == "" {
-		return nil, tc.logError(fmt.Errorf("no evaluation job ID found"))
+		return nil, nil, tc.logError(fmt.Errorf("no evaluation job ID found"))
 	}
 
 	cmd := exec.Command("oc", "get", "job", "-n", namespace, "-l",
@@ -792,11 +797,14 @@ func (tc *scenarioConfig) getJobNodeSelector() (map[string]string, error) {
 		"-o", "json")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, tc.logError(fmt.Errorf("failed to get Job for nodeSelector: %v, output: %s", err, string(output)))
+		return nil, nil, tc.logError(fmt.Errorf("failed to get Job for nodeSelector: %v, output: %s", err, string(output)))
 	}
 
 	var list struct {
 		Items []struct {
+			Metadata struct {
+				Labels map[string]string `json:"labels"`
+			} `json:"metadata"`
 			Spec struct {
 				Template struct {
 					Spec struct {
@@ -807,44 +815,58 @@ func (tc *scenarioConfig) getJobNodeSelector() (map[string]string, error) {
 		} `json:"items"`
 	}
 	if err := json.Unmarshal(output, &list); err != nil {
-		return nil, tc.logError(fmt.Errorf("failed to parse Job JSON for nodeSelector: %v", err))
+		return nil, nil, tc.logError(fmt.Errorf("failed to parse Job JSON for nodeSelector: %v", err))
 	}
 	if len(list.Items) == 0 {
-		return nil, tc.logError(fmt.Errorf("no Job found for job_id=%s in namespace %s", id, namespace))
+		return nil, nil, tc.logError(fmt.Errorf("no Job found for job_id=%s in namespace %s", id, namespace))
 	}
 	sel := list.Items[0].Spec.Template.Spec.NodeSelector
 	if sel == nil {
 		sel = map[string]string{}
 	}
-	return sel, nil
+	labels := list.Items[0].Metadata.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	return sel, labels, nil
 }
 
 // jobSpecShouldNotHaveNodeSelector asserts that eval-hub did not set a nodeSelector on
-// the Job. For queue-backed jobs, Kueue injects the admitted ResourceFlavor's nodeLabels
-// (nvidia.com/gpu.product=<GPU_PRODUCT>) onto the pod template *on admission*, which races
-// with the read. That Kueue-injected label is expected and tolerated; any other selector —
-// including nvidia.com/gpu.product with a value other than GPU_PRODUCT (e.g. a provider's
-// leaked node_selector) — can only come from eval-hub and fails the assertion. This is
-// race-free: eval-hub sets nodeSelector synchronously at Job creation, so a leak is present
-// immediately, whereas Kueue can only ever inject the flavor's own product value.
+// the Job. For queue-backed Kueue Jobs (kueue.x-k8s.io/queue-name set), Kueue injects
+// the admitted ResourceFlavor's nodeLabels (nvidia.com/gpu.product=<GPU_PRODUCT>) onto
+// the pod template *on admission*, which races with the read. That Kueue-injected label
+// is expected and tolerated only for those Jobs. Non-Kueue Jobs (e.g. scenario 1a) must
+// have an empty nodeSelector. Any other selector — including nvidia.com/gpu.product with
+// a value other than GPU_PRODUCT (e.g. a provider's leaked node_selector) — can only
+// come from eval-hub and fails the assertion. This is race-free: eval-hub sets
+// nodeSelector and the queue-name label synchronously at Job creation, so a leak is
+// present immediately, whereas Kueue can only ever inject the flavor's own product value.
 func (tc *scenarioConfig) jobSpecShouldNotHaveNodeSelector() error {
-	sel, err := tc.getJobNodeSelector()
+	sel, labels, err := tc.getJobNodeSelector()
 	if err != nil {
 		return err
 	}
 
 	gpuProduct := os.Getenv("GPU_PRODUCT")
+	queueBacked := labels[kueueQueueNameLabelKey] != ""
 	for k, v := range sel {
-		// Tolerate only the Kueue-injected ResourceFlavor label.
-		if k == gpuProductNodeSelectorKey && gpuProduct != "" && v == gpuProduct {
+		// Tolerate the ResourceFlavor label only on queue-backed Kueue Jobs.
+		if queueBacked && k == gpuProductNodeSelectorKey && gpuProduct != "" && v == gpuProduct {
 			continue
 		}
-		return tc.logError(fmt.Errorf(
-			"expected no eval-hub-set nodeSelector, but found %s=%s (only the Kueue-injected ResourceFlavor label %s=%s is allowed)",
-			k, v, gpuProductNodeSelectorKey, gpuProduct))
+		if queueBacked {
+			return tc.logError(fmt.Errorf(
+				"expected no eval-hub-set nodeSelector, but found %s=%s (only the Kueue-injected ResourceFlavor label %s=%s is allowed)",
+				k, v, gpuProductNodeSelectorKey, gpuProduct))
+		}
+		return tc.logError(fmt.Errorf("expected no nodeSelector, but found %s=%s", k, v))
 	}
 
-	logDebug("Job has no eval-hub-set nodeSelector (Kueue flavor label %s=%s tolerated)\n", gpuProductNodeSelectorKey, gpuProduct)
+	if queueBacked {
+		logDebug("Job has no eval-hub-set nodeSelector (Kueue flavor label %s=%s tolerated)\n", gpuProductNodeSelectorKey, gpuProduct)
+	} else {
+		logDebug("Job has no nodeSelector\n")
+	}
 	return nil
 }
 

--- a/tests/features/gpu_step_definitions_test.go
+++ b/tests/features/gpu_step_definitions_test.go
@@ -768,7 +768,15 @@ func (tc *scenarioConfig) jobSpecShouldHaveNodeSelector(selectorKeyValue string)
 	return nil
 }
 
-func (tc *scenarioConfig) jobSpecShouldNotHaveNodeSelector() error {
+// gpuProductNodeSelectorKey is the node label Kueue copies from an admitted
+// ResourceFlavor's nodeLabels onto the Job's pod template. Both eval-hub (from a
+// provider's node_selector) and Kueue (from the ResourceFlavor) write this same key,
+// so assertions must distinguish them by value.
+const gpuProductNodeSelectorKey = "nvidia.com/gpu.product"
+
+// getJobNodeSelector returns the nodeSelector map from the evaluation job's Kubernetes
+// Job pod template. Returns an empty (non-nil) map when no nodeSelector is set.
+func (tc *scenarioConfig) getJobNodeSelector() (map[string]string, error) {
 	namespace := tc.reqHeaders["X-Tenant"]
 	if namespace == "" {
 		namespace = "test-tenant"
@@ -776,23 +784,67 @@ func (tc *scenarioConfig) jobSpecShouldNotHaveNodeSelector() error {
 
 	id := tc.lastId
 	if id == "" {
-		return tc.logError(fmt.Errorf("no evaluation job ID found"))
+		return nil, tc.logError(fmt.Errorf("no evaluation job ID found"))
 	}
 
 	cmd := exec.Command("oc", "get", "job", "-n", namespace, "-l",
 		fmt.Sprintf("job_id=%s", id),
-		"-o", "jsonpath={.items[0].spec.template.spec.nodeSelector}")
+		"-o", "json")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return tc.logError(fmt.Errorf("failed to get Job nodeSelector: %v, output: %s", err, string(output)))
+		return nil, tc.logError(fmt.Errorf("failed to get Job for nodeSelector: %v, output: %s", err, string(output)))
 	}
 
-	actualValue := strings.TrimSpace(string(output))
-	if actualValue != "" && actualValue != "<nil>" && actualValue != "null" && actualValue != "map[]" {
-		return tc.logError(fmt.Errorf("expected no nodeSelector, but found: %s", actualValue))
+	var list struct {
+		Items []struct {
+			Spec struct {
+				Template struct {
+					Spec struct {
+						NodeSelector map[string]string `json:"nodeSelector"`
+					} `json:"spec"`
+				} `json:"template"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(output, &list); err != nil {
+		return nil, tc.logError(fmt.Errorf("failed to parse Job JSON for nodeSelector: %v", err))
+	}
+	if len(list.Items) == 0 {
+		return nil, tc.logError(fmt.Errorf("no Job found for job_id=%s in namespace %s", id, namespace))
+	}
+	sel := list.Items[0].Spec.Template.Spec.NodeSelector
+	if sel == nil {
+		sel = map[string]string{}
+	}
+	return sel, nil
+}
+
+// jobSpecShouldNotHaveNodeSelector asserts that eval-hub did not set a nodeSelector on
+// the Job. For queue-backed jobs, Kueue injects the admitted ResourceFlavor's nodeLabels
+// (nvidia.com/gpu.product=<GPU_PRODUCT>) onto the pod template *on admission*, which races
+// with the read. That Kueue-injected label is expected and tolerated; any other selector —
+// including nvidia.com/gpu.product with a value other than GPU_PRODUCT (e.g. a provider's
+// leaked node_selector) — can only come from eval-hub and fails the assertion. This is
+// race-free: eval-hub sets nodeSelector synchronously at Job creation, so a leak is present
+// immediately, whereas Kueue can only ever inject the flavor's own product value.
+func (tc *scenarioConfig) jobSpecShouldNotHaveNodeSelector() error {
+	sel, err := tc.getJobNodeSelector()
+	if err != nil {
+		return err
 	}
 
-	logDebug("Job has no nodeSelector as expected\n")
+	gpuProduct := os.Getenv("GPU_PRODUCT")
+	for k, v := range sel {
+		// Tolerate only the Kueue-injected ResourceFlavor label.
+		if k == gpuProductNodeSelectorKey && gpuProduct != "" && v == gpuProduct {
+			continue
+		}
+		return tc.logError(fmt.Errorf(
+			"expected no eval-hub-set nodeSelector, but found %s=%s (only the Kueue-injected ResourceFlavor label %s=%s is allowed)",
+			k, v, gpuProductNodeSelectorKey, gpuProduct))
+	}
+
+	logDebug("Job has no eval-hub-set nodeSelector (Kueue flavor label %s=%s tolerated)\n", gpuProductNodeSelectorKey, gpuProduct)
 	return nil
 }
 


### PR DESCRIPTION
## What and why

Fix for the below failure in 3.6 ea1 tests:
```
The EvalHub product or Kueue integration injects nodeSelector: {"nvidia.com/gpu.product":"NVIDIA-A10G"} into evaluation job pods based on cluster GPU hardware detection, even when the test explicitly expects no nodeSelector or when the nodeSelector conflicts with the ResourceFlavor configuration. This is a behavioral change where the product automatically adds GPU node affinity when GPU hardware is detected.
```

The root cause is that the assertion reads the Job's nodeSelector after Kueue may have injected the ResourceFlavor's nodeLabels (`nvidia.com/gpu.product=<GPU_PRODUCT>`). 
The fix: make "should not have nodeSelector" assert on what eval-hub sets — tolerate the Kueue-injected flavor label, but fail on any selector eval-hub itself would have added (e.g. a provider's leaked node_selector). This is race-free because a value that isn't the flavor label (like DOES_NOT_EXIST) can only come from eval-hub, and eval-hub sets nodeSelector synchronously at Job creation.

Closes #

Assisted-by: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [X] test / ci

## Testing

- [X] Tests added or updated
- [ ] Tested manually

## Breaking changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved GPU scheduling validation for jobs using queues.
  - Confirmed that only the expected GPU product label is retained, while conflicting or unexpected selectors are rejected.
  - Updated checks to account for scheduler-injected GPU labels and distinguish queued jobs from standalone jobs.

- **Documentation**
  - Added comments explaining GPU label injection and the handling of conflicting provider selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->