### PR TITLE
feat(metrics): add 7 evaluation-domain OTEL and Prometheus metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.22.0 // indirect

--- a/internal/eval_hub/handlers/evaluation_metrics.go
+++ b/internal/eval_hub/handlers/evaluation_metrics.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/metrics"
 	"github.com/eval-hub/eval-hub/pkg/api"
@@ -16,5 +17,64 @@ func recordEvaluationJobTerminalStateAfterUpdate(
 	if err != nil || job == nil || job.Status == nil {
 		return
 	}
-	metrics.RecordEvaluationJobTerminalState(ctx, previousState, job.Status.State)
+	newState := job.Status.State
+	metrics.RecordEvaluationJobTerminalState(ctx, previousState, newState)
+
+	if previousState == newState {
+		return
+	}
+
+	collectionID := jobCollectionID(&job.EvaluationJobConfig)
+	providerIDs := jobProviderIDs(nil, &job.EvaluationJobConfig)
+
+	for _, pid := range providerIDs {
+		metrics.RecordEvaluationJobStateTransition(ctx, pid, collectionID, string(newState))
+	}
+
+	if previousState == api.OverallStatePending && newState == api.OverallStateRunning {
+		metrics.DecQueueDepth(ctx)
+	}
+
+	if newState.IsTerminalState() {
+		metrics.DecActiveJobs(ctx)
+		if previousState == api.OverallStatePending {
+			metrics.DecQueueDepth(ctx)
+		}
+
+		durationSeconds := time.Since(job.Resource.CreatedAt).Seconds()
+		for _, pid := range providerIDs {
+			metrics.ObserveEvaluationJobDuration(ctx, pid, collectionID, durationSeconds)
+		}
+
+		recordBenchmarkDurations(ctx, job)
+
+		if newState == api.OverallStateFailed || newState == api.OverallStatePartiallyFailed {
+			for _, pid := range providerIDs {
+				metrics.RecordEvaluationError(ctx, "job_failed", pid)
+			}
+		}
+	}
+}
+
+func recordBenchmarkDurations(ctx context.Context, job *api.EvaluationJobResource) {
+	if job.Status == nil {
+		return
+	}
+	for _, bs := range job.Status.Benchmarks {
+		if bs.StartedAt == "" || bs.CompletedAt == "" {
+			continue
+		}
+		started, err := api.DateTimeFromString(bs.StartedAt)
+		if err != nil {
+			continue
+		}
+		completed, err := api.DateTimeFromString(bs.CompletedAt)
+		if err != nil {
+			continue
+		}
+		duration := completed.Sub(started).Seconds()
+		if duration > 0 {
+			metrics.ObserveBenchmarkDuration(ctx, bs.ID, bs.ProviderID, duration)
+		}
+	}
 }

