### PR TITLE
fix: forward model auth on HTTP upstream

### DIFF
--- a/internal/eval_runtime_sidecar/proxy/model_proxy.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy.go
@@ -81,8 +81,9 @@ func loggerForRequest(logger *slog.Logger, req *http.Request) *slog.Logger {
 //     placeholder (e.g. "Bearer local" from OPENAI_API_KEY workarounds) or absent/empty auth.
 //     The adapter cannot read the SA token (pod-level auto-mount is disabled); the sidecar
 //     injects it on its behalf.
-//  5. When the resolved upstream uses HTTP, Authorization is removed and a warning is logged
-//     so credentials are not sent in the clear. The request is still forwarded.
+//  5. Resolved credentials are forwarded on both HTTP and HTTPS upstreams. In-cluster model
+//     endpoints are often plain HTTP but still require SA or secret-backed auth; stripping
+//     Authorization on HTTP caused 401s for those services.
 func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *slog.Logger, secretMountPath, saTokenPath string) *httputil.ReverseProxy {
 	secretCache := loadSecretCache(secretMountPath, logger)
 
@@ -137,12 +138,7 @@ func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *s
 			}
 		}
 
-		if modelTargetUsesHTTP(target) {
-			if credential != "" || pr.Out.Header.Get("Authorization") != "" {
-				pr.Out.Header.Del("Authorization")
-				reqLog.Warn("Dropping model Authorization header: upstream URL uses HTTP", "target_host", target.Host)
-			}
-		} else if credential != "" {
+		if credential != "" {
 			SetAuthHeader(pr.Out, credential)
 			switch {
 			case isExplicitHardcodedToken(authHeader):
@@ -169,10 +165,6 @@ func NewModelReverseProxy(defaultTarget *url.URL, client *http.Client, logger *s
 	rp.ErrorHandler = proxyErrorHandler(logger, "Error proxying model request")
 
 	return rp
-}
-
-func modelTargetUsesHTTP(u *url.URL) bool {
-	return u != nil && strings.EqualFold(u.Scheme, "http")
 }
 
 // modelRoundTripper wraps an inner RoundTripper and intercepts requests marked with the

--- a/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
+++ b/internal/eval_runtime_sidecar/proxy/model_proxy_test.go
@@ -33,10 +33,10 @@ func startModelTestUpstream(t *testing.T, handler http.HandlerFunc, useTLS bool)
 	return target, &http.Client{}
 }
 
-func TestModelProxyDropsAuthOnHTTPUpstream(t *testing.T) {
+func TestModelProxyForwardsSATokenOnHTTPUpstream(t *testing.T) {
 	var gotAuth string
 	var logBuf bytes.Buffer
-	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	target, client := startModelTestUpstream(t, func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
@@ -59,14 +59,38 @@ func TestModelProxyDropsAuthOnHTTPUpstream(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
-	if gotAuth != "" {
-		t.Fatalf("expected no Authorization on HTTP upstream, got %q", gotAuth)
+	if gotAuth != "Bearer sa-token-from-sidecar" {
+		t.Fatalf("expected SA token on HTTP upstream, got %q", gotAuth)
 	}
-	if !strings.Contains(logBuf.String(), "Dropping model Authorization header") {
-		t.Fatalf("logs = %q, want auth drop warning", logBuf.String())
+	if !strings.Contains(logBuf.String(), "Injected SA token for model request") {
+		t.Fatalf("logs = %q, want SA injection log", logBuf.String())
 	}
-	if !strings.Contains(logBuf.String(), "upstream URL uses HTTP") {
-		t.Fatalf("logs = %q, want HTTP upstream warning", logBuf.String())
+}
+
+func TestModelProxyForwardsRefCredentialOnHTTPUpstream(t *testing.T) {
+	var gotAuth string
+	target, client := startModelTestUpstream(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}, false)
+
+	secretDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(secretDir, "api-key"), []byte("sk-http-model"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	rp := NewModelReverseProxy(target, client, slog.New(slog.NewTextHandler(io.Discard, nil)), secretDir, "")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer api-key:ref")
+	rr := httptest.NewRecorder()
+	rp.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if gotAuth != "Bearer sk-http-model" {
+		t.Fatalf("expected resolved api-key on HTTP upstream, got %q", gotAuth)
 	}
 }
 
@@ -760,33 +784,5 @@ func TestModelProxySATokenUnavailableOnHTTPS(t *testing.T) {
 	}
 	if !strings.Contains(logBuf.String(), "SA token injection skipped") {
 		t.Fatalf("logs = %q, want SA token unavailable warning", logBuf.String())
-	}
-}
-
-func TestModelProxyDropsCopiedAdapterAuthOnHTTPWithoutCredential(t *testing.T) {
-	var gotAuth string
-	var logBuf bytes.Buffer
-	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-
-	target, client := startModelTestUpstream(t, func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
-		w.WriteHeader(http.StatusOK)
-	}, false)
-
-	rp := NewModelReverseProxy(target, client, log, t.TempDir(), "")
-
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
-	req.Header.Set("Authorization", "Bearer token:")
-	rr := httptest.NewRecorder()
-	rp.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rr.Code)
-	}
-	if gotAuth != "" {
-		t.Fatalf("expected adapter Authorization stripped on HTTP upstream, got %q", gotAuth)
-	}
-	if !strings.Contains(logBuf.String(), "Explicit token: prefix with empty value") {
-		t.Fatalf("logs = %q, want empty token warning", logBuf.String())
 	}
 }


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Fixes a #958 regression where the model proxy dropped Authorization on HTTP upstreams after injecting SA or ref-resolved credentials, causing 401s on in-cluster HTTP models that require auth.

Forward sidecar-resolved credentials on both HTTP and HTTPS; SetAuthHeader overwrites the adapter header when injection succeeds.

Closes #
Fixes: https://redhat.atlassian.net/browse/RHOAIENG-93620
Assisted-by: <!-- Cursor, Claude etc --> Cursor

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model requests now forward resolved credentials to both HTTP and HTTPS upstreams.
  * Supported credentials include service-account tokens, secret-backed API keys, and configured token values.

* **Bug Fixes**
  * HTTP model requests no longer lose valid authorization headers.
  * Removed the previous behavior that stripped authorization headers from HTTP upstream requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->