### PR TITLE
feat: HF test_data_ref support for Kubernetes jobs

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -51,7 +51,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
     -o evalhub-mcp \
     ./cmd/evalhub_mcp
 
-# Runtime stage
+# Runtime stage (ubi-minimal + python3.11 for optional HF init entrypoint)
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Create user and app directory
@@ -65,6 +65,14 @@ COPY --from=builder --chown=evalhub:evalhub /build/eval-hub /app/eval-hub
 COPY --from=builder --chown=evalhub:evalhub /build/eval-runtime-sidecar /app/eval-runtime-sidecar
 COPY --from=builder --chown=evalhub:evalhub /build/eval-runtime-init /app/eval-runtime-init
 COPY --from=builder --chown=evalhub:evalhub /build/evalhub-mcp /app/evalhub-mcp
+
+# Hugging Face Hub test-data download entrypoint (python3.11 /app/hf_download.py)
+COPY cmd/eval_hf_runtime_init/requirements.txt /app/hf-requirements.txt
+RUN microdnf install -y python3.11 python3.11-pip && \
+    microdnf clean all && \
+    pip3.11 install --no-cache-dir -r /app/hf-requirements.txt
+COPY --chown=evalhub:evalhub cmd/eval_hf_runtime_init/hf_download.py /app/hf_download.py
+RUN chmod 755 /app/hf_download.py && chown evalhub:evalhub /app/hf_download.py
 
 # The swagger source files required for the openapi.yaml and docs
 COPY --chown=evalhub:evalhub docs/openapi.* /app/docs/