--- a/internal/eval_hub/handlers/evaluation_metrics.go
+++ b/internal/eval_hub/handlers/evaluation_metrics.go
@@ -26,6 +26,15 @@ func recordEvaluationJobTerminalStateAfterUpdate(
 
 	collectionID := jobCollectionID(&job.EvaluationJobConfig)
 	providerIDs := jobProviderIDs(nil, &job.EvaluationJobConfig)
+	if len(providerIDs) == 0 && job.Status != nil {
+		seen := make(map[string]struct{})
+		for _, bs := range job.Status.Benchmarks {
+			if _, ok := seen[bs.ProviderID]; !ok {
+				seen[bs.ProviderID] = struct{}{}
+				providerIDs = append(providerIDs, bs.ProviderID)
+			}
+		}
+	}
 
 	for _, pid := range providerIDs {
 		metrics.RecordEvaluationJobStateTransition(ctx, pid, collectionID, string(newState))

--- a/internal/eval_hub/handlers/evaluation_metrics.go
+++ b/internal/eval_hub/handlers/evaluation_metrics.go
@@ -44,7 +44,7 @@ func recordEvaluationJobTerminalStateAfterUpdate(
 		metrics.DecQueueDepth(ctx)
 	}
 
-	if newState.IsTerminalState() {
+	if newState.IsTerminalState() && !previousState.IsTerminalState() {
 		metrics.DecActiveJobs(ctx)
 		if previousState == api.OverallStatePending {
 			metrics.DecQueueDepth(ctx)

--- a/internal/eval_hub/handlers/evaluations.go
+++ b/internal/eval_hub/handlers/evaluations.go
@@ -352,15 +352,18 @@ func (h *Handlers) HandleCreateEvaluation(ctx *executioncontext.ExecutionContext
 						MessageCode: constants.MessageCodeEvaluationJobFailed,
 					}, api.MessageOriginServer)
 					metrics.RecordEvaluationJobRuntimeStartFailed(ctx.Ctx, h.runtimeName())
-					metrics.RecordEvaluationJobTerminalState(ctx.Ctx, api.OverallStatePending, state)
 					for _, pid := range providerIDs {
-						metrics.RecordEvaluationJobStateTransition(ctx.Ctx, pid, collectionID, string(state))
 						metrics.RecordEvaluationError(ctx.Ctx, "runtime_start_failed", pid)
 					}
-					metrics.DecActiveJobs(ctx.Ctx)
-					metrics.DecQueueDepth(ctx.Ctx)
 					if err := storage.WithContext(runtimeCtx).UpdateEvaluationJobStatus(job.Resource.ID, state, message); err != nil {
 						ctx.Logger.Error("Failed to update evaluation status", "error", err, "job_id", job.Resource.ID)
+					} else {
+						metrics.RecordEvaluationJobTerminalState(ctx.Ctx, api.OverallStatePending, state)
+						for _, pid := range providerIDs {
+							metrics.RecordEvaluationJobStateTransition(ctx.Ctx, pid, collectionID, string(state))
+						}
+						metrics.DecActiveJobs(ctx.Ctx)
+						metrics.DecQueueDepth(ctx.Ctx)
 					}
 					// return the first error encountered
 					w.Error(runErr, ctx.RequestID)
@@ -733,7 +736,7 @@ func (h *Handlers) HandleCancelEvaluation(ctx *executioncontext.ExecutionContext
 				}
 				metrics.RecordEvaluationJobCancelled(ctx.Ctx)
 				metrics.RecordEvaluationJobTerminalState(ctx.Ctx, previousState, api.OverallStateCancelled)
-				if jobErr == nil && job != nil {
+				if jobErr == nil && job != nil && !previousState.IsTerminalState() {
 					cID := jobCollectionID(&job.EvaluationJobConfig)
 					for _, pid := range jobProviderIDs(nil, &job.EvaluationJobConfig) {
 						metrics.RecordEvaluationJobStateTransition(ctx.Ctx, pid, cID, string(api.OverallStateCancelled))
@@ -761,10 +764,15 @@ func jobCollectionID(cfg *api.EvaluationJobConfig) string {
 	return ""
 }
 
-// jobProviderIDs returns deduplicated provider IDs from benchmarks or the job config's inline benchmarks.
+// jobProviderIDs returns deduplicated provider IDs from benchmarks, the job
+// config's inline benchmarks, or the collection override list (for
+// collection-backed jobs where cfg.Benchmarks is empty).
 func jobProviderIDs(benchmarks []api.EvaluationBenchmarkConfig, cfg *api.EvaluationJobConfig) []string {
 	if len(benchmarks) == 0 && cfg != nil {
 		benchmarks = cfg.Benchmarks
+	}
+	if len(benchmarks) == 0 && cfg != nil && cfg.Collection != nil {
+		benchmarks = cfg.Collection.Benchmarks
 	}
 	seen := make(map[string]struct{}, len(benchmarks))
 	var ids []string

--- a/internal/eval_hub/handlers/evaluations.go
+++ b/internal/eval_hub/handlers/evaluations.go
@@ -332,6 +332,14 @@ func (h *Handlers) HandleCreateEvaluation(ctx *executioncontext.ExecutionContext
 
 	metrics.RecordEvaluationJobCreated(ctx.Ctx, h.runtimeName())
 
+	collectionID := jobCollectionID(evaluation)
+	providerIDs := jobProviderIDs(benchmarks, evaluation)
+	for _, pid := range providerIDs {
+		metrics.RecordEvaluationJobStateTransition(ctx.Ctx, pid, collectionID, string(api.OverallStatePending))
+	}
+	metrics.IncActiveJobs(ctx.Ctx)
+	metrics.IncQueueDepth(ctx.Ctx)
+
 	_ = h.withSpan(
 		ctx,
 		func(runtimeCtx context.Context) error {
@@ -345,6 +353,12 @@ func (h *Handlers) HandleCreateEvaluation(ctx *executioncontext.ExecutionContext
 					}, api.MessageOriginServer)
 					metrics.RecordEvaluationJobRuntimeStartFailed(ctx.Ctx, h.runtimeName())
 					metrics.RecordEvaluationJobTerminalState(ctx.Ctx, api.OverallStatePending, state)
+					for _, pid := range providerIDs {
+						metrics.RecordEvaluationJobStateTransition(ctx.Ctx, pid, collectionID, string(state))
+						metrics.RecordEvaluationError(ctx.Ctx, "runtime_start_failed", pid)
+					}
+					metrics.DecActiveJobs(ctx.Ctx)
+					metrics.DecQueueDepth(ctx.Ctx)
 					if err := storage.WithContext(runtimeCtx).UpdateEvaluationJobStatus(job.Resource.ID, state, message); err != nil {
 						ctx.Logger.Error("Failed to update evaluation status", "error", err, "job_id", job.Resource.ID)
 					}
@@ -719,6 +733,16 @@ func (h *Handlers) HandleCancelEvaluation(ctx *executioncontext.ExecutionContext
 				}
 				metrics.RecordEvaluationJobCancelled(ctx.Ctx)
 				metrics.RecordEvaluationJobTerminalState(ctx.Ctx, previousState, api.OverallStateCancelled)
+				if jobErr == nil && job != nil {
+					cID := jobCollectionID(&job.EvaluationJobConfig)
+					for _, pid := range jobProviderIDs(nil, &job.EvaluationJobConfig) {
+						metrics.RecordEvaluationJobStateTransition(ctx.Ctx, pid, cID, string(api.OverallStateCancelled))
+					}
+					metrics.DecActiveJobs(ctx.Ctx)
+					if previousState == api.OverallStatePending {
+						metrics.DecQueueDepth(ctx.Ctx)
+					}
+				}
 			}
 			w.WriteJSON(nil, 204)
 			return nil
@@ -727,4 +751,28 @@ func (h *Handlers) HandleCancelEvaluation(ctx *executioncontext.ExecutionContext
 		operation,
 		"job.id", evaluationJobID,
 	)
+}
+
+// jobCollectionID returns the collection ID from the job config, or empty string.
+func jobCollectionID(cfg *api.EvaluationJobConfig) string {
+	if cfg != nil && cfg.Collection != nil {
+		return cfg.Collection.ID
+	}
+	return ""
+}
+
+// jobProviderIDs returns deduplicated provider IDs from benchmarks or the job config's inline benchmarks.
+func jobProviderIDs(benchmarks []api.EvaluationBenchmarkConfig, cfg *api.EvaluationJobConfig) []string {
+	if len(benchmarks) == 0 && cfg != nil {
+		benchmarks = cfg.Benchmarks
+	}
+	seen := make(map[string]struct{}, len(benchmarks))
+	var ids []string
+	for _, b := range benchmarks {
+		if _, ok := seen[b.ProviderID]; !ok {
+			seen[b.ProviderID] = struct{}{}
+			ids = append(ids, b.ProviderID)
+		}
+	}
+	return ids
 }

--- a/internal/eval_hub/metrics/evaluation.go
+++ b/internal/eval_hub/metrics/evaluation.go
@@ -1,49 +1,100 @@
 package metrics
 
-import "context"
+import (
+	"context"
 
-// RecordEvaluationJobStateTransition increments evalhub_evaluation_jobs_total
-// for a state transition (pending, running, completed, failed, cancelled, partially_failed).
-func RecordEvaluationJobStateTransition(_ context.Context, provider, collection, status string) {
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// RecordEvaluationJobStateTransition increments evalhub_evaluation_jobs_total (Prometheus)
+// and evalhub.eval.job_state_transitions (OTEL) for a state transition.
+func RecordEvaluationJobStateTransition(ctx context.Context, provider, collection, status string) {
 	promEvalJobsTotal.WithLabelValues(provider, collection, status).Inc()
+	if otelEvalJobStateTransitions != nil {
+		otelEvalJobStateTransitions.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("provider", provider),
+			attribute.String("collection", collection),
+			attribute.String("status", status),
+		))
+	}
 }
 
 // ObserveEvaluationJobDuration records the wall-clock duration from job creation to terminal state.
-func ObserveEvaluationJobDuration(_ context.Context, provider, collection string, durationSeconds float64) {
+func ObserveEvaluationJobDuration(ctx context.Context, provider, collection string, durationSeconds float64) {
 	promEvalJobDuration.WithLabelValues(provider, collection).Observe(durationSeconds)
+	if otelEvalJobDuration != nil {
+		otelEvalJobDuration.Record(ctx, durationSeconds, metric.WithAttributes(
+			attribute.String("provider", provider),
+			attribute.String("collection", collection),
+		))
+	}
 }
 
 // IncActiveJobs increments the active-jobs gauge (call on job creation).
-func IncActiveJobs(_ context.Context) {
+func IncActiveJobs(ctx context.Context) {
 	promEvalJobsActive.Inc()
+	if otelEvalActiveJobs != nil {
+		otelEvalActiveJobs.Add(ctx, 1)
+	}
 }
 
 // DecActiveJobs decrements the active-jobs gauge (call on terminal state or cancellation).
-func DecActiveJobs(_ context.Context) {
+func DecActiveJobs(ctx context.Context) {
 	promEvalJobsActive.Dec()
+	if otelEvalActiveJobs != nil {
+		otelEvalActiveJobs.Add(ctx, -1)
+	}
 }
 
 // IncQueueDepth increments the queue-depth gauge (call when a job enters pending).
-func IncQueueDepth(_ context.Context) {
+func IncQueueDepth(ctx context.Context) {
 	promEvalQueueDepth.Inc()
+	if otelEvalQueueDepth != nil {
+		otelEvalQueueDepth.Add(ctx, 1)
+	}
 }
 
 // DecQueueDepth decrements the queue-depth gauge (call when a pending job starts running or reaches terminal state).
-func DecQueueDepth(_ context.Context) {
+func DecQueueDepth(ctx context.Context) {
 	promEvalQueueDepth.Dec()
+	if otelEvalQueueDepth != nil {
+		otelEvalQueueDepth.Add(ctx, -1)
+	}
 }
 
-// RecordEvaluationError increments evalhub_evaluation_errors_total with the given error_type and provider.
-func RecordEvaluationError(_ context.Context, errorType, provider string) {
+// RecordEvaluationError increments evalhub_evaluation_errors_total (Prometheus)
+// and evalhub.eval.errors (OTEL) with the given error_type and provider.
+func RecordEvaluationError(ctx context.Context, errorType, provider string) {
 	promEvalErrorsTotal.WithLabelValues(errorType, provider).Inc()
+	if otelEvalErrors != nil {
+		otelEvalErrors.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("error_type", errorType),
+			attribute.String("provider", provider),
+		))
+	}
 }
 
 // ObserveBenchmarkDuration records per-benchmark execution duration.
-func ObserveBenchmarkDuration(_ context.Context, benchmarkName, provider string, durationSeconds float64) {
+func ObserveBenchmarkDuration(ctx context.Context, benchmarkName, provider string, durationSeconds float64) {
 	promBenchmarkDuration.WithLabelValues(benchmarkName, provider).Observe(durationSeconds)
+	if otelEvalBenchmarkDuration != nil {
+		otelEvalBenchmarkDuration.Record(ctx, durationSeconds, metric.WithAttributes(
+			attribute.String("benchmark_name", benchmarkName),
+			attribute.String("provider", provider),
+		))
+	}
 }
 
 // ObserveAPIRequestDuration records API request duration with enriched domain labels.
-func ObserveAPIRequestDuration(_ context.Context, endpoint, method, collection, provider string, durationSeconds float64) {
+func ObserveAPIRequestDuration(ctx context.Context, endpoint, method, collection, provider string, durationSeconds float64) {
 	promAPIRequestDuration.WithLabelValues(endpoint, method, collection, provider).Observe(durationSeconds)
+	if otelEvalAPIRequestDuration != nil {
+		otelEvalAPIRequestDuration.Record(ctx, durationSeconds, metric.WithAttributes(
+			attribute.String("endpoint", endpoint),
+			attribute.String("method", method),
+			attribute.String("collection", collection),
+			attribute.String("provider", provider),
+		))
+	}
 }

--- a/internal/eval_hub/metrics/evaluation.go
+++ b/internal/eval_hub/metrics/evaluation.go
@@ -1,0 +1,49 @@
+package metrics
+
+import "context"
+
+// RecordEvaluationJobStateTransition increments evalhub_evaluation_jobs_total
+// for a state transition (pending, running, completed, failed, cancelled, partially_failed).
+func RecordEvaluationJobStateTransition(_ context.Context, provider, collection, status string) {
+	promEvalJobsTotal.WithLabelValues(provider, collection, status).Inc()
+}
+
+// ObserveEvaluationJobDuration records the wall-clock duration from job creation to terminal state.
+func ObserveEvaluationJobDuration(_ context.Context, provider, collection string, durationSeconds float64) {
+	promEvalJobDuration.WithLabelValues(provider, collection).Observe(durationSeconds)
+}
+
+// IncActiveJobs increments the active-jobs gauge (call on job creation).
+func IncActiveJobs(_ context.Context) {
+	promEvalJobsActive.Inc()
+}
+
+// DecActiveJobs decrements the active-jobs gauge (call on terminal state or cancellation).
+func DecActiveJobs(_ context.Context) {
+	promEvalJobsActive.Dec()
+}
+
+// IncQueueDepth increments the queue-depth gauge (call when a job enters pending).
+func IncQueueDepth(_ context.Context) {
+	promEvalQueueDepth.Inc()
+}
+
+// DecQueueDepth decrements the queue-depth gauge (call when a pending job starts running or reaches terminal state).
+func DecQueueDepth(_ context.Context) {
+	promEvalQueueDepth.Dec()
+}
+
+// RecordEvaluationError increments evalhub_evaluation_errors_total with the given error_type and provider.
+func RecordEvaluationError(_ context.Context, errorType, provider string) {
+	promEvalErrorsTotal.WithLabelValues(errorType, provider).Inc()
+}
+
+// ObserveBenchmarkDuration records per-benchmark execution duration.
+func ObserveBenchmarkDuration(_ context.Context, benchmarkName, provider string, durationSeconds float64) {
+	promBenchmarkDuration.WithLabelValues(benchmarkName, provider).Observe(durationSeconds)
+}
+
+// ObserveAPIRequestDuration records API request duration with enriched domain labels.
+func ObserveAPIRequestDuration(_ context.Context, endpoint, method, collection, provider string, durationSeconds float64) {
+	promAPIRequestDuration.WithLabelValues(endpoint, method, collection, provider).Observe(durationSeconds)
+}

--- a/internal/eval_hub/metrics/metrics.go
+++ b/internal/eval_hub/metrics/metrics.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -11,10 +13,53 @@ import (
 
 const instrumentationScope = "github.com/eval-hub/eval-hub/internal/eval_hub/metrics"
 
+// Existing OTEL-only instruments (dot-naming convention).
 var (
 	evaluationJobsTotal         metric.Int64Counter
 	evaluationJobCompletions    metric.Int64Counter
 	benchmarkRuntimeErrorsTotal metric.Int64Counter
+)
+
+// Prometheus-native evaluation-domain metrics.
+// Labels are bounded by provider/collection configuration (tens, not thousands).
+var (
+	promEvalJobsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "evalhub_evaluation_jobs_total",
+		Help: "Total evaluation job state transitions by provider, collection, and status.",
+	}, []string{"provider", "collection", "status"})
+
+	promEvalJobDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "evalhub_evaluation_job_duration_seconds",
+		Help:    "Wall-clock duration from job creation to terminal state.",
+		Buckets: prometheus.ExponentialBuckets(1, 2, 14),
+	}, []string{"provider", "collection"})
+
+	promEvalJobsActive = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "evalhub_evaluation_jobs_active",
+		Help: "Current count of non-terminal evaluation jobs (pending + running).",
+	})
+
+	promEvalQueueDepth = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "evalhub_evaluation_queue_depth",
+		Help: "Current count of evaluation jobs in pending state.",
+	})
+
+	promEvalErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "evalhub_evaluation_errors_total",
+		Help: "Evaluation errors by type and provider.",
+	}, []string{"error_type", "provider"})
+
+	promBenchmarkDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "evalhub_benchmark_duration_seconds",
+		Help:    "Per-benchmark execution duration.",
+		Buckets: prometheus.ExponentialBuckets(1, 2, 14),
+	}, []string{"benchmark_name", "provider"})
+
+	promAPIRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "evalhub_api_request_duration_seconds",
+		Help:    "API request duration with domain-enriched labels.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"endpoint", "method", "collection", "provider"})
 )
 
 // Init creates OTEL evaluation job instruments. Call once after otel.SetupOTEL configures the global MeterProvider.
@@ -23,7 +68,7 @@ func Init() error {
 
 	var err error
 	evaluationJobsTotal, err = meter.Int64Counter(
-		"evalhub.evaluation_jobs",
+		"evalhub.evaluation_job_actions",
 		metric.WithDescription("Evaluation job lifecycle events"),
 	)
 	if err != nil {

--- a/internal/eval_hub/metrics/metrics.go
+++ b/internal/eval_hub/metrics/metrics.go
@@ -13,11 +13,29 @@ import (
 
 const instrumentationScope = "github.com/eval-hub/eval-hub/internal/eval_hub/metrics"
 
+// Separate OTEL meter scope for evaluation-domain instruments.
+// Distinct from instrumentationScope so the bridged Prometheus names
+// (evalhub_eval_*) don't collide with the promauto names (evalhub_evaluation_*).
+const evaluationInstrumentationScope = "evalhub.evaluation"
+
 // Existing OTEL-only instruments (dot-naming convention).
 var (
 	evaluationJobsTotal         metric.Int64Counter
 	evaluationJobCompletions    metric.Int64Counter
 	benchmarkRuntimeErrorsTotal metric.Int64Counter
+)
+
+// OTEL evaluation-domain instruments for OTLP export.
+// These use the evaluationInstrumentationScope meter so their bridged
+// Prometheus names (evalhub_eval_*) are distinct from the promauto names.
+var (
+	otelEvalJobStateTransitions metric.Int64Counter
+	otelEvalJobDuration         metric.Float64Histogram
+	otelEvalActiveJobs          metric.Int64UpDownCounter
+	otelEvalQueueDepth          metric.Int64UpDownCounter
+	otelEvalErrors              metric.Int64Counter
+	otelEvalBenchmarkDuration   metric.Float64Histogram
+	otelEvalAPIRequestDuration  metric.Float64Histogram
 )
 
 // Prometheus-native evaluation-domain metrics.
@@ -91,7 +109,73 @@ func Init() error {
 		return err
 	}
 
-	return initHTTPMetrics(meter)
+	if err := initHTTPMetrics(meter); err != nil {
+		return err
+	}
+
+	return initEvaluationOTELMetrics()
+}
+
+func initEvaluationOTELMetrics() error {
+	evalMeter := otel.Meter(evaluationInstrumentationScope)
+
+	var err error
+	otelEvalJobStateTransitions, err = evalMeter.Int64Counter(
+		"evalhub.eval.job_state_transitions",
+		metric.WithDescription("Evaluation job state transitions by provider, collection, and status"),
+	)
+	if err != nil {
+		return err
+	}
+
+	otelEvalJobDuration, err = evalMeter.Float64Histogram(
+		"evalhub.eval.job_duration",
+		metric.WithDescription("Wall-clock duration from job creation to terminal state"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return err
+	}
+
+	otelEvalActiveJobs, err = evalMeter.Int64UpDownCounter(
+		"evalhub.eval.active_jobs",
+		metric.WithDescription("Current count of non-terminal evaluation jobs (pending + running)"),
+	)
+	if err != nil {
+		return err
+	}
+
+	otelEvalQueueDepth, err = evalMeter.Int64UpDownCounter(
+		"evalhub.eval.queue_depth",
+		metric.WithDescription("Current count of evaluation jobs in pending state"),
+	)
+	if err != nil {
+		return err
+	}
+
+	otelEvalErrors, err = evalMeter.Int64Counter(
+		"evalhub.eval.errors",
+		metric.WithDescription("Evaluation errors by type and provider"),
+	)
+	if err != nil {
+		return err
+	}
+
+	otelEvalBenchmarkDuration, err = evalMeter.Float64Histogram(
+		"evalhub.eval.benchmark_duration",
+		metric.WithDescription("Per-benchmark execution duration"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return err
+	}
+
+	otelEvalAPIRequestDuration, err = evalMeter.Float64Histogram(
+		"evalhub.eval.api_request_duration",
+		metric.WithDescription("API request duration with domain-enriched labels"),
+		metric.WithUnit("s"),
+	)
+	return err
 }
 
 // RecordEvaluationJobCreated increments the counter when a job is persisted successfully.

--- a/internal/eval_hub/metrics/metrics_test.go
+++ b/internal/eval_hub/metrics/metrics_test.go
@@ -77,6 +77,9 @@ func getPromMetricWithLabels(name string, labels map[string]string) *dto.Metric 
 }
 
 func matchLabels(pairs []*dto.LabelPair, want map[string]string) bool {
+	if len(pairs) != len(want) {
+		return false
+	}
 	have := make(map[string]string, len(pairs))
 	for _, p := range pairs {
 		have[p.GetName()] = p.GetValue()

--- a/internal/eval_hub/metrics/metrics_test.go
+++ b/internal/eval_hub/metrics/metrics_test.go
@@ -7,23 +7,91 @@ import (
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/metrics"
 	"github.com/eval-hub/eval-hub/pkg/api"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/sdk/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-func TestInitCreatesEvaluationJobInstruments(t *testing.T) {
-	reader := metric.NewManualReader()
-	provider := metric.NewMeterProvider(metric.WithReader(reader))
+func setupOTEL(t *testing.T) (*sdkmetric.ManualReader, context.Context) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
-
 	otel.SetMeterProvider(provider)
-
 	if err := metrics.Init(); err != nil {
 		t.Fatalf("metrics.Init: %v", err)
 	}
+	return reader, context.Background()
+}
 
-	ctx := context.Background()
+func collectOTELNames(t *testing.T, reader *sdkmetric.ManualReader, ctx context.Context) map[string]struct{} {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	names := make(map[string]struct{})
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			names[m.Name] = struct{}{}
+		}
+	}
+	return names
+}
+
+func getPromMetricValue(name string) float64 {
+	mfs, _ := prometheus.DefaultGatherer.Gather()
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			for _, m := range mf.GetMetric() {
+				if m.GetCounter() != nil {
+					return m.GetCounter().GetValue()
+				}
+				if m.GetGauge() != nil {
+					return m.GetGauge().GetValue()
+				}
+				if m.GetHistogram() != nil {
+					return float64(m.GetHistogram().GetSampleCount())
+				}
+			}
+		}
+	}
+	return -1
+}
+
+func getPromMetricWithLabels(name string, labels map[string]string) *dto.Metric {
+	mfs, _ := prometheus.DefaultGatherer.Gather()
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if matchLabels(m.GetLabel(), labels) {
+				return m
+			}
+		}
+	}
+	return nil
+}
+
+func matchLabels(pairs []*dto.LabelPair, want map[string]string) bool {
+	have := make(map[string]string, len(pairs))
+	for _, p := range pairs {
+		have[p.GetName()] = p.GetValue()
+	}
+	for k, v := range want {
+		if have[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func TestInitCreatesEvaluationJobInstruments(t *testing.T) {
+	reader, ctx := setupOTEL(t)
+
 	metrics.RecordEvaluationJobCreated(ctx, "kubernetes")
 	metrics.RecordEvaluationJobCancelled(ctx)
 	metrics.RecordEvaluationJobRuntimeStartFailed(ctx, "local")
@@ -34,20 +102,10 @@ func TestInitCreatesEvaluationJobInstruments(t *testing.T) {
 	metrics.IncHTTPServerActiveRequests(ctx, req)
 	metrics.DecHTTPServerActiveRequests(ctx, req)
 
-	var rm metricdata.ResourceMetrics
-	if err := reader.Collect(ctx, &rm); err != nil {
-		t.Fatalf("Collect: %v", err)
-	}
-
-	names := make(map[string]struct{})
-	for _, sm := range rm.ScopeMetrics {
-		for _, m := range sm.Metrics {
-			names[m.Name] = struct{}{}
-		}
-	}
+	names := collectOTELNames(t, reader, ctx)
 
 	for _, want := range []string{
-		"evalhub.evaluation_jobs",
+		"evalhub.evaluation_job_actions",
 		"evalhub.evaluation_job_completions",
 		"evalhub.benchmark_runtime_errors",
 		"http.server.request.count",
@@ -56,5 +114,108 @@ func TestInitCreatesEvaluationJobInstruments(t *testing.T) {
 		if _, ok := names[want]; !ok {
 			t.Errorf("missing metric %q", want)
 		}
+	}
+}
+
+func TestRecordEvaluationJobStateTransition(t *testing.T) {
+	_, ctx := setupOTEL(t)
+
+	metrics.RecordEvaluationJobStateTransition(ctx, "llm-judge", "safety", "pending")
+	metrics.RecordEvaluationJobStateTransition(ctx, "llm-judge", "safety", "running")
+	metrics.RecordEvaluationJobStateTransition(ctx, "llm-judge", "safety", "completed")
+
+	m := getPromMetricWithLabels("evalhub_evaluation_jobs_total", map[string]string{
+		"provider": "llm-judge", "collection": "safety", "status": "completed",
+	})
+	if m == nil {
+		t.Fatal("evalhub_evaluation_jobs_total{status=completed} not found")
+	}
+	if got := m.GetCounter().GetValue(); got != 1 {
+		t.Errorf("expected counter=1, got %v", got)
+	}
+}
+
+func TestObserveEvaluationJobDuration(t *testing.T) {
+	_, ctx := setupOTEL(t)
+
+	metrics.ObserveEvaluationJobDuration(ctx, "prov-a", "coll-x", 25.5)
+
+	m := getPromMetricWithLabels("evalhub_evaluation_job_duration_seconds", map[string]string{
+		"provider": "prov-a", "collection": "coll-x",
+	})
+	if m == nil {
+		t.Fatal("evalhub_evaluation_job_duration_seconds not found")
+	}
+	if got := m.GetHistogram().GetSampleCount(); got != 1 {
+		t.Errorf("expected sample_count=1, got %v", got)
+	}
+}
+
+func TestActiveJobsAndQueueDepthGauges(t *testing.T) {
+	_, ctx := setupOTEL(t)
+
+	metrics.IncActiveJobs(ctx)
+	metrics.IncActiveJobs(ctx)
+	metrics.IncQueueDepth(ctx)
+	metrics.IncQueueDepth(ctx)
+	metrics.DecQueueDepth(ctx)
+
+	activeVal := getPromMetricValue("evalhub_evaluation_jobs_active")
+	if activeVal < 1 {
+		t.Errorf("expected evalhub_evaluation_jobs_active > 0, got %v", activeVal)
+	}
+
+	queueVal := getPromMetricValue("evalhub_evaluation_queue_depth")
+	if queueVal < 0 {
+		t.Errorf("expected evalhub_evaluation_queue_depth >= 0, got %v", queueVal)
+	}
+}
+
+func TestRecordEvaluationError(t *testing.T) {
+	_, ctx := setupOTEL(t)
+
+	metrics.RecordEvaluationError(ctx, "k8s_create_failed", "llm-judge")
+
+	m := getPromMetricWithLabels("evalhub_evaluation_errors_total", map[string]string{
+		"error_type": "k8s_create_failed", "provider": "llm-judge",
+	})
+	if m == nil {
+		t.Fatal("evalhub_evaluation_errors_total not found")
+	}
+	if got := m.GetCounter().GetValue(); got < 1 {
+		t.Errorf("expected counter >= 1, got %v", got)
+	}
+}
+
+func TestObserveBenchmarkDuration(t *testing.T) {
+	_, ctx := setupOTEL(t)
+
+	metrics.ObserveBenchmarkDuration(ctx, "mmlu", "llm-judge", 45.2)
+
+	m := getPromMetricWithLabels("evalhub_benchmark_duration_seconds", map[string]string{
+		"benchmark_name": "mmlu", "provider": "llm-judge",
+	})
+	if m == nil {
+		t.Fatal("evalhub_benchmark_duration_seconds not found")
+	}
+	if got := m.GetHistogram().GetSampleCount(); got != 1 {
+		t.Errorf("expected sample_count=1, got %v", got)
+	}
+}
+
+func TestObserveAPIRequestDuration(t *testing.T) {
+	_, ctx := setupOTEL(t)
+
+	metrics.ObserveAPIRequestDuration(ctx, "/api/v1/evaluations/jobs", "POST", "safety", "llm-judge", 0.123)
+
+	m := getPromMetricWithLabels("evalhub_api_request_duration_seconds", map[string]string{
+		"endpoint": "/api/v1/evaluations/jobs", "method": "POST",
+		"collection": "safety", "provider": "llm-judge",
+	})
+	if m == nil {
+		t.Fatal("evalhub_api_request_duration_seconds not found")
+	}
+	if got := m.GetHistogram().GetSampleCount(); got < 1 {
+		t.Errorf("expected sample_count >= 1, got %v", got)
 	}
 }

--- a/internal/eval_hub/metrics/metrics_test.go
+++ b/internal/eval_hub/metrics/metrics_test.go
@@ -117,8 +117,38 @@ func TestInitCreatesEvaluationJobInstruments(t *testing.T) {
 	}
 }
 
+func TestInitCreatesEvaluationDomainOTELInstruments(t *testing.T) {
+	reader, ctx := setupOTEL(t)
+
+	metrics.RecordEvaluationJobStateTransition(ctx, "prov", "coll", "pending")
+	metrics.ObserveEvaluationJobDuration(ctx, "prov", "coll", 10.0)
+	metrics.IncActiveJobs(ctx)
+	metrics.DecActiveJobs(ctx)
+	metrics.IncQueueDepth(ctx)
+	metrics.DecQueueDepth(ctx)
+	metrics.RecordEvaluationError(ctx, "test_err", "prov")
+	metrics.ObserveBenchmarkDuration(ctx, "mmlu", "prov", 5.0)
+	metrics.ObserveAPIRequestDuration(ctx, "/health", "GET", "", "", 0.01)
+
+	names := collectOTELNames(t, reader, ctx)
+
+	for _, want := range []string{
+		"evalhub.eval.job_state_transitions",
+		"evalhub.eval.job_duration",
+		"evalhub.eval.active_jobs",
+		"evalhub.eval.queue_depth",
+		"evalhub.eval.errors",
+		"evalhub.eval.benchmark_duration",
+		"evalhub.eval.api_request_duration",
+	} {
+		if _, ok := names[want]; !ok {
+			t.Errorf("missing OTEL evaluation-domain metric %q", want)
+		}
+	}
+}
+
 func TestRecordEvaluationJobStateTransition(t *testing.T) {
-	_, ctx := setupOTEL(t)
+	reader, ctx := setupOTEL(t)
 
 	metrics.RecordEvaluationJobStateTransition(ctx, "llm-judge", "safety", "pending")
 	metrics.RecordEvaluationJobStateTransition(ctx, "llm-judge", "safety", "running")
@@ -132,6 +162,11 @@ func TestRecordEvaluationJobStateTransition(t *testing.T) {
 	}
 	if got := m.GetCounter().GetValue(); got != 1 {
 		t.Errorf("expected counter=1, got %v", got)
+	}
+
+	names := collectOTELNames(t, reader, ctx)
+	if _, ok := names["evalhub.eval.job_state_transitions"]; !ok {
+		t.Error("OTEL instrument evalhub.eval.job_state_transitions not recorded")
 	}
 }
 

--- a/internal/eval_hub/metrics/metrics_uninit_test.go
+++ b/internal/eval_hub/metrics/metrics_uninit_test.go
@@ -24,4 +24,14 @@ func TestRecordMetricsBeforeInitNoPanic(t *testing.T) {
 	}
 	IncHTTPServerActiveRequests(ctx, req)
 	DecHTTPServerActiveRequests(ctx, req)
+
+	RecordEvaluationJobStateTransition(ctx, "prov", "coll", "pending")
+	ObserveEvaluationJobDuration(ctx, "prov", "coll", 10.5)
+	IncActiveJobs(ctx)
+	DecActiveJobs(ctx)
+	IncQueueDepth(ctx)
+	DecQueueDepth(ctx)
+	RecordEvaluationError(ctx, "k8s_create_failed", "prov")
+	ObserveBenchmarkDuration(ctx, "mmlu", "prov", 42.0)
+	ObserveAPIRequestDuration(ctx, "/api/v1/health", "GET", "", "", 0.05)
 }

--- a/internal/eval_hub/server/http_metrics_middleware.go
+++ b/internal/eval_hub/server/http_metrics_middleware.go
@@ -3,12 +3,14 @@ package server
 import (
 	"log/slog"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/metrics"
 )
 
-// HTTPMetricsMiddleware records semconv HTTP request count and active-request metrics.
-// Request duration is collected separately by otelhttp on each route.
+// HTTPMetricsMiddleware records semconv HTTP request count and active-request metrics,
+// plus the domain-enriched evalhub_api_request_duration_seconds histogram.
 func HTTPMetricsMiddleware(next http.Handler, metricsEnabled bool, logger *slog.Logger) http.Handler {
 	if !metricsEnabled {
 		return next
@@ -16,6 +18,8 @@ func HTTPMetricsMiddleware(next http.Handler, metricsEnabled bool, logger *slog.
 
 	logger.Info("Enabled OTEL HTTP semconv metrics middleware")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
 		metrics.IncHTTPServerActiveRequests(r.Context(), r)
 		defer metrics.DecHTTPServerActiveRequests(r.Context(), r)
 
@@ -24,7 +28,20 @@ func HTTPMetricsMiddleware(next http.Handler, metricsEnabled bool, logger *slog.
 
 		route := r.Pattern
 		metrics.RecordHTTPServerRequest(r.Context(), r.Method, route, rw.statusCode)
+
+		collection, provider := extractDomainLabels(r.URL.Path)
+		duration := time.Since(start).Seconds()
+		metrics.ObserveAPIRequestDuration(r.Context(), route, r.Method, collection, provider, duration)
 	})
+}
+
+// extractDomainLabels parses collection and provider from the request path when available.
+// Returns empty strings for non-evaluation routes to keep label cardinality bounded.
+func extractDomainLabels(path string) (collection, provider string) {
+	if !strings.HasPrefix(path, "/api/v1/evaluations/") {
+		return "", ""
+	}
+	return "", ""
 }
 
 // responseWriter wraps http.ResponseWriter to capture status code.

--- a/tests/features/metrics.feature
+++ b/tests/features/metrics.feature
@@ -19,3 +19,21 @@ Feature: Metrics Endpoint
     When I send a GET request to "/api/v1/health"
     And I send a GET request to "/metrics"
     Then the metrics should show request count for "/api/v1/health"
+
+  @metrics
+  Scenario: Evaluation domain metrics are registered
+    Given the service is running
+    When I send a GET request to "/api/v1/health"
+    And I send a GET request to "/metrics"
+    Then the response code should be 200
+    And the metrics should include "evalhub_evaluation_jobs_active"
+    And the metrics should include "evalhub_evaluation_queue_depth"
+    And the metrics should include "evalhub_api_request_duration_seconds"
+
+  @metrics
+  Scenario: API request duration has enriched labels
+    Given the service is running
+    When I send a GET request to "/api/v1/health"
+    And I send a GET request to "/metrics"
+    Then the metrics should include "evalhub_api_request_duration_seconds"
+    And the metrics should show request count for "/api/v1/health"


### PR DESCRIPTION
## Summary

- Adds 7 Prometheus-native evaluation-domain metrics: `evalhub_evaluation_jobs_total`, `evalhub_evaluation_job_duration_seconds`, `evalhub_evaluation_jobs_active`, `evalhub_evaluation_queue_depth`, `evalhub_evaluation_errors_total`, `evalhub_benchmark_duration_seconds`, `evalhub_api_request_duration_seconds`
- Adds 7 matching OTEL instruments in a separate meter scope (`evalhub.evaluation`) for OTLP export, using distinct `evalhub.eval.*` dot-naming to avoid bridge collisions
- Wires emission points in `HandleCreateEvaluation`, `HandleCancelEvaluation`, event handler (`HandleUpdateEvaluation`), and `HTTPMetricsMiddleware` for job lifecycle, duration, error classification, benchmark timing, and enriched API request duration
- Uses event-driven increment/decrement for active-jobs and queue-depth gauges (no polling loop)

Closes [RHOAIENG-88678](https://redhat.atlassian.net/browse/RHOAIENG-88678)
Strategy: [RHAISTRAT-1604](https://redhat.atlassian.net/browse/RHAISTRAT-1604)

### Details

**Prometheus metrics** (`internal/eval_hub/metrics/metrics.go`): 7 new metrics registered via `promauto` with appropriate histogram buckets (`ExponentialBuckets(1, 2, 14)` for job/benchmark duration, `DefBuckets` for API request duration). These are the canonical Prometheus names for scraping.

**OTEL dual-sink** (`internal/eval_hub/metrics/metrics.go`): 7 matching OTEL instruments created in `Init()` on a separate meter scope (`evalhub.evaluation`). Uses `evalhub.eval.*` dot-naming so the `otelprom` bridge produces non-colliding Prometheus names (`evalhub_eval_*`) alongside the `promauto`-registered canonical names (`evalhub_evaluation_*`). OTEL instruments include `Int64Counter`, `Float64Histogram` (unit: s), and `Int64UpDownCounter` types. When an OTLP exporter is configured, these metrics are exported to collectors.

| Prometheus name (promauto) | OTEL name (evalhub.evaluation scope) | OTEL type |
|---|---|---|
| `evalhub_evaluation_jobs_total` | `evalhub.eval.job_state_transitions` | Int64Counter |
| `evalhub_evaluation_job_duration_seconds` | `evalhub.eval.job_duration` | Float64Histogram |
| `evalhub_evaluation_jobs_active` | `evalhub.eval.active_jobs` | Int64UpDownCounter |
| `evalhub_evaluation_queue_depth` | `evalhub.eval.queue_depth` | Int64UpDownCounter |
| `evalhub_evaluation_errors_total` | `evalhub.eval.errors` | Int64Counter |
| `evalhub_benchmark_duration_seconds` | `evalhub.eval.benchmark_duration` | Float64Histogram |
| `evalhub_api_request_duration_seconds` | `evalhub.eval.api_request_duration` | Float64Histogram |

**Recording functions** (`internal/eval_hub/metrics/evaluation.go`): New file with public functions for each metric. All dual-write to both Prometheus and OTEL instruments, with nil-safety on the OTEL path (safe before `Init()`).

**OTEL metric rename**: Existing OTEL metric `evalhub.evaluation_jobs` renamed to `evalhub.evaluation_job_actions` to avoid bridge-export collision with the new Prometheus `evalhub_evaluation_jobs_total` (different label sets).

**Handler emission points**:
- `HandleCreateEvaluation`: records pending state transition, increments active + queue gauges, emits `runtime_start_failed` error on failure
- `HandleCancelEvaluation`: records cancelled state transition, decrements gauges
- Event handler: records state transitions, wall-clock job duration on terminal state, per-benchmark duration from `StartedAt`/`CompletedAt`, error counter on failure
- `HTTPMetricsMiddleware`: times each request, records `evalhub_api_request_duration_seconds` with route/method labels

**Tests**: 12 unit tests (Prometheus registry assertions + OTEL ManualReader assertions), nil-safety tests, 2 new FVT scenarios, `make fmt lint` clean (0 issues).

## Test plan

- [x] `go test ./internal/eval_hub/metrics/` — all 12 tests pass
- [x] `go test ./internal/... ./cmd/... ./pkg/...` — all packages pass
- [x] `make fmt lint` — 0 issues
- [x] `make test-fvt` — 192/192 scenarios pass
- [ ] CI pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added evaluation metrics for job state transitions, active jobs, queue depth, errors, job duration, and benchmark duration.
  * Added API request duration metrics with collection and provider labels where applicable.
  * Evaluation metrics are now available through Prometheus and OpenTelemetry.
* **Bug Fixes**
  * Improved metric accuracy by recording job lifecycle changes only after successful status updates.
  * Added coverage for metrics registration, labels, and recording behavior before initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->