### PR TITLE
test(fvt): added coverage for open-telco-v1 collection testing

### DIFF
--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -971,7 +971,7 @@ Feature: Collections Endpoint
     When I send a GET request to "/api/v1/evaluations/collections/open-telco-v1"
     Then the response code should be 200
     And the response should contain "category" with value "telecom"
-  
+
   Scenario: Verify out of box collection retrieval - threshold - open-telco-v1
     Given the service is running
     And there is a system collection with id "open-telco-v1"
@@ -994,7 +994,7 @@ Feature: Collections Endpoint
     And the response should contain the value "inspect" at path "$.benchmarks[1].provider_id"
     And the response should contain the value "inspect" at path "$.benchmarks[2].provider_id"
     And the response should contain the value "inspect" at path "$.benchmarks[3].provider_id"
-  
+
   Scenario: Verify out of box collection retrieval - benchmarks thresholds - open-telco-v1
     Given the service is running
     And there is a system collection with id "open-telco-v1"
@@ -1006,7 +1006,7 @@ Feature: Collections Endpoint
     And the response should equal the value "0.70" at path "$.benchmarks[1].pass_criteria.threshold"
     And the response should equal the value "0.25" at path "$.benchmarks[2].pass_criteria.threshold"
     And the response should equal the value "0.45" at path "$.benchmarks[3].pass_criteria.threshold"
-  
+
   Scenario: Verify out of box collection retrieval - weights - open-telco-v1
     Given the service is running
     And there is a system collection with id "open-telco-v1"
@@ -1024,7 +1024,7 @@ Feature: Collections Endpoint
     Then the response code should be 200
     And the response should contain "description"
     And the response should contain the value "GSMA Open-Telco suite" at path "$.description"
-  
+
   Scenario: Verify out of box collection retrieval - tags - open-telco-v1
     Given the service is running
     And there is a system collection with id "open-telco-v1"

