### PR TITLE
fix(providers): correct typo in NeMo Guardrails PII benchmark description

### DIFF
--- a/config/providers/nemo-guardrails.yaml
+++ b/config/providers/nemo-guardrails.yaml
@@ -124,7 +124,7 @@ benchmarks:
   - id: pii
     name: Personally Identifiable Information
     description: >-
-      Evaluate a NeMo config against personally identifiable information datasdt
+      Evaluate a NeMo config against a personally identifiable information dataset
     category: safety
     metrics:
       - accuracy


### PR DESCRIPTION
## What and why

- correct a typo in a nemo guardrails description

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually
