### PR TITLE
fix(config): align truthfulqa_mc1 agent text with acc metric

### DIFF
--- a/config/providers/lm_evaluation_harness.yaml
+++ b/config/providers/lm_evaluation_harness.yaml
@@ -3471,7 +3471,7 @@ benchmarks:
   pass_criteria:
     threshold: 0.25
   agent:
-    result_interpretation: Multiple-choice accuracy (mc1) on multiple-choice questions; higher is better.
+    result_interpretation: Multiple-choice accuracy (acc) on multiple-choice questions; higher is better.
     score_ranges:
     - range: 0.0-0.25
       meaning: Below random chance for 4-choice questions


### PR DESCRIPTION
## Summary

- Update `truthfulqa_mc1` `agent.result_interpretation` to reference `acc` instead of `mc1`, matching the `primary_score.metric` change from #930.

## Context

Follow-up to the lm-eval metric alignment for `safety-and-fairness-v1`. The metric was renamed to `acc`, but the agent guidance text still said `mc1`, which misleads MCP/agent consumers.

## Test plan

- [ ] Config validation passes (`make validate-configs` / CI)
- [ ] No functional change to job scoring — agent/MCP text only


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the TruthfulQA benchmark results description to reference the accurate accuracy metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->