--- a/tests/features/collections.feature
+++ b/tests/features/collections.feature
@@ -957,3 +957,82 @@ Feature: Collections Endpoint
       """
     Then the response code should be 400
     And the response should contain the value "request_validation_failed" at path "$.message_code"
+
+  Scenario: Verify out of box collection retrieval - name - open-telco-v1
+    Given the service is running
+    And there is a system collection with id "open-telco-v1"
+    When I send a GET request to "/api/v1/evaluations/collections/open-telco-v1"
+    Then the response code should be 200
+    And the response should contain "name" with value "Open-Telco v1"
+
+  Scenario: Verify out of box collection retrieval - category - open-telco-v1
+    Given the service is running
+    And there is a system collection with id "open-telco-v1"
+    When I send a GET request to "/api/v1/evaluations/collections/open-telco-v1"
+    Then the response code should be 200
+    And the response should contain "category" with value "telecom"
+  
+  Scenario: Verify out of box collection retrieval - threshold - open-telco-v1
+    Given the service is running
+    And there is a system collection with id "open-telco-v1"
+    When I send a GET request to "/api/v1/evaluations/collections/open-telco-v1"
+    Then the response code should be 200
+    And the response should equal the value "0.475" at path "$.pass_criteria.threshold"
+
+  Scenario: Verify out of box collection retrieval - benchmarks - open-telco-v1
+    Given the service is running
+    And there is a system collection with id "open-telco-v1"
+    When I send a GET request to "/api/v1/evaluations/collections/open-telco-v1"
+    Then the response code should be 200
+    And the response should contain "benchmarks"
+    And the array at path "benchmarks" in the response should have length 4
+    And the response should contain the value "inspect/telemath" at path "$.benchmarks[0].id"
+    And the response should contain the value "inspect/teleqna" at path "$.benchmarks[1].id"
+    And the response should contain the value "inspect/telelogs" at path "$.benchmarks[2].id"
+    And the response should contain the value "inspect/3gpp-tsg" at path "$.benchmarks[3].id"
+    And the response should contain the value "inspect" at path "$.benchmarks[0].provider_id"
+    And the response should contain the value "inspect" at path "$.benchmarks[1].provider_id"
+    And the response should contain the value "inspect" at path "$.benchmarks[2].provider_id"
+    And the response should contain the value "inspect" at path "$.benchmarks[3].provider_id"
+  
+  Scenario: Verify out of box collection retrieval - benchmarks thresholds - open-telco-v1
+    Given the service is running
+    And there is a system collection with id "open-telco-v1"
+    When I send a GET request to "/api/v1/evaluations/collections/open-telco-v1"
+    Then the response code should be 200
+    And the response should contain "benchmarks"
+    And the array at path "benchmarks" in the response should have length 4
+    And the response should equal the value "0.50" at path "$.benchmarks[0].pass_criteria.threshold"
+    And the response should equal the value "0.70" at path "$.benchmarks[1].pass_criteria.threshold"
+    And the response should equal the value "0.25" at path "$.benchmarks[2].pass_criteria.threshold"
+    And the response should equal the value "0.45" at path "$.benchmarks[3].pass_criteria.threshold"
+  
+  Scenario: Verify out of box collection retrieval - weights - open-telco-v1
+    Given the service is running
+    And there is a system collection with id "open-telco-v1"
+    When I send a GET request to "/api/v1/evaluations/collections/open-telco-v1"
+    Then the response code should be 200
+    And the response should equal the value "1" at path "$.benchmarks[0].weight"
+    And the response should equal the value "1" at path "$.benchmarks[1].weight"
+    And the response should equal the value "1" at path "$.benchmarks[2].weight"
+    And the response should equal the value "1" at path "$.benchmarks[3].weight"
+
+  Scenario: Verify out of box collection retrieval - description - open-telco-v1
+    Given the service is running
+    And there is a system collection with id "open-telco-v1"
+    When I send a GET request to "/api/v1/evaluations/collections/open-telco-v1"
+    Then the response code should be 200
+    And the response should contain "description"
+    And the response should contain the value "GSMA Open-Telco suite" at path "$.description"
+  
+  Scenario: Verify out of box collection retrieval - tags - open-telco-v1
+    Given the service is running
+    And there is a system collection with id "open-telco-v1"
+    When I send a GET request to "/api/v1/evaluations/collections/open-telco-v1"
+    Then the response code should be 200
+    And the response should contain "tags"
+    And the array at path "tags" in the response should have length 9
+    And the response should contain the value "telecom" at path "$.tags[*]"
+    And the response should contain the value "open-telco" at path "$.tags[*]"
+    And the response should contain the value "inspect" at path "$.tags[*]"
+    And the response should contain the value "vllm" at path "$.tags[*]"

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1968,3 +1968,65 @@ Feature: Evaluation Jobs
     Then the MLflow artifact should exist
     And the MLflow artifact should contain "card_version"
     And the MLflow artifact should contain "schema_version"
+
+  Scenario: Verify Evaluation Jobs Can Use OOB Collections - open-telco-v1
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_oob_open_telco_v1.json"
+    Then the response code should be 202
+    And the response should contain the value "open-telco-v1" at path "$.collection.id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the response should contain the value "open-telco-v1" at path "$.collection.id"
+    And the response should contain the value "Evaluation job is completed" at path "$.status.message.message"
+    And the response should contain the value "completed" at path "$.status.benchmarks[0].status"
+    And the response should contain the value "completed" at path "$.status.benchmarks[1].status"
+    And the response should contain the value "completed" at path "$.status.benchmarks[2].status"
+    And the response should contain the value "completed" at path "$.status.benchmarks[3].status"
+    And the array at path "results.benchmarks" in the response should have length 4
+    And the response should contain the value "inspect/telemath" at path "$.results.benchmarks[*].id"
+    And the response should contain the value "inspect/teleqna" at path "$.results.benchmarks[*].id"
+    And the response should contain the value "inspect/telelogs" at path "$.results.benchmarks[*].id"
+    And the response should contain the value "inspect/3gpp-tsg" at path "$.results.benchmarks[*].id"
+    And the response should equal the value "5" at path "$.collection.benchmarks[0].parameters.num_examples"
+    And the response should equal the value "5" at path "$.collection.benchmarks[1].parameters.num_examples"
+    And the response should equal the value "5" at path "$.collection.benchmarks[2].parameters.num_examples"
+    And the response should equal the value "5" at path "$.collection.benchmarks[3].parameters.num_examples"
+    And the response should contain "results"
+    And the response should contain the value "telemath_scorer/accuracy" at path "$.results.benchmarks[?(@.id=='inspect/telemath')].metrics[*].name"
+    And the response should contain the value "choice/accuracy" at path "$.results.benchmarks[?(@.id=='inspect/teleqna')].metrics[*].name"
+    And the response should contain the value "telelogs_scorer/accuracy" at path "$.results.benchmarks[?(@.id=='inspect/telelogs')].metrics[*].name"
+    And the response should contain the value "pattern/accuracy" at path "$.results.benchmarks[?(@.id=='inspect/3gpp-tsg')].metrics[*].name"
+    # TODO: Add metric value validations once a job completes successfully on a cluster with the telco inspect runner - https://redhat.atlassian.net/browse/RHOAIENG-87955
+
+  @kueue
+  Scenario: Create evaluation job with queue and collection - open-telco-v1
+    Given the service is running
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_kueue_oob_open_telco_v1.json"
+    Then the response code should be 202
+    And the response should contain the value "kueue" at path "$.collection.benchmarks[0].hardware_config.queue.kind"
+    And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[0].hardware_config.queue.name"
+    And the response should contain the value "open-telco-v1" at path "$.collection.id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    And the response should contain the value "completed" at path "$.status.state"
+    And the response should contain the value "open-telco-v1" at path "$.collection.id"
+    And the response should contain the value "kueue" at path "$.collection.benchmarks[0].hardware_config.queue.kind"
+    And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[0].hardware_config.queue.name"
+  
+  @mlflow
+  Scenario: Card generated for completed job with collection - open-telco-v1
+    Given the service is running
+    And there is a system collection with id "open-telco-v1"
+    When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evalcard_collection_telco.json"
+    Then the response code should be 202
+    And the "resource.id" field in the response should be saved as "value:job_id"
+    And the "resource.mlflow_experiment_id" field in the response should be saved as "value:mlflow_experiment_id"
+    And I wait for the evaluation job status to be "completed"
+    When I send a GET request to "/api/v1/evaluations/jobs/{id}"
+    Then the response code should be 200
+    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    Then the MLflow artifact should exist
+    And the MLflow artifact should contain "context.collection_id"
+    And the MLflow artifact should contain the value "open-telco-v1" at path "$.context.collection_id"

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -2026,7 +2026,7 @@ Feature: Evaluation Jobs
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[2].hardware_config.queue.name"
     And the response should contain the value "kueue" at path "$.collection.benchmarks[3].hardware_config.queue.kind"
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[3].hardware_config.queue.name"
-  
+
   @mlflow
   Scenario: Card generated for completed job with collection - open-telco-v1
     Given the service is running

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -2006,6 +2006,12 @@ Feature: Evaluation Jobs
     Then the response code should be 202
     And the response should contain the value "kueue" at path "$.collection.benchmarks[0].hardware_config.queue.kind"
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[0].hardware_config.queue.name"
+    And the response should contain the value "kueue" at path "$.collection.benchmarks[1].hardware_config.queue.kind"
+    And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[1].hardware_config.queue.name"
+    And the response should contain the value "kueue" at path "$.collection.benchmarks[2].hardware_config.queue.kind"
+    And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[2].hardware_config.queue.name"
+    And the response should contain the value "kueue" at path "$.collection.benchmarks[3].hardware_config.queue.kind"
+    And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[3].hardware_config.queue.name"
     And the response should contain the value "open-telco-v1" at path "$.collection.id"
     And I wait for the evaluation job status to be "completed"
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
@@ -2014,6 +2020,12 @@ Feature: Evaluation Jobs
     And the response should contain the value "open-telco-v1" at path "$.collection.id"
     And the response should contain the value "kueue" at path "$.collection.benchmarks[0].hardware_config.queue.kind"
     And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[0].hardware_config.queue.name"
+    And the response should contain the value "kueue" at path "$.collection.benchmarks[1].hardware_config.queue.kind"
+    And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[1].hardware_config.queue.name"
+    And the response should contain the value "kueue" at path "$.collection.benchmarks[2].hardware_config.queue.kind"
+    And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[2].hardware_config.queue.name"
+    And the response should contain the value "kueue" at path "$.collection.benchmarks[3].hardware_config.queue.kind"
+    And the response should contain the value "{{env:QUEUE_NAME|user-queue}}" at path "$.collection.benchmarks[3].hardware_config.queue.name"
   
   @mlflow
   Scenario: Card generated for completed job with collection - open-telco-v1

--- a/tests/features/test_data/evalcard_collection_telco.jsonnet
+++ b/tests/features/test_data/evalcard_collection_telco.jsonnet
@@ -1,0 +1,21 @@
+local test = import 'test.libsonnet';
+
+test.oobCollectionRefJobWithBenchmarks(
+  'evalcard_collection_telco_test',
+  'open-telco-v1',
+  [
+    test.benchmark('inspect/telemath', 'inspect', { num_examples: 5 }),
+    test.benchmark('inspect/teleqna', 'inspect', { num_examples: 5 }),
+    test.benchmark('inspect/telelogs', 'inspect', { num_examples: 5 }),
+    test.benchmark('inspect/3gpp-tsg', 'inspect', { num_examples: 5 }),
+  ],
+) + {
+  description: 'Job for card testing with telco collection',
+  tags: ['evalcard', 'collection', 'telco'],
+  experiment: {
+    name: 'evalcard_collection_telco_experiment',
+  },
+  pass_criteria: {
+    threshold: 0.5,
+  },
+}

--- a/tests/features/test_data/evaluation_job_kueue_oob_open_telco_v1.jsonnet
+++ b/tests/features/test_data/evaluation_job_kueue_oob_open_telco_v1.jsonnet
@@ -1,0 +1,31 @@
+local test = import 'test.libsonnet';
+
+{
+  name: 'test-evaluation-job-queue-collection',
+  collection: {
+    id: 'open-telco-v1',
+    benchmarks: [
+      test.benchmark('inspect/telemath', 'inspect', { num_examples: 5 }) + {
+        hardware_config: {
+          queue: test.queueConfig(),
+        },
+      },
+      test.benchmark('inspect/teleqna', 'inspect', { num_examples: 5 }) + {
+        hardware_config: {
+          queue: test.queueConfig(),
+        },
+      },
+      test.benchmark('inspect/telelogs', 'inspect', { num_examples: 5 }) + {
+        hardware_config: {
+          queue: test.queueConfig(),
+        },
+      },
+      test.benchmark('inspect/3gpp-tsg', 'inspect', { num_examples: 5 }) + {
+        hardware_config: {
+          queue: test.queueConfig(),
+        },
+      },
+    ],
+  },
+  model: test.model(),
+}

--- a/tests/features/test_data/evaluation_job_oob_open_telco_v1.jsonnet
+++ b/tests/features/test_data/evaluation_job_oob_open_telco_v1.jsonnet
@@ -1,0 +1,12 @@
+local test = import 'test.libsonnet';
+
+test.oobCollectionRefJobWithBenchmarks(
+  'test-evaluation-job-oob-collection',
+  'open-telco-v1',
+  [
+    test.benchmark('inspect/telemath', 'inspect', { num_examples: 5 }),
+    test.benchmark('inspect/teleqna', 'inspect', { num_examples: 5 }),
+    test.benchmark('inspect/telelogs', 'inspect', { num_examples: 5 }),
+    test.benchmark('inspect/3gpp-tsg', 'inspect', { num_examples: 5 }),
+  ],
+)


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->
Added 8 collection retrieval scenarios (name, category, threshold,benchmarks, benchmark thresholds, weights, description, tags) and 3 evaluation job scenarios (OOB collection, kueue, MLflow card) for the open-telco-v1 telco collection added in RHOAI 3.6EA1.


Closes # https://redhat.atlassian.net/browse/RHOAIENG-84378

Assisted-by: <!-- Cursor, Claude etc -->: Claude

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [X] Tests added or updated
- [X] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->

Note - 
1. Tested on the `autorag cluster` - https://redhat.atlassian.net/browse/RHOAIENG-87955
2. Opened an issue to add to the `dev-pool-connect` cluster - https://gitlab.cee.redhat.com/atris/shepard/-/work_items/209



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive acceptance coverage for the out-of-the-box `open-telco-v1` evaluation collection.
  - Validated collection metadata, thresholds, weights, benchmarks, providers, descriptions, and required tags.
  - Verified successful evaluation runs, benchmark metrics, evaluation card metadata, and queue settings.
  - Added test configurations covering four inspection benchmarks with configurable example limits and queue behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->