### PR TITLE
docs: add SDK version badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Signed release](https://github.com/eval-hub/eval-hub/actions/workflows/signed-release.yml/badge.svg)](https://github.com/eval-hub/eval-hub/actions/workflows/signed-release.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/eval-hub/eval-hub/badge)](https://scorecard.dev/viewer/?uri=github.com/eval-hub/eval-hub)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13751/badge)](https://www.bestpractices.dev/projects/13751)
+[![SDK PyPI Version](https://img.shields.io/pypi/v/eval-hub-sdk?label=SDK%20PyPI%20Version)](https://pypi.org/project/eval-hub-sdk/)
+[![SDK Version](https://img.shields.io/github/v/release/eval-hub/eval-hub-sdk?label=SDK)](https://github.com/eval-hub/eval-hub-sdk/releases/latest)
 
 A lightweight REST API service for orchestrating LLM evaluations across multiple backends. Written in Go, it routes evaluation requests to frameworks like lm-evaluation-harness, RAGAS, Garak, and GuideLLM orchestrated via a [complementary SDK](https://github.com/eval-hub/eval-hub-sdk), tracks experiments via MLflow, and runs natively on OpenShift.
 


### PR DESCRIPTION
## Summary
- Add a PyPI version badge for `eval-hub-sdk`, linking to [pypi.org/project/eval-hub-sdk](https://pypi.org/project/eval-hub-sdk/)
- Add a GitHub release badge for `eval-hub/eval-hub-sdk`, linking to the [latest release](https://github.com/eval-hub/eval-hub-sdk/releases/latest)

## Test plan
- [x] Verify badges render correctly in the README on the PR preview
- [x] Confirm badge links resolve to the correct PyPI and GitHub pages


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added README badges displaying the SDK’s latest PyPI version and GitHub release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->