### PR TITLE
test(fvt): add bounded MLflow EvalCard wait for RHOAIENG-92933

### DIFF
--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1535,7 +1535,7 @@ Feature: Evaluation Jobs
     And I wait for the evaluation job status to be "completed"
     When I send a GET request to "/api/v1/evaluations/jobs/{id}"
     Then the response code should be 200
-    When I fetch the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
+    When I wait for the MLflow artifact "evaluation-card.json" for experiment "{{value:mlflow_experiment_id}}" and job "{{value:job_id}}"
     Then the MLflow artifact should exist
     And the MLflow artifact should contain "results.benchmarks[0]"
     And the MLflow artifact should contain "results.benchmarks[1]"

--- a/tests/features/mlflow_steps_test.go
+++ b/tests/features/mlflow_steps_test.go
@@ -18,6 +18,11 @@ import (
 
 // --- MLflow Artifact Step Definitions ---
 
+const (
+	maxMLflowArtifactWait     = 1 * time.Minute
+	maxMLflowArtifactInterval = 5 * time.Second
+)
+
 func (tc *scenarioConfig) iFetchMLflowArtifact(artifactPath, runIDPattern string) error {
 	// Resolve run ID from saved values or use literal
 	runID, err := tc.getValue(runIDPattern)
@@ -172,6 +177,60 @@ func (tc *scenarioConfig) iFetchMLflowArtifactByExperimentAndJob(artifactName, e
 	}
 
 	return tc.fetchMLflowArtifactWithExperimentID(artifactName, experimentIDResolved, runID)
+}
+
+func (tc *scenarioConfig) iWaitForMLflowArtifactByExperimentAndJob(artifactName, experimentID, jobID string) error {
+	experimentIDResolved, jobIDResolved, err := tc.resolveMLflowExperimentAndJobIDs(experimentID, jobID)
+	if err != nil {
+		return err
+	}
+
+	deadline := time.Now().Add(maxMLflowArtifactWait)
+	if tc.waitDeadline > 0 && tc.waitDeadline < maxMLflowArtifactWait {
+		deadline = time.Now().Add(tc.waitDeadline)
+	}
+	interval := maxMLflowArtifactInterval
+	if tc.waitInterval > 0 && tc.waitInterval < interval {
+		interval = tc.waitInterval
+	}
+
+	var lastErr error
+	for {
+		runID, err := tc.findMLflowRunIDForJob(experimentIDResolved, jobIDResolved)
+		if err != nil {
+			// Search failures other than an absent run indicate MLflow configuration,
+			// authentication, or connectivity problems and should fail immediately.
+			return err
+		}
+		if runID == "" {
+			lastErr = fmt.Errorf("no MLflow run found for job %s in experiment %s", jobIDResolved, experimentIDResolved)
+		} else if fetchErr := tc.fetchMLflowArtifactWithExperimentID(artifactName, experimentIDResolved, runID); fetchErr == nil {
+			return nil
+		} else if !isTransientMLflowNotFound(tc.mlflowArtifactError) {
+			return fetchErr
+		} else {
+			lastErr = fetchErr
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		waitFor := interval
+		if remaining < waitFor {
+			waitFor = remaining
+		}
+		tc.logDebug("MLflow artifact %q is not available yet; retrying in %s\n", artifactName, waitFor)
+		timer := time.NewTimer(waitFor)
+		<-timer.C
+	}
+
+	return tc.logError(fmt.Errorf("timed out waiting for MLflow artifact %q: %w", artifactName, lastErr))
+}
+
+func isTransientMLflowNotFound(err error) bool {
+	var apiErr *mlflowclient.APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
 }
 
 func (tc *scenarioConfig) theMLflowArtifactShouldNotExistForExperimentAndJob(artifactName, experimentID, jobID string) error {

--- a/tests/features/suite_bootstrap_test.go
+++ b/tests/features/suite_bootstrap_test.go
@@ -617,6 +617,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	// MLflow artifact steps
 	ctx.Step(`^I fetch the MLflow artifact "([^"]*)" for run "([^"]*)"$`, tc.iFetchMLflowArtifact)
 	ctx.Step(`^I fetch the MLflow artifact "([^"]*)" for experiment "([^"]*)" and job "([^"]*)"$`, tc.iFetchMLflowArtifactByExperimentAndJob)
+	ctx.Step(`^I wait for the MLflow artifact "([^"]*)" for experiment "([^"]*)" and job "([^"]*)"$`, tc.iWaitForMLflowArtifactByExperimentAndJob)
 	ctx.Step(`^the MLflow artifact should exist$`, tc.theMLflowArtifactShouldExist)
 	ctx.Step(`^the MLflow artifact "([^"]*)" should not exist for experiment "([^"]*)" and job "([^"]*)"$`, tc.theMLflowArtifactShouldNotExistForExperimentAndJob)
 	ctx.Step(`^the MLflow artifact should contain "([^"]*)"$`, tc.theMLflowArtifactShouldContain)


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Addressing https://redhat.atlassian.net/browse/RHOAIENG-92933?focusedCommentId=18341069, the test waits for the MLflow run and evaluation-card.json. It then retries every five seconds for up to one minute, checking if eval card is successfully generated


Closes #

Assisted-by: <!-- Cursor, Claude etc -->

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Test Improvements**
  * End-to-end evaluation tests now wait for MLflow artifacts to become available before validating them.
  * Added retry handling for temporarily unavailable artifacts, with configurable polling intervals and timeouts.
  * Improved timeout and error reporting for artifact retrieval failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->