### PR TITLE
ci: add workflow to validate provider container images exist

### DIFF
--- a/.github/workflows/validate-provider-images.yml
+++ b/.github/workflows/validate-provider-images.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
       - "config/providers/**"
+      - ".github/workflows/validate-provider-images.yml"
   push:
     branches: [main]
     paths:
       - "config/providers/**"
+      - ".github/workflows/validate-provider-images.yml"
   workflow_dispatch: {}
 
 permissions:
@@ -29,9 +31,26 @@ jobs:
       - name: Install crane
         env:
           CRANE_VERSION: v0.22.1
+          SLSA_VERIFIER_VERSION: v2.7.1
         run: |
-          curl -sSL "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
-            | tar -xzf - crane
+          ARCHIVE="go-containerregistry_Linux_x86_64.tar.gz"
+          PROVENANCE="multiple.intoto.jsonl"
+
+          curl -sSL -o "$ARCHIVE" \
+            "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/${ARCHIVE}"
+          curl -sSL -o "$PROVENANCE" \
+            "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/${PROVENANCE}"
+
+          curl -sSL -o slsa-verifier \
+            "https://github.com/slsa-framework/slsa-verifier/releases/download/${SLSA_VERIFIER_VERSION}/slsa-verifier-linux-amd64"
+          chmod +x slsa-verifier
+
+          ./slsa-verifier verify-artifact "$ARCHIVE" \
+            --provenance-path "$PROVENANCE" \
+            --source-uri github.com/google/go-containerregistry \
+            --source-tag "$CRANE_VERSION"
+
+          tar -xzf "$ARCHIVE" crane
           sudo mv crane /usr/local/bin/
           crane version
 

--- a/.github/workflows/validate-provider-images.yml
+++ b/.github/workflows/validate-provider-images.yml
@@ -1,0 +1,62 @@
+name: Validate provider container images exist
+
+on:
+  pull_request:
+    paths:
+      - "config/providers/**"
+  push:
+    branches: [main]
+    paths:
+      - "config/providers/**"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install crane
+        env:
+          CRANE_VERSION: v0.22.1
+        run: |
+          curl -sSL "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+            | tar -xzf - crane
+          sudo mv crane /usr/local/bin/
+          crane version
+
+      - name: Verify provider images exist in registry
+        run: |
+          EXIT=0
+          echo "Checking container images referenced in provider configs..."
+          echo ""
+          for file in config/providers/*.yaml; do
+            image=$(yq -r '.runtime.k8s.image // ""' "$file")
+            [ -z "$image" ] && continue
+            name=$(basename "$file")
+            printf "  %-40s %-60s " "$name" "$image"
+            if crane manifest "$image" > /dev/null 2>&1; then
+              echo "OK"
+            else
+              echo "NOT FOUND"
+              EXIT=1
+            fi
+          done
+          echo ""
+          if [ "$EXIT" -ne 0 ]; then
+            echo "One or more provider images could not be found in their registry."
+            echo "Verify the image name, org, and tag are correct."
+          else
+            echo "All provider images verified."
+          fi
+          exit $EXIT


### PR DESCRIPTION
## Summary

- Adds a new CI workflow (`validate-provider-images.yml`) that verifies every `image:` reference in `config/providers/*.yaml` resolves to a real container manifest in its registry.
- Uses [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane) to check manifests without pulling image layers — fast and lightweight (~1-2s per image).
- Runs on PRs and pushes that touch `config/providers/`, plus manual `workflow_dispatch`.
- All pinned GitHub Action versions use the latest releases:
  - `step-security/harden-runner` v2.21.1
  - `actions/checkout` v7.0.1
  - `crane` v0.22.1

## Motivation

Provider YAML files reference container images (e.g. `quay.io/evalhub/community-ruler:latest`) but no existing CI step verifies those images actually exist. Typos in the registry org or image name (like `eval-hub` vs `evalhub`) pass all current checks silently.

This was identified during review of #966 where the NeMo Guardrails provider references `quay.io/eval-hub/community-nemo-guardrails:latest` — using the wrong Quay.io org (`eval-hub` instead of `evalhub`).

## Test plan

- [ ] Workflow runs successfully on this PR (since it touches `config/providers/` path filter — though no provider files changed, `workflow_dispatch` can be used for manual trigger)
- [ ] Verify a deliberately wrong image name causes the job to fail
- [ ] Confirm `crane manifest` checks complete within a reasonable time

Assisted-by: Cursor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated validation for container images referenced in provider configurations.
  - Image availability is checked for provider configuration changes, updates to the main branch, and manual runs.
  - Missing or inaccessible images are reported clearly and cause validation to fail, helping prevent invalid configurations from being accepted.
  - Validation runs with hardened settings and uses a pinned image-inspection tool for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->