--- a/cmd/eval_hf_runtime_init/hf_download.py
+++ b/cmd/eval_hf_runtime_init/hf_download.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Download Hugging Face Hub repository content into /test_data for evaluation jobs."""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import re
+import shutil
+import signal
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+DEST_DIR = Path("/test_data")
+METADATA_DIR = Path("/run/init-metadata")
+METADATA_FILE = METADATA_DIR / ".git-metadata"
+SECRET_DIR = Path("/var/run/secrets/test-data")
+TOKEN_KEY = "token"
+
+ENV_REPO_ID = "TEST_DATA_HF_REPO_ID"
+ENV_REVISION = "TEST_DATA_HF_REVISION"
+ENV_SUB_PATH = "TEST_DATA_HF_SUBPATH"
+ENV_DOWNLOAD_TIMEOUT = "TEST_DATA_DOWNLOAD_TIMEOUT"
+ENV_HF_ENDPOINT = "HF_ENDPOINT"
+
+DEFAULT_TIMEOUT_SECONDS = 600
+# OpenShift/Kubernetes init containers often run as a random UID without $HOME;
+# huggingface_hub otherwise tries to write under /.cache and fails with EACCES.
+DEFAULT_HF_CACHE_DIR = Path("/tmp/huggingface")
+# Kubelet default; surfaced in ContainerStatus.state.terminated.message for the operator.
+DEFAULT_TERMINATION_MESSAGE_PATH = Path("/dev/termination-log")
+# Kubelet reads at most 4 KiB from the termination message file.
+_MAX_TERMINATION_MESSAGE_BYTES = 4096
+
+logger = logging.getLogger(__name__)
+
+
+class DownloadTimeoutError(TimeoutError):
+    """Raised when the Hugging Face download exceeds the configured timeout."""
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
+_GO_DURATION_TOKEN_RE = re.compile(r"(\d+(?:\.\d+)?)(ns|us|µs|ms|s|m|h)")
+_GO_DURATION_MULTIPLIERS = {
+    "ns": 1e-9,
+    "us": 1e-6,
+    "µs": 1e-6,
+    "ms": 1e-3,
+    "s": 1.0,
+    "m": 60.0,
+    "h": 3600.0,
+}
+
+
+def _parse_go_duration_seconds(raw: str) -> float:
+    """Parse Go time.ParseDuration strings (for example 10m0s, 15m, 600s)."""
+    total = 0.0
+    pos = 0
+    for match in _GO_DURATION_TOKEN_RE.finditer(raw):
+        if match.start() != pos:
+            raise ValueError(f"invalid duration: {raw!r}")
+        pos = match.end()
+        unit = match.group(2)
+        if unit == "ns":
+            raise ValueError("nanosecond durations are not supported")
+        if unit in {"us", "µs"}:
+            raise ValueError("microsecond durations are not supported")
+        total += float(match.group(1)) * _GO_DURATION_MULTIPLIERS[unit]
+    if pos != len(raw) or pos == 0:
+        raise ValueError(f"invalid duration: {raw!r}")
+    return total
+
+
+def _parse_timeout_seconds() -> float:
+    raw = os.environ.get(ENV_DOWNLOAD_TIMEOUT, "").strip()
+    if not raw:
+        return float(DEFAULT_TIMEOUT_SECONDS)
+    try:
+        value = _parse_go_duration_seconds(raw)
+    except ValueError as exc:
+        raise ValueError(f"invalid {ENV_DOWNLOAD_TIMEOUT}: {exc}") from exc
+    if value <= 0:
+        raise ValueError(f"invalid {ENV_DOWNLOAD_TIMEOUT}: must be a positive duration")
+    return value
+
+
+def _configure_hf_hub_timeouts(seconds: float) -> None:
+    # huggingface_hub expects integer-second timeout env vars.
+    hub_timeout = str(math.ceil(seconds))
+    os.environ["HF_HUB_ETAG_TIMEOUT"] = hub_timeout
+    os.environ["HF_HUB_DOWNLOAD_TIMEOUT"] = hub_timeout
+
+
+def _configure_hf_cache() -> Path:
+    cache_root = Path(os.environ.get("HF_HOME", "").strip() or DEFAULT_HF_CACHE_DIR)
+    hub_cache = cache_root / "hub"
+    hub_cache.mkdir(parents=True, exist_ok=True)
+    os.environ["HF_HOME"] = str(cache_root)
+    os.environ["HUGGINGFACE_HUB_CACHE"] = str(hub_cache)
+    return hub_cache
+
+
+def _validate_hf_endpoint(endpoint: str) -> str | None:
+    endpoint = endpoint.strip()
+    if not endpoint:
+        return None
+    parsed = urlparse(endpoint)
+    if parsed.scheme != "https":
+        raise ValueError(f"{ENV_HF_ENDPOINT} must use https scheme")
+    if not parsed.hostname:
+        raise ValueError(f"{ENV_HF_ENDPOINT} must include a hostname")
+    return endpoint
+
+
+def _read_token() -> str | None:
+    token_path = SECRET_DIR / TOKEN_KEY
+    if not token_path.is_file():
+        return None
+    token = token_path.read_text(encoding="utf-8").strip()
+    return token or None
+
+
+def _write_metadata(commit_sha: str) -> None:
+    METADATA_DIR.mkdir(parents=True, exist_ok=True)
+    METADATA_FILE.write_text(commit_sha + "\n", encoding="utf-8")
+
+
+def _copy_tree(src: Path, dst: Path) -> None:
+    if not src.is_dir():
+        raise FileNotFoundError(f"source path {src} is not a directory")
+    dst.mkdir(parents=True, exist_ok=True)
+    for item in src.iterdir():
+        target = dst / item.name
+        if item.is_dir():
+            shutil.copytree(item, target, dirs_exist_ok=True)
+        else:
+            shutil.copy2(item, target)
+
+
+def _validate_sub_path(sub_path: str) -> str:
+    clean = Path(sub_path)
+    if clean.is_absolute() or ".." in clean.parts:
+        raise ValueError(f"sub_path escapes repository root: {sub_path!r}")
+    return sub_path.strip().strip("/")
+
+
+def _sub_path_allow_patterns(sub_path: str) -> list[str]:
+    normalized = _validate_sub_path(sub_path)
+    return [normalized, f"{normalized}/**"]
+
+
+def _stage_sub_path(download_root: Path, sub_path: str, dest: Path) -> None:
+    clean = Path(_validate_sub_path(sub_path))
+    source = download_root / clean
+    if not source.exists():
+        raise FileNotFoundError(f"sub_path {sub_path!r} not found in repository")
+    if source.is_dir():
+        _copy_tree(source, dest)
+    else:
+        dest.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, dest / source.name)
+
+
+def _clear_dest_dir(dest: Path) -> None:
+    """Remove prior contents under dest while preserving the mount directory itself."""
+    dest.mkdir(parents=True, exist_ok=True)
+    for item in dest.iterdir():
+        if item.is_dir():
+            shutil.rmtree(item)
+        else:
+            item.unlink()
+
+
+def _dest_has_data(root: Path) -> bool:
+    """Return True when root contains at least one staged entry."""
+    if not root.is_dir():
+        return False
+    return any(root.iterdir())
+
+
+def _install_timeout(seconds: float) -> None:
+    if seconds <= 0:
+        return
+
+    def _handle_timeout(signum, frame):  # noqa: ARG001
+        raise DownloadTimeoutError(f"download exceeded timeout of {seconds:g}s")
+
+    signal.signal(signal.SIGALRM, _handle_timeout)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+
+
+def _clear_timeout() -> None:
+    signal.setitimer(signal.ITIMER_REAL, 0)
+
+
+def _termination_message_path() -> Path:
+    raw = os.environ.get("TERMINATION_MESSAGE_PATH", "").strip()
+    if raw:
+        return Path(raw)
+    return DEFAULT_TERMINATION_MESSAGE_PATH
+
+
+def _write_termination_message(message: str) -> None:
+    text = message.strip()
+    if not text:
+        return
+    encoded = text.encode("utf-8")
+    if len(encoded) > _MAX_TERMINATION_MESSAGE_BYTES:
+        encoded = encoded[:_MAX_TERMINATION_MESSAGE_BYTES]
+        text = encoded.decode("utf-8", errors="ignore")
+    path = _termination_message_path()
+    try:
+        path.write_text(text + "\n", encoding="utf-8")
+    except OSError as err:
+        logger.warning("failed to write termination message to %s: %s", path, err)
+
+
+def _fail(message: str) -> int:
+    logger.error("%s", message)
+    _write_termination_message(message)
+    return 1
+
+
+def main() -> int:
+    _configure_logging()
+    hf_cache_dir = _configure_hf_cache()
+
+    repo_id = os.environ.get(ENV_REPO_ID, "").strip()
+    if not repo_id:
+        return _fail(f"{ENV_REPO_ID} is required")
+
+    revision = os.environ.get(ENV_REVISION, "").strip() or None
+    sub_path = os.environ.get(ENV_SUB_PATH, "").strip()
+
+    try:
+        endpoint = _validate_hf_endpoint(os.environ.get(ENV_HF_ENDPOINT, ""))
+        timeout_seconds = _parse_timeout_seconds()
+    except ValueError as err:
+        return _fail(str(err))
+
+    if endpoint:
+        os.environ["HF_ENDPOINT"] = endpoint
+
+    _configure_hf_hub_timeouts(timeout_seconds)
+    from huggingface_hub import HfApi, snapshot_download
+    from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
+
+    token = _read_token()
+    api = HfApi(endpoint=endpoint or None, token=token)
+
+    logger.info("resolving revision for repo_id=%s revision=%s", repo_id, revision or "default")
+    _install_timeout(timeout_seconds)
+    commit_sha = ""
+    try:
+        info = api.repo_info(repo_id=repo_id, revision=revision, repo_type="dataset")
+        commit_sha = info.sha
+        if not commit_sha:
+            raise RuntimeError(f"could not resolve commit SHA for {repo_id}")
+
+        logger.info("downloading repository repo_id=%s revision=%s", repo_id, commit_sha)
+        snapshot_kwargs = {
+            "repo_id": repo_id,
+            "repo_type": "dataset",
+            "revision": commit_sha,
+            "token": token,
+            "endpoint": endpoint or None,
+        }
+        _clear_dest_dir(DEST_DIR)
+        if sub_path:
+            download_root = Path(
+                snapshot_download(
+                    **snapshot_kwargs,
+                    cache_dir=str(hf_cache_dir),
+                    allow_patterns=_sub_path_allow_patterns(sub_path),
+                )
+            )
+            _stage_sub_path(download_root, sub_path, DEST_DIR)
+        else:
+            # Download into /tmp cache and copy into DEST_DIR. Using local_dir=DEST_DIR
+            # on OpenShift writes staging files under /test_data/.cache; permission
+            # errors there can leave DEST_DIR empty after metadata cleanup.
+            download_root = Path(
+                snapshot_download(
+                    **snapshot_kwargs,
+                    cache_dir=str(hf_cache_dir),
+                )
+            )
+            _copy_tree(download_root, DEST_DIR)
+
+        if not _dest_has_data(DEST_DIR):
+            raise RuntimeError(f"no files were staged under {DEST_DIR}")
+
+        _write_metadata(commit_sha)
+        logger.info("hf source ready dest=%s commit_sha=%s", DEST_DIR, commit_sha)
+    except DownloadTimeoutError as err:
+        return _fail(str(err))
+    except GatedRepoError:
+        return _fail(
+            f"repository {repo_id} is gated; provide secret_ref with a Hugging Face token"
+        )
+    except RepositoryNotFoundError as err:
+        return _fail(f"repository not found: {err}")
+    except Exception as err:  # noqa: BLE001
+        return _fail(f"hf download failed: {err}")
+    finally:
+        _clear_timeout()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cmd/eval_hf_runtime_init/requirements.txt
+++ b/cmd/eval_hf_runtime_init/requirements.txt
@@ -1,0 +1,2 @@
+huggingface_hub==0.36.1
+requests>=2.33.0

--- a/cmd/eval_runtime_init/git.go
+++ b/cmd/eval_runtime_init/git.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	git "github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
@@ -20,6 +19,7 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 
 	"github.com/eval-hub/eval-hub/internal/runtimeenv"
+	"github.com/eval-hub/eval-hub/internal/testdatainit"
 	"github.com/eval-hub/eval-hub/pkg/api"
 )
 
@@ -43,13 +43,9 @@ func runGit() error {
 		return fmt.Errorf("%s is required", envGitRef)
 	}
 
-	timeout := defaultTimeout
-	if raw := strings.TrimSpace(os.Getenv(envGitTimeout)); raw != "" {
-		parsed, err := time.ParseDuration(raw)
-		if err != nil {
-			return fmt.Errorf("invalid %s: %w", envGitTimeout, err)
-		}
-		timeout = parsed
+	timeout, err := testdatainit.ParseDownloadTimeout(envGitTimeout)
+	if err != nil {
+		return err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/cmd/eval_runtime_init/main.go
+++ b/cmd/eval_runtime_init/main.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -20,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/eval-hub/eval-hub/internal/runtimeenv"
+	"github.com/eval-hub/eval-hub/internal/testdatainit"
 )
 
 const (
@@ -37,8 +37,6 @@ const (
 	envGitRef     = "TEST_DATA_GIT_REF"
 	envGitSubPath = "TEST_DATA_GIT_SUBPATH"
 	envGitTimeout = "TEST_DATA_GIT_TIMEOUT"
-
-	defaultTimeout = 10 * time.Minute
 )
 
 // Paths and URL validation are package vars so unit tests can redirect mounts and
@@ -75,16 +73,9 @@ func runS3() error {
 	}
 
 	keyPrefix = strings.TrimPrefix(keyPrefix, "/")
-	timeout := defaultTimeout
-	if raw := strings.TrimSpace(os.Getenv(envS3Timeout)); raw != "" {
-		parsed, err := time.ParseDuration(raw)
-		if err != nil {
-			return fmt.Errorf("invalid %s: %w", envS3Timeout, err)
-		}
-		if parsed <= 0 {
-			return fmt.Errorf("invalid %s: must be a positive duration", envS3Timeout)
-		}
-		timeout = parsed
+	timeout, err := testdatainit.ParseDownloadTimeout(envS3Timeout)
+	if err != nil {
+		return err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,6 +2,10 @@ service:
   port: 8080
   host: "127.0.0.1"
   termination_file: "/tmp/termination-log"
+  # test_data_ref:
+  #   download_timeout: 10m   # S3, git, and HF init containers; default 10m
+  #   hf:
+  #     endpoint: https://huggingface.co
   # read_timeout: 15s       # http.Server ReadTimeout; omit or 0 for default (15s)
   # write_timeout: 15s      # http.Server WriteTimeout; omit or 0 for default (15s)
   # idle_timeout: 60s       # http.Server IdleTimeout; omit or 0 for default (60s)

--- a/internal/eval_hub/config/service_config.go
+++ b/internal/eval_hub/config/service_config.go
@@ -16,17 +16,18 @@ const DefaultMaxLogResponseBytes int64 = 50 << 20 // 50 MiB
 const DefaultLogStreamTimeout = 5 * time.Minute
 
 type ServiceConfig struct {
-	Version         string `mapstructure:"version,omitempty"`
-	Build           string `mapstructure:"build,omitempty"`
-	BuildDate       string `mapstructure:"build_date,omitempty"`
-	GitHash         string `mapstructure:"git_hash,omitempty"`
-	Port            int    `mapstructure:"port,omitempty"`
-	Host            string `mapstructure:"host,omitempty"`
-	TerminationFile string `mapstructure:"termination_file"`
-	EvalInitImage   string `mapstructure:"eval_init_image,omitempty"`
-	LocalMode       bool   `mapstructure:"local_mode,omitempty"`
-	TLSCertFile     string `mapstructure:"tls_cert_file,omitempty"`
-	TLSKeyFile      string `mapstructure:"tls_key_file,omitempty"`
+	Version         string                    `mapstructure:"version,omitempty"`
+	Build           string                    `mapstructure:"build,omitempty"`
+	BuildDate       string                    `mapstructure:"build_date,omitempty"`
+	GitHash         string                    `mapstructure:"git_hash,omitempty"`
+	Port            int                       `mapstructure:"port,omitempty"`
+	Host            string                    `mapstructure:"host,omitempty"`
+	TerminationFile string                    `mapstructure:"termination_file"`
+	EvalInitImage   string                    `mapstructure:"eval_init_image,omitempty"`
+	TestDataRef     *TestDataRefServiceConfig `mapstructure:"test_data_ref,omitempty"`
+	LocalMode       bool                      `mapstructure:"local_mode,omitempty"`
+	TLSCertFile     string                    `mapstructure:"tls_cert_file,omitempty"`
+	TLSKeyFile      string                    `mapstructure:"tls_key_file,omitempty"`
 	// ReadTimeout is http.Server ReadTimeout (entire request read). Zero uses default (15s).
 	ReadTimeout time.Duration `mapstructure:"read_timeout,omitempty"`
 	// WriteTimeout is http.Server WriteTimeout. Zero uses default (15s).
@@ -151,6 +152,22 @@ func (c *ServiceConfig) EffectiveLogStreamTimeout() time.Duration {
 	return c.LogStreamTimeout
 }
 
+// EffectiveTestDataRefDownloadTimeout returns the shared test-data init download timeout.
+func (c *ServiceConfig) EffectiveTestDataRefDownloadTimeout() time.Duration {
+	if c == nil || c.TestDataRef == nil {
+		return DefaultTestDataRefDownloadTimeout
+	}
+	return c.TestDataRef.EffectiveDownloadTimeout()
+}
+
+// EffectiveHFHubEndpoint returns the Hugging Face Hub API base URL for HF test-data jobs.
+func (c *ServiceConfig) EffectiveHFHubEndpoint() string {
+	if c == nil || c.TestDataRef == nil {
+		return DefaultHFHubEndpoint
+	}
+	return c.TestDataRef.EffectiveHFEndpoint()
+}
+
 // ValidateHTTPConfig returns an error when HTTP-related settings are invalid.
 func (c *ServiceConfig) ValidateHTTPConfig() error {
 	if c == nil {
@@ -179,6 +196,11 @@ func (c *ServiceConfig) ValidateHTTPConfig() error {
 	}
 	if c.LogStreamTimeout < 0 {
 		return fmt.Errorf("service.log_stream_timeout must not be negative")
+	}
+	if c.TestDataRef != nil {
+		if err := c.TestDataRef.Validate(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/eval_hub/config/test_data_ref_config.go
+++ b/internal/eval_hub/config/test_data_ref_config.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultTestDataRefDownloadTimeout is applied when service.test_data_ref.download_timeout is omitted or zero.
+const DefaultTestDataRefDownloadTimeout = 10 * time.Minute
+
+// DefaultHFHubEndpoint is the default Hugging Face Hub API URL for HF test-data init containers.
+const DefaultHFHubEndpoint = "https://huggingface.co"
+
+// TestDataRefServiceConfig holds cluster-wide defaults for test_data_ref init containers.
+type TestDataRefServiceConfig struct {
+	// DownloadTimeout applies to S3, git, and HF init containers.
+	DownloadTimeout time.Duration               `mapstructure:"download_timeout,omitempty"`
+	HF              *HFTestDataRefServiceConfig `mapstructure:"hf,omitempty"`
+}
+
+// HFTestDataRefServiceConfig holds Hugging Face Hub defaults for test_data_ref.hf jobs.
+type HFTestDataRefServiceConfig struct {
+	Endpoint string `mapstructure:"endpoint,omitempty"`
+}
+
+// EffectiveDownloadTimeout returns the shared test-data download timeout.
+func (c *TestDataRefServiceConfig) EffectiveDownloadTimeout() time.Duration {
+	if c == nil || c.DownloadTimeout <= 0 {
+		return DefaultTestDataRefDownloadTimeout
+	}
+	return c.DownloadTimeout
+}
+
+// EffectiveHFEndpoint returns the Hugging Face Hub API base URL.
+func (c *TestDataRefServiceConfig) EffectiveHFEndpoint() string {
+	if c == nil || c.HF == nil {
+		return DefaultHFHubEndpoint
+	}
+	endpoint := strings.TrimSpace(c.HF.Endpoint)
+	if endpoint == "" {
+		return DefaultHFHubEndpoint
+	}
+	return endpoint
+}
+
+// Validate returns an error when test_data_ref settings are invalid.
+func (c *TestDataRefServiceConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.DownloadTimeout < 0 {
+		return fmt.Errorf("service.test_data_ref.download_timeout must not be negative")
+	}
+	if c.HF != nil {
+		if err := validateHFHubEndpoint(c.HF.Endpoint); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateHFHubEndpoint(endpoint string) error {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return nil
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("service.test_data_ref.hf.endpoint is invalid: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("service.test_data_ref.hf.endpoint must use https scheme")
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("service.test_data_ref.hf.endpoint must include a hostname")
+	}
+	return nil
+}

--- a/internal/eval_hub/config/test_data_ref_config_test.go
+++ b/internal/eval_hub/config/test_data_ref_config_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTestDataRefServiceConfigEffectiveDownloadTimeout(t *testing.T) {
+	if got := (&TestDataRefServiceConfig{}).EffectiveDownloadTimeout(); got != DefaultTestDataRefDownloadTimeout {
+		t.Fatalf("got %v, want default %v", got, DefaultTestDataRefDownloadTimeout)
+	}
+	if got := (&TestDataRefServiceConfig{DownloadTimeout: 20 * time.Minute}).EffectiveDownloadTimeout(); got != 20*time.Minute {
+		t.Fatalf("got %v, want 20m", got)
+	}
+}
+
+func TestTestDataRefServiceConfigEffectiveHFEndpoint(t *testing.T) {
+	if got := (&TestDataRefServiceConfig{}).EffectiveHFEndpoint(); got != DefaultHFHubEndpoint {
+		t.Fatalf("got %q, want default", got)
+	}
+	if got := (&TestDataRefServiceConfig{HF: &HFTestDataRefServiceConfig{Endpoint: "https://hf.example"}}).EffectiveHFEndpoint(); got != "https://hf.example" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestTestDataRefServiceConfigValidate(t *testing.T) {
+	if err := (&TestDataRefServiceConfig{DownloadTimeout: -1}).Validate(); err == nil {
+		t.Fatal("expected negative download timeout to be rejected")
+	}
+	if err := (&TestDataRefServiceConfig{
+		HF: &HFTestDataRefServiceConfig{Endpoint: "https://hf.example"},
+	}).Validate(); err != nil {
+		t.Fatalf("expected valid endpoint, got: %v", err)
+	}
+	if err := (&TestDataRefServiceConfig{
+		HF: &HFTestDataRefServiceConfig{Endpoint: "ftp://hf.example"},
+	}).Validate(); err == nil {
+		t.Fatal("expected invalid endpoint scheme to be rejected")
+	}
+	if err := (&TestDataRefServiceConfig{
+		HF: &HFTestDataRefServiceConfig{Endpoint: "http://hf.example"},
+	}).Validate(); err == nil {
+		t.Fatal("expected http endpoint to be rejected")
+	}
+	if err := (&TestDataRefServiceConfig{
+		HF: &HFTestDataRefServiceConfig{Endpoint: "not-a-url"},
+	}).Validate(); err == nil {
+		t.Fatal("expected malformed endpoint to be rejected")
+	}
+}
+
+func TestServiceConfigEffectiveTestDataRefSettings(t *testing.T) {
+	sc := &ServiceConfig{
+		TestDataRef: &TestDataRefServiceConfig{
+			DownloadTimeout: 12 * time.Minute,
+			HF:              &HFTestDataRefServiceConfig{Endpoint: "https://hub.example"},
+		},
+	}
+	if got := sc.EffectiveTestDataRefDownloadTimeout(); got != 12*time.Minute {
+		t.Fatalf("download timeout = %v", got)
+	}
+	if got := sc.EffectiveHFHubEndpoint(); got != "https://hub.example" {
+		t.Fatalf("hf endpoint = %q", got)
+	}
+}

--- a/internal/eval_hub/runtimes/k8s/job_builders.go
+++ b/internal/eval_hub/runtimes/k8s/job_builders.go
@@ -75,7 +75,14 @@ const (
 	envTestDataGitURLName           = "TEST_DATA_GIT_URL"
 	envTestDataGitRefName           = "TEST_DATA_GIT_REF"
 	envTestDataGitSubPathName       = "TEST_DATA_GIT_SUBPATH"
+	envTestDataHFRepoIDName         = "TEST_DATA_HF_REPO_ID"
+	envTestDataHFRevisionName       = "TEST_DATA_HF_REVISION"
+	envTestDataHFSubPathName        = "TEST_DATA_HF_SUBPATH"
+	envTestDataHFEndpointName       = "HF_ENDPOINT"
 	testDataGitAuthVolumeName       = "test-data-git-auth"
+	testDataHFAuthVolumeName        = "test-data-hf-auth"
+	defaultTestDataHFInitCmd        = "python3.11"
+	defaultTestDataHFInitScript     = "/app/hf_download.py"
 	initMetadataVolumeName          = "init-metadata" // emptyDir shared between init container and sidecar only
 	initMetadataMountPath           = runtimeenv.InitMetadataDir
 	defaultInitCPURequest           = "100m"

--- a/internal/eval_hub/runtimes/k8s/job_config.go
+++ b/internal/eval_hub/runtimes/k8s/job_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
 	"github.com/eval-hub/eval-hub/internal/eval_hub/runtimes/shared"
@@ -79,7 +80,9 @@ type jobConfig struct {
 	testDataS3                 s3TestDataConfig
 	testDataPVC                pvcTestDataConfig
 	testDataGit                gitTestDataConfig
+	testDataHF                 hfTestDataConfig
 	testDataInitImage          string
+	testDataDownloadTimeout    time.Duration
 	sidecarConfig              *config.SidecarConfig
 	// queueKind and queueName come from a queue-backed HardwareProfile when set,
 	// otherwise from effective hardware_config.queue, else deprecated evaluation.queue
@@ -104,6 +107,14 @@ type gitTestDataConfig struct {
 	ref       string
 	subPath   string
 	secretRef string
+}
+
+type hfTestDataConfig struct {
+	repoID      string
+	revision    string
+	subPath     string
+	secretRef   string
+	hubEndpoint string // service.test_data_ref.hf.endpoint; injected into HF init container
 }
 
 func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.ProviderResource, benchmarkConfig *api.EvaluationBenchmarkConfig, benchmarkIndex int, serviceConfig *config.Config, hardwareProfile *hardwareProfileResources) (*jobConfig, error) {
@@ -220,6 +231,14 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 		testDataGitSecretRef = strings.TrimSpace(benchmarkConfig.TestDataRef.Git.SecretRef)
 	}
 
+	var testDataHFRepoID, testDataHFRevision, testDataHFSubPath, testDataHFSecretRef string
+	if benchmarkConfig.TestDataRef != nil && benchmarkConfig.TestDataRef.HF != nil {
+		testDataHFRepoID = strings.TrimSpace(benchmarkConfig.TestDataRef.HF.RepoID)
+		testDataHFRevision = strings.TrimSpace(benchmarkConfig.TestDataRef.HF.Revision)
+		testDataHFSubPath = strings.TrimSpace(benchmarkConfig.TestDataRef.HF.SubPath)
+		testDataHFSecretRef = strings.TrimSpace(benchmarkConfig.TestDataRef.HF.SecretRef)
+	}
+
 	// GPU resource requests/limits are always propagated to the pod spec so that Kueue can
 	// account for GPU quota. Provider nodeSelector is the default; a HardwareProfile with
 	// Node scheduling overrides it, and a Queue-backed profile (or hardware_config.queue /
@@ -278,6 +297,12 @@ func buildJobConfig(evaluation *api.EvaluationJobResource, provider *api.Provide
 			ref:       testDataGitRef,
 			subPath:   testDataGitSubPath,
 			secretRef: testDataGitSecretRef,
+		},
+		testDataHF: hfTestDataConfig{
+			repoID:    testDataHFRepoID,
+			revision:  testDataHFRevision,
+			subPath:   testDataHFSubPath,
+			secretRef: testDataHFSecretRef,
 		},
 	}
 	applyHardwareProfileResources(out, hardwareProfile)

--- a/internal/eval_hub/runtimes/k8s/job_volumes.go
+++ b/internal/eval_hub/runtimes/k8s/job_volumes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/eval-hub/eval-hub/internal/testdatainit"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -168,7 +169,7 @@ func buildRuntimeContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 	// PVC test data: mount the PVC directly — no init container required.
 	// Git and S3 are exclusive with PVC (enforced by the API validator).
 	// All test-data mounts are read-only on the adapter; result files go to /data.
-	if hasS3TestData(cfg) || hasGitTestData(cfg) {
+	if hasS3TestData(cfg) || hasGitTestData(cfg) || hasHFTestData(cfg) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      testDataVolumeName,
 			MountPath: testDataMountPath,
@@ -338,7 +339,7 @@ func buildSidecarContainerVolumesAndMounts(configMap string, cfg *jobConfig) ([]
 	// Mount the init-metadata volume on the sidecar so it can read .git-metadata written
 	// by the init container and report the resolved commit SHA to eval-hub.
 	// The volume is declared by initContainerVolumesAndMounts; only the mount is added here.
-	if hasGitTestData(cfg) {
+	if hasGitTestData(cfg) || hasHFTestData(cfg) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      initMetadataVolumeName,
 			MountPath: initMetadataMountPath,
@@ -410,10 +411,10 @@ func initContainerVolumesAndMounts(cfg *jobConfig) ([]corev1.Container, []corev1
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{defaultTestDataInitCmd},
 			Resources:       initResources,
-			Env: []corev1.EnvVar{
+			Env: appendTestDataDownloadTimeoutEnv([]corev1.EnvVar{
 				{Name: envTestDataS3BucketName, Value: cfg.testDataS3.bucket},
 				{Name: envTestDataS3KeyName, Value: normalizeS3Key(cfg.testDataS3.key)},
-			},
+			}, cfg),
 			SecurityContext: defaultSecurityContext(),
 			VolumeMounts: []corev1.VolumeMount{
 				{
@@ -447,10 +448,10 @@ func initContainerVolumesAndMounts(cfg *jobConfig) ([]corev1.Container, []corev1
 			},
 		)
 
-		envVars := []corev1.EnvVar{
+		envVars := appendTestDataDownloadTimeoutEnv([]corev1.EnvVar{
 			{Name: envTestDataGitURLName, Value: cfg.testDataGit.url},
 			{Name: envTestDataGitRefName, Value: cfg.testDataGit.ref},
-		}
+		}, cfg)
 		if cfg.testDataGit.subPath != "" {
 			envVars = append(envVars, corev1.EnvVar{Name: envTestDataGitSubPathName, Value: cfg.testDataGit.subPath})
 		}
@@ -491,6 +492,74 @@ func initContainerVolumesAndMounts(cfg *jobConfig) ([]corev1.Container, []corev1
 			Env:             envVars,
 			SecurityContext: defaultSecurityContext(),
 			VolumeMounts:    gitInitVolumeMounts,
+		})
+	}
+	if hasHFTestData(cfg) {
+		if cfg.testDataInitImage == "" {
+			return nil, nil, fmt.Errorf("init image is required when Hugging Face test data is configured")
+		}
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: testDataVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			corev1.Volume{
+				Name: initMetadataVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		)
+
+		envVars := appendTestDataDownloadTimeoutEnv([]corev1.EnvVar{
+			{Name: envTestDataHFRepoIDName, Value: cfg.testDataHF.repoID},
+			{Name: envTestDataHFEndpointName, Value: cfg.testDataHF.hubEndpoint},
+		}, cfg)
+		if cfg.testDataHF.revision != "" {
+			envVars = append(envVars, corev1.EnvVar{Name: envTestDataHFRevisionName, Value: cfg.testDataHF.revision})
+		}
+		if cfg.testDataHF.subPath != "" {
+			envVars = append(envVars, corev1.EnvVar{Name: envTestDataHFSubPathName, Value: cfg.testDataHF.subPath})
+		}
+
+		hfInitVolumeMounts := []corev1.VolumeMount{
+			{
+				Name:      testDataVolumeName,
+				MountPath: testDataMountPath,
+			},
+			{
+				Name:      initMetadataVolumeName,
+				MountPath: initMetadataMountPath,
+			},
+		}
+
+		if cfg.testDataHF.secretRef != "" {
+			volumes = append(volumes, corev1.Volume{
+				Name: testDataHFAuthVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: cfg.testDataHF.secretRef,
+					},
+				},
+			})
+			hfInitVolumeMounts = append(hfInitVolumeMounts, corev1.VolumeMount{
+				Name:      testDataHFAuthVolumeName,
+				MountPath: testDataInitMountPath,
+				ReadOnly:  true,
+			})
+		}
+
+		initContainers = append(initContainers, corev1.Container{
+			Name:            initContainerName,
+			Image:           cfg.testDataInitImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{defaultTestDataHFInitCmd, defaultTestDataHFInitScript},
+			Resources:       initResources,
+			Env:             envVars,
+			SecurityContext: defaultSecurityContext(),
+			VolumeMounts:    hfInitVolumeMounts,
 		})
 	}
 	return initContainers, volumes, nil
@@ -569,6 +638,20 @@ func hasPVCTestData(cfg *jobConfig) bool {
 // secretRef is intentionally not required here — public repos need no auth.
 func hasGitTestData(cfg *jobConfig) bool {
 	return cfg.testDataGit.url != "" && cfg.testDataGit.ref != ""
+}
+
+func hasHFTestData(cfg *jobConfig) bool {
+	return strings.TrimSpace(cfg.testDataHF.repoID) != ""
+}
+
+func appendTestDataDownloadTimeoutEnv(envVars []corev1.EnvVar, cfg *jobConfig) []corev1.EnvVar {
+	if cfg == nil || cfg.testDataDownloadTimeout <= 0 {
+		return envVars
+	}
+	return append(envVars, corev1.EnvVar{
+		Name:  testdatainit.EnvDownloadTimeout,
+		Value: cfg.testDataDownloadTimeout.String(),
+	})
 }
 
 func normalizeS3Key(key string) string {

--- a/internal/eval_hub/runtimes/k8s/job_volumes_test.go
+++ b/internal/eval_hub/runtimes/k8s/job_volumes_test.go
@@ -2,8 +2,10 @@ package k8s
 
 import (
 	"testing"
+	"time"
 
 	"github.com/eval-hub/eval-hub/internal/eval_hub/config"
+	"github.com/eval-hub/eval-hub/internal/testdatainit"
 	"github.com/eval-hub/eval-hub/pkg/api"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -848,5 +850,157 @@ func TestBuildJobWithGitTestDataMissingInitImage(t *testing.T) {
 	_, err := buildJob(cfg, nil)
 	if err == nil {
 		t.Fatal("expected error when git test data is set but init image is missing")
+	}
+}
+
+func TestBuildJobWithHFTestDataPublicRepo(t *testing.T) {
+	cfg := &jobConfig{
+		jobID:                   "job-hf-public",
+		resourceGUID:            "guid-hf-public",
+		benchmarkIndex:          0,
+		namespace:               "default",
+		providerID:              "provider-1",
+		benchmarkID:             "bench-1",
+		adapterImage:            "adapter:latest",
+		defaultEnv:              []api.EnvVar{},
+		testDataInitImage:       "quay.io/evalhub/evalhub:test",
+		testDataDownloadTimeout: 15 * time.Minute,
+		testDataHF: hfTestDataConfig{
+			repoID:      "cais/mmlu",
+			revision:    "main",
+			hubEndpoint: "https://huggingface.co",
+		},
+	}
+
+	job, err := buildJob(cfg, nil)
+	if err != nil {
+		t.Fatalf("buildJob returned error: %v", err)
+	}
+
+	initContainer := findContainer(job.Spec.Template.Spec.InitContainers, initContainerName)
+	if initContainer == nil {
+		t.Fatal("expected HF init container")
+	}
+	if initContainer.Image != "quay.io/evalhub/evalhub:test" {
+		t.Fatalf("unexpected init image: %s", initContainer.Image)
+	}
+	if len(initContainer.Command) != 2 || initContainer.Command[0] != defaultTestDataHFInitCmd || initContainer.Command[1] != defaultTestDataHFInitScript {
+		t.Fatalf("expected init command [%q, %q], got %v", defaultTestDataHFInitCmd, defaultTestDataHFInitScript, initContainer.Command)
+	}
+
+	var foundRepoID, foundEndpoint, foundTimeout bool
+	for _, env := range initContainer.Env {
+		switch env.Name {
+		case envTestDataHFRepoIDName:
+			foundRepoID = env.Value == "cais/mmlu"
+		case envTestDataHFRevisionName:
+			if env.Value != "main" {
+				t.Fatalf("expected revision main, got %q", env.Value)
+			}
+		case envTestDataHFEndpointName:
+			foundEndpoint = env.Value == "https://huggingface.co"
+		case testdatainit.EnvDownloadTimeout:
+			foundTimeout = env.Value == (15 * time.Minute).String()
+		}
+	}
+	if !foundRepoID {
+		t.Fatal("expected repo_id env var on HF init container")
+	}
+	if !foundEndpoint {
+		t.Fatal("expected HF endpoint env var on HF init container")
+	}
+	if !foundTimeout {
+		t.Fatal("expected download timeout env var on HF init container")
+	}
+
+	sidecar := findContainer(job.Spec.Template.Spec.InitContainers, sidecarContainerName)
+	if sidecar == nil {
+		t.Fatal("expected sidecar init container")
+	}
+	var foundMetadataMount bool
+	for _, m := range sidecar.VolumeMounts {
+		if m.Name == initMetadataVolumeName {
+			foundMetadataMount = true
+		}
+	}
+	if !foundMetadataMount {
+		t.Fatal("expected sidecar to mount init-metadata volume for HF source")
+	}
+}
+
+func TestBuildJobWithHFTestDataPrivateRepo(t *testing.T) {
+	cfg := &jobConfig{
+		jobID:             "job-hf-private",
+		resourceGUID:      "guid-hf-private",
+		benchmarkIndex:    0,
+		namespace:         "default",
+		providerID:        "provider-1",
+		benchmarkID:       "bench-1",
+		adapterImage:      "adapter:latest",
+		defaultEnv:        []api.EnvVar{},
+		testDataInitImage: "quay.io/evalhub/evalhub:test",
+		testDataHF: hfTestDataConfig{
+			repoID:      "org/gated-dataset",
+			secretRef:   "my-hf-secret",
+			hubEndpoint: "https://huggingface.co",
+		},
+	}
+
+	job, err := buildJob(cfg, nil)
+	if err != nil {
+		t.Fatalf("buildJob returned error: %v", err)
+	}
+
+	initContainer := findContainer(job.Spec.Template.Spec.InitContainers, initContainerName)
+	if initContainer == nil {
+		t.Fatal("expected HF init container")
+	}
+
+	var foundSecretVolume, foundSecretMount bool
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if v.Name == testDataHFAuthVolumeName {
+			foundSecretVolume = true
+			if v.Secret == nil || v.Secret.SecretName != "my-hf-secret" {
+				t.Fatalf("expected secret volume with secret %q", "my-hf-secret")
+			}
+		}
+	}
+	for _, m := range initContainer.VolumeMounts {
+		if m.Name == testDataHFAuthVolumeName && m.MountPath == testDataInitMountPath && m.ReadOnly {
+			foundSecretMount = true
+		}
+	}
+	if !foundSecretVolume {
+		t.Fatal("expected HF secret volume for gated repo")
+	}
+	if !foundSecretMount {
+		t.Fatal("expected HF secret mount in init container for gated repo")
+	}
+
+	for _, m := range job.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if m.Name == testDataHFAuthVolumeName {
+			t.Fatalf("adapter must not mount HF secret volume")
+		}
+	}
+}
+
+func TestBuildJobWithHFTestDataMissingInitImage(t *testing.T) {
+	cfg := &jobConfig{
+		jobID:          "job-hf-no-image",
+		resourceGUID:   "guid-hf-no-image",
+		benchmarkIndex: 0,
+		namespace:      "default",
+		providerID:     "provider-1",
+		benchmarkID:    "bench-1",
+		adapterImage:   "adapter:latest",
+		defaultEnv:     []api.EnvVar{},
+		testDataHF: hfTestDataConfig{
+			repoID: "cais/mmlu",
+		},
+	}
+
+	_, err := buildJob(cfg, nil)
+	if err == nil {
+		t.Fatal("expected error when HF test data is set but init image is missing")
 	}
 }

--- a/internal/eval_hub/runtimes/k8s/k8s_runtime.go
+++ b/internal/eval_hub/runtimes/k8s/k8s_runtime.go
@@ -228,6 +228,8 @@ func (r *K8sRuntime) createBenchmarkResources(ctx context.Context,
 		return fmt.Errorf("service config is required")
 	}
 	jobConfig.testDataInitImage = r.serviceConfig.Service.EvalInitImage
+	jobConfig.testDataDownloadTimeout = r.serviceConfig.Service.EffectiveTestDataRefDownloadTimeout()
+	jobConfig.testDataHF.hubEndpoint = r.serviceConfig.Service.EffectiveHFHubEndpoint()
 	jobConfig.mlflowCABundleConfigMap = r.resolveMLFlowCABundleConfigMap(ctx, jobConfig, logger)
 	logger.Info(
 		"kubernetes job config",

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json.go
@@ -31,7 +31,7 @@ func sidecarForJobPod(cfg *config.Config, jc *jobConfig) (*config.SidecarConfig,
 				export.EvalHub.InsecureSkipVerify = false
 			}
 		}
-		if hasGitTestData(jc) {
+		if hasGitTestData(jc) || hasHFTestData(jc) {
 			export.InitContainer = &config.InitContainerConfig{IsGitJob: true}
 		}
 		if jc.mlflowTrackingURI != "" {

--- a/internal/eval_hub/runtimes/k8s/sidecar_config_json_test.go
+++ b/internal/eval_hub/runtimes/k8s/sidecar_config_json_test.go
@@ -156,6 +156,27 @@ func TestSidecarForJobPodSetsIsGitJob(t *testing.T) {
 	}
 }
 
+func TestSidecarForJobPodSetsIsGitJobForHFSource(t *testing.T) {
+	cfg := &config.Config{
+		Sidecar: &config.SidecarConfig{BaseURL: config.DefaultSidecarBaseURL},
+	}
+	jc := &jobConfig{
+		jobID:      "hf-job-id",
+		evalHubURL: "http://eval-hub:8080",
+		testDataHF: hfTestDataConfig{
+			repoID: "cais/mmlu",
+		},
+	}
+
+	export, err := sidecarForJobPod(cfg, jc)
+	if err != nil {
+		t.Fatalf("sidecarForJobPod: %v", err)
+	}
+	if export.InitContainer == nil || !export.InitContainer.IsGitJob {
+		t.Fatal("expected InitContainer.IsGitJob=true in sidecar config for HF source job")
+	}
+}
+
 func TestSidecarForJobPodIsGitJobFalseForNonGitJob(t *testing.T) {
 	cfg := &config.Config{
 		Sidecar: &config.SidecarConfig{BaseURL: config.DefaultSidecarBaseURL},

--- a/internal/eval_hub/serialization/json.go
+++ b/internal/eval_hub/serialization/json.go
@@ -41,11 +41,11 @@ func formatValidationError(errs validator.ValidationErrors) string {
 		return fmt.Sprintf("%s must be one of: %s", e.Field(), strings.ReplaceAll(e.Param(), " ", ", "))
 	case "excluded_with":
 		if isTestDataRefSourceField(e.Field()) {
-			return "test_data_ref: exactly one of s3, pvc, or git must be set"
+			return "test_data_ref: exactly one of s3, pvc, git, or hf must be set"
 		}
 	case "required_without_all":
 		if isTestDataRefSourceField(e.Field()) {
-			return "test_data_ref: one of s3, pvc, or git must be set"
+			return "test_data_ref: one of s3, pvc, git, or hf must be set"
 		}
 	case "git_http_with_secret":
 		if param := e.Param(); param != "" {
@@ -62,7 +62,7 @@ func formatValidationError(errs validator.ValidationErrors) string {
 
 func isTestDataRefSourceField(field string) bool {
 	switch field {
-	case "s3", "pvc", "git":
+	case "s3", "pvc", "git", "hf":
 		return true
 	default:
 		return false

--- a/internal/eval_hub/serialization/json_test.go
+++ b/internal/eval_hub/serialization/json_test.go
@@ -67,7 +67,40 @@ func TestUnmarshal_TestDataRefMutualExclusionValidationError(t *testing.T) {
 		t.Fatalf("expected ServiceError, got %T: %v", err, err)
 	}
 	got := svcErr.Error()
-	if !strings.Contains(got, "test_data_ref") {
+	if !strings.Contains(got, "test_data_ref: exactly one of s3, pvc, git, or hf must be set") {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestUnmarshal_TestDataRefHFMutualExclusionValidationError(t *testing.T) {
+	validate := testhelpers.NewValidator(t)
+	logger := logging.FallbackLogger()
+	ctx := executioncontext.NewExecutionContext(context.Background(), "req-1", logger, "user", "tenant")
+
+	body := []byte(`{
+		"name":"test-job",
+		"model":{"name":"m","url":"http://example.com"},
+		"benchmarks":[{
+			"id":"bench-1",
+			"provider_id":"provider-1",
+			"test_data_ref":{
+				"hf":{"repo_id":"cais/mmlu"},
+				"s3":{"bucket":"b","key":"k","secret_ref":"s"}
+			}
+		}]
+	}`)
+	cfg := &api.EvaluationJobConfig{}
+
+	err := Unmarshal(validate, ctx, body, cfg)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var svcErr *serviceerrors.ServiceError
+	if !errors.As(err, &svcErr) {
+		t.Fatalf("expected ServiceError, got %T: %v", err, err)
+	}
+	got := svcErr.Error()
+	if !strings.Contains(got, "test_data_ref: exactly one of s3, pvc, git, or hf must be set") {
 		t.Fatalf("error = %q", got)
 	}
 }
@@ -97,7 +130,7 @@ func TestUnmarshal_TestDataRefRequiredValidationError(t *testing.T) {
 		t.Fatalf("expected ServiceError, got %T: %v", err, err)
 	}
 	got := svcErr.Error()
-	if !strings.Contains(got, "test_data_ref") {
+	if !strings.Contains(got, "test_data_ref: one of s3, pvc, git, or hf must be set") {
 		t.Fatalf("error = %q", got)
 	}
 }

--- a/internal/eval_hub/validation/validator_test.go
+++ b/internal/eval_hub/validation/validator_test.go
@@ -572,7 +572,7 @@ func TestRequiredWithoutAllFields(t *testing.T) {
 		ref := api.TestDataRef{}
 		err := validate.Struct(ref)
 		if err == nil {
-			t.Fatal("expected validation error when neither s3 nor pvc nor git is set")
+			t.Fatal("expected validation error when neither s3, pvc, git, nor hf is set")
 		}
 	}
 	{
@@ -600,6 +600,15 @@ func TestRequiredWithoutAllFields(t *testing.T) {
 		err := validate.Struct(ref)
 		if err != nil {
 			t.Fatalf("expected no error when git is set, got: %v", err)
+		}
+	}
+	{
+		ref := api.TestDataRef{
+			HF: &api.HFTestDataRef{RepoID: "cais/mmlu"},
+		}
+		err := validate.Struct(ref)
+		if err != nil {
+			t.Fatalf("expected no error when hf is set, got: %v", err)
 		}
 	}
 	{
@@ -704,6 +713,27 @@ func TestTestDataRef_GitAndPVCRejected(t *testing.T) {
 	}
 	if err := validate.Struct(ref); err == nil {
 		t.Fatal("expected validation error when both git and pvc are set")
+	}
+}
+
+func TestTestDataRef_HFOnlyAccepted(t *testing.T) {
+	validate := newTestValidator(t)
+	ref := api.TestDataRef{
+		HF: &api.HFTestDataRef{RepoID: "cais/mmlu"},
+	}
+	if err := validate.Struct(ref); err != nil {
+		t.Fatalf("expected no error for valid hf-only TestDataRef, got: %v", err)
+	}
+}
+
+func TestTestDataRef_HFAndS3Rejected(t *testing.T) {
+	validate := newTestValidator(t)
+	ref := api.TestDataRef{
+		HF: &api.HFTestDataRef{RepoID: "cais/mmlu"},
+		S3: &api.S3TestDataRef{Bucket: "b", Key: "k", SecretRef: "s"},
+	}
+	if err := validate.Struct(ref); err == nil {
+		t.Fatal("expected validation error when both hf and s3 are set")
 	}
 }
 

--- a/internal/testdatainit/timeout.go
+++ b/internal/testdatainit/timeout.go
@@ -1,0 +1,41 @@
+// Package testdatainit holds helpers shared by test-data init container binaries.
+package testdatainit
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// EnvDownloadTimeout is the unified timeout env var set by the Kubernetes job builder
+// for S3, git, and HF test-data init containers.
+const EnvDownloadTimeout = "TEST_DATA_DOWNLOAD_TIMEOUT"
+
+// DefaultDownloadTimeout matches the service default (service.test_data_ref.download_timeout).
+const DefaultDownloadTimeout = 10 * time.Minute
+
+// ParseDownloadTimeout reads TEST_DATA_DOWNLOAD_TIMEOUT when set, otherwise sourceEnv
+// (e.g. TEST_DATA_S3_TIMEOUT), otherwise DefaultDownloadTimeout.
+func ParseDownloadTimeout(sourceEnv string) (time.Duration, error) {
+	if raw := strings.TrimSpace(os.Getenv(EnvDownloadTimeout)); raw != "" {
+		return parsePositiveDuration(EnvDownloadTimeout, raw)
+	}
+	if sourceEnv != "" {
+		if raw := strings.TrimSpace(os.Getenv(sourceEnv)); raw != "" {
+			return parsePositiveDuration(sourceEnv, raw)
+		}
+	}
+	return DefaultDownloadTimeout, nil
+}
+
+func parsePositiveDuration(name, raw string) (time.Duration, error) {
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("invalid %s: must be a positive duration", name)
+	}
+	return parsed, nil
+}

--- a/internal/testdatainit/timeout_test.go
+++ b/internal/testdatainit/timeout_test.go
@@ -1,0 +1,46 @@
+package testdatainit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDownloadTimeout(t *testing.T) {
+	t.Setenv(EnvDownloadTimeout, "")
+	t.Setenv("TEST_DATA_S3_TIMEOUT", "")
+
+	got, err := ParseDownloadTimeout("TEST_DATA_S3_TIMEOUT")
+	if err != nil {
+		t.Fatalf("ParseDownloadTimeout() error = %v", err)
+	}
+	if got != DefaultDownloadTimeout {
+		t.Fatalf("got %v, want default %v", got, DefaultDownloadTimeout)
+	}
+
+	t.Setenv(EnvDownloadTimeout, "5m")
+	got, err = ParseDownloadTimeout("TEST_DATA_S3_TIMEOUT")
+	if err != nil {
+		t.Fatalf("ParseDownloadTimeout() error = %v", err)
+	}
+	if got != 5*time.Minute {
+		t.Fatalf("got %v, want 5m", got)
+	}
+
+	t.Setenv(EnvDownloadTimeout, "")
+	t.Setenv("TEST_DATA_S3_TIMEOUT", "2m")
+	got, err = ParseDownloadTimeout("TEST_DATA_S3_TIMEOUT")
+	if err != nil {
+		t.Fatalf("ParseDownloadTimeout() error = %v", err)
+	}
+	if got != 2*time.Minute {
+		t.Fatalf("got %v, want 2m", got)
+	}
+}
+
+func TestParseDownloadTimeoutRejectsInvalid(t *testing.T) {
+	t.Setenv(EnvDownloadTimeout, "nope")
+	_, err := ParseDownloadTimeout("")
+	if err == nil {
+		t.Fatal("expected error for invalid duration")
+	}
+}

--- a/tests/features/evaluation_jobs.feature
+++ b/tests/features/evaluation_jobs.feature
@@ -1276,7 +1276,7 @@ Feature: Evaluation Jobs
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_pvc_and_s3.json"
     Then the response code should be 400
     And the response should contain the value "request_validation_failed" at path "$.message_code"
-    And the response should contain the value "exactly one of s3, pvc, or git must be set" at path "$.message"
+    And the response should contain the value "exactly one of s3, pvc, git, or hf must be set" at path "$.message"
 
   # Requires trustyai-service-operator eval-job failure reconciler (unschedulable PVC → FAILED after scheduling grace).
   # Wait deadline must exceed that grace period with margin.
@@ -1390,7 +1390,7 @@ Feature: Evaluation Jobs
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_git_and_s3.json"
     Then the response code should be 400
     And the response should contain the value "request_validation_failed" at path "$.message_code"
-    And the response should contain the value "exactly one of s3, pvc, or git must be set" at path "$.message"
+    And the response should contain the value "exactly one of s3, pvc, git, or hf must be set" at path "$.message"
 
   @git
   @negative
@@ -1399,7 +1399,7 @@ Feature: Evaluation Jobs
     When I send a POST request to "/api/v1/evaluations/jobs" with body "file:/evaluation_job_git_and_pvc.json"
     Then the response code should be 400
     And the response should contain the value "request_validation_failed" at path "$.message_code"
-    And the response should contain the value "exactly one of s3, pvc, or git must be set" at path "$.message"
+    And the response should contain the value "exactly one of s3, pvc, git, or hf must be set" at path "$.message"
 
   @git
   @negative


### PR DESCRIPTION
Add Hugging Face Hub dataset download via init container, service config for download timeout and hub endpoint, and unified timeout handling for S3/git/HF init paths.

## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes #

Assisted-by: <!-- Cursor, Claude etc -->

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Hugging Face as a test-data source for evaluation jobs.
  - Supports repository revisions, subpaths, private or gated repositories, authentication, and custom Hub endpoints.
  - Hugging Face test data is automatically downloaded and mounted for jobs.
  - Added configurable download timeouts, with a 10-minute default.

- **Validation**
  - Test-data configuration recognizes Hugging Face references and prevents conflicting sources.
  - Added validation for download timeouts and Hub endpoint URLs.

- **Documentation**
  - Added an example Hugging Face test-data configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->