### PR TITLE
test: pin anyio<4.15 for MLflow integration test venv

### DIFF
--- a/tests/mlflow/scripts/download_mlflow.sh
+++ b/tests/mlflow/scripts/download_mlflow.sh
@@ -57,10 +57,14 @@ if ! command -v uv >/dev/null 2>&1; then
     exit 1
 fi
 
+# anyio 4.15+ lazy-imports break starlette WSGI in mlflow server (/health returns 500).
+# See https://anyio.readthedocs.io/en/stable/versionhistory.html#id1
+ANYIO_PIN="anyio<4.15"
+
 if [[ -n "${REQUESTED_VERSION}" ]]; then
-    uv pip install --python "${PYTHON}" "mlflow==${REQUESTED_VERSION}"
+    uv pip install --python "${PYTHON}" "mlflow==${REQUESTED_VERSION}" "${ANYIO_PIN}"
 else
-    uv pip install --python "${PYTHON}" mlflow
+    uv pip install --python "${PYTHON}" mlflow "${ANYIO_PIN}"
 fi
 
 if [ -x "${VENV_DIR}/bin/mlflow" ]; then


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->
TestMLFlowIntegration installs MLflow into tests/mlflow/.venv without a lockfile. 
Recent anyio 4.15 releases use lazy submodule imports that break starlette WSGI in the mlflow server, so GET /health returns 500 and make start-mlflow times out after 20s.
Pin anyio<4.15 alongside mlflow in download_mlflow.sh so CI and local integration runs resolve a compatible anyio (e.g. 4.14.x).

Closes #

Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